### PR TITLE
fix: handle OverflowError for large cache_time in files.download

### DIFF
--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -145,9 +145,15 @@ def download(
         if cache_time:
             # Time on files is not tz-aware, and will be the same tz as the server's time,
             # so we can safely remove the tzinfo from the Date fact before comparison.
-            ctime = host.get_fact(Date).replace(tzinfo=None) - timedelta(seconds=cache_time)
-            if info["mtime"] and info["mtime"] < ctime:
-                download = True
+            try:
+                ctime = host.get_fact(Date).replace(tzinfo=None) - timedelta(seconds=cache_time)
+                if info["mtime"] and info["mtime"] < ctime:
+                    download = True
+            except OverflowError:
+                # If cache_time is too large for timedelta (>999999999 seconds), skip the
+                # cache time check. This allows users to effectively disable re-downloading
+                # by using very large cache_time values without causing a crash.
+                pass
 
         if sha1sum:
             if sha1sum != host.get_fact(Sha1File, path=dest):

--- a/tests/operations/files.download/download_cache_time_overflow.json
+++ b/tests/operations/files.download/download_cache_time_overflow.json
@@ -1,0 +1,20 @@
+{
+    "args": ["http://myfile"],
+    "kwargs": {
+        "dest": "/home/myfile",
+        "cache_time": 9999999999999
+    },
+    "facts": {
+        "server.Date": "datetime:2015-01-01T00:30:00",
+        "files.File": {
+            "path=/home/myfile": {
+                "mtime": "datetime:2015-01-01T00:00:00"
+            }
+        },
+        "server.Which": {
+            "command=curl": "yes"
+        }
+    },
+    "commands": [],
+    "noop_description": "file /home/myfile has already been downloaded"
+}


### PR DESCRIPTION
Fixes #1394

## Problem
Large  values (e.g., ) cause  when  performs date arithmetic with .

## Solution
Wrap cache time calculation in try-except block. On OverflowError, skip cache check (file won't be re-downloaded unless forced or checksum mismatch).

## Changes
- : Add try-except around cache time calculation (lines 145-156)
- : Test case for extreme cache_time

## Testing
✅ New test:  - Verifies graceful handling  
✅ All 161 files operation tests pass  
✅ No regressions  

Closes #1394