### PR TITLE
Add shellcheck support (workflow to detect/not fix) and fix scripts to pass checks

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,26 @@
+---
+name: Shellcheck
+
+on:
+  push:
+    branches: [3.x]
+  pull_request:
+    branches: [3.x]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Check shell scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y shellcheck
+      - name: shellcheck
+        run: |
+          git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' | xargs shellcheck

--- a/scripts/build-public-docs.sh
+++ b/scripts/build-public-docs.sh
@@ -26,11 +26,11 @@ fi
 
 if [ -n "${TAG_NAME}" ] && [[ "$TAG_NAME" =~ ^v[0-9]\.[0-9]+([\.a-z0-9]+)?$ ]]; then
     echo "Building ${BRANCH_NAME} docs for tag: ${TAG_NAME}"
-    env DOCS_VERSION=$BRANCH_NAME sphinx-build -a docs/ docs/public/en/$BRANCH_NAME/
+    env DOCS_VERSION="$BRANCH_NAME" sphinx-build -a docs/ docs/public/en/"$BRANCH_NAME"/
 
     if [ "${BRANCH_NAME}" = "${LATEST_BRANCH}" ]; then
         echo "Generating /page redirects"
-        env DOCS_VERSION=$BRANCH_NAME python scripts/generate_redirect_pages.py
+        env DOCS_VERSION="$BRANCH_NAME" python scripts/generate_redirect_pages.py
     fi
 fi
 

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 echo "Execute pytest..."
-pytest $@
+pytest "$@"
 
 echo "Tests complete!"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-VERSION=`python setup.py --version`
-MAJOR_BRANCH="`python setup.py --version | cut -d'.' -f1`.x"
+VERSION=$(python setup.py --version)
+MAJOR_BRANCH="$(python setup.py --version | cut -d'.' -f1).x"
 
 echo "# Releasing pyinfra v${VERSION} (branch ${MAJOR_BRANCH})"
 


### PR DESCRIPTION
More about shellcheck: https://www.shellcheck.net/

I personally introduced it to a good number of my and projects of others
already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

Individual commits might have more information.

On 3.x branch you would get now ([shellcheckit](https://github.com/yarikoptic/improveit/blob/main/shellcheckit) is just a little helper I have to prep this PR etc)

```shell
❯ shellcheckit doit
pyinfra/connectors/util.py:#!/bin/sh
scripts/build-public-docs.sh:#!/bin/bash
scripts/dev-lint.sh:#!/usr/bin/env bash
scripts/dev-test-e2e.sh:#!/usr/bin/env bash
scripts/dev-test.sh:#!/usr/bin/env bash
scripts/release.sh:#!/bin/sh
scripts/spellcheck.sh:#!/usr/bin/env bash

In scripts/build-public-docs.sh line 29:
    env DOCS_VERSION=$BRANCH_NAME sphinx-build -a docs/ docs/public/en/$BRANCH_NAME/
                     ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                       ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    env DOCS_VERSION="$BRANCH_NAME" sphinx-build -a docs/ docs/public/en/"$BRANCH_NAME"/


In scripts/build-public-docs.sh line 33:
        env DOCS_VERSION=$BRANCH_NAME python scripts/generate_redirect_pages.py
                         ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        env DOCS_VERSION="$BRANCH_NAME" python scripts/generate_redirect_pages.py


In scripts/dev-test.sh line 6:
pytest $@
       ^-- SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In scripts/release.sh line 3:
set -euo pipefail
         ^------^ SC3040 (warning): In POSIX sh, set option pipefail is undefined.


In scripts/release.sh line 5:
VERSION=`python setup.py --version`
        ^-------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
VERSION=$(python setup.py --version)


In scripts/release.sh line 6:
MAJOR_BRANCH="`python setup.py --version | cut -d'.' -f1`.x"
              ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
MAJOR_BRANCH="$(python setup.py --version | cut -d'.' -f1).x"

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC3040 -- In POSIX sh, set option pipefail ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```
