### PR TITLE
docs(connectors): document command wrapping and parameter filtering best practices

### DIFF
--- a/docs/api/connectors.md
+++ b/docs/api/connectors.md
@@ -56,7 +56,7 @@ class MyConnector(BaseConnector):
     @staticmethod
     def make_names_data(_=None):
         ...  # see above
- 
+
     def run_shell_command(
         self,
         command: StringCommand,
@@ -189,6 +189,60 @@ screen.
 ```
 
 `disconnect` can be used after all operations complete to clean up any connection/s remaining to the hosts being managed.
+
+
+## Implementing `run_shell_command`
+
+When implementing `run_shell_command`, connectors should use pyinfra's command wrapping utilities rather than manually constructing commands. The `make_unix_command_for_host()` function from `pyinfra.connectors.util` handles shell wrapping, sudo elevation, environment variables, working directory changes, command retries and shell executable selection.
+
+Its worth being aware that when passing `arguments` to `make_unix_command_for_host()`, connector control parameters must be filtered out. These parameters (`_success_exit_codes`, `_timeout`, `_get_pty`, `_stdin`) are defined in `pyinfra.api.arguments.ConnectorArguments` and are meant for the connector's internal logic after command generation, not for command construction itself.
+
+The recommended approach is to use `extract_control_arguments()` from `pyinfra.connectors.util` which handles this filtering for you:
+
+```py
+from pyinfra.connectors.util import extract_control_arguments, make_unix_command_for_host
+
+class MyConnector(BaseConnector):
+    handles_execution = True
+
+    def run_shell_command(
+        self,
+        command: StringCommand,
+        print_output: bool = False,
+        print_input: bool = False,
+        **arguments: Unpack["ConnectorArguments"],
+    ) -> Tuple[bool, CommandOutput]:
+        """Execute a command with proper shell wrapping."""
+
+        # Extract and remove control parameters from arguments
+        # This modifies arguments dict in place and returns the extracted params
+        control_args = extract_control_arguments(arguments)
+
+        # Generate properly wrapped command with sudo, environment, etc
+        # arguments now contains only command generation parameters
+        wrapped_command = make_unix_command_for_host(
+            self.state,
+            self.host,
+            command,
+            **arguments,
+        )
+
+        # Use control parameters for execution
+        timeout = control_args.get("_timeout")
+        success_exit_codes = control_args.get("_success_exit_codes", [0])
+
+        # Execute the wrapped command using your connector's method
+        exit_code, output = self._execute(wrapped_command, timeout=timeout)
+
+        # Check success based on exit codes
+        success = exit_code in success_exit_codes
+
+        return success, output
+```
+
+Without proper command wrapping, shell operators and complex commands will fail. For example `timeout 60 bash -c 'command' || true` executed without shell wrapping will result in `bash: ||: command not found`. PyInfra operations and fact gathering rely on shell operators (`&&`, `||`, pipes, redirects) so using `make_unix_command_for_host()` ensures your connector handles these correctly.
+
+For complete examples see pyinfra's built-in connectors in `pyinfra/connectors/docker.py`, `pyinfra/connectors/chroot.py`, `pyinfra/connectors/ssh.py` and `pyinfra/connectors/local.py`, as well as the command wrapping utilities in `pyinfra/connectors/util.py`.
 
 
 ## pyproject.toml


### PR DESCRIPTION
## Description

Adds comprehensive guidance to the connector documentation on proper command wrapping and connector control parameter filtering. This addresses a documentation gap that can lead to `TypeError` exceptions in custom connectors.

### What's Added

A new section **"Implementing `run_shell_command`"** that covers:

- Using `make_unix_command_for_host()` for proper shell wrapping (essential for shell operators like `&&`, `||`, pipes)
- Filtering connector control parameters with `extract_control_arguments()` utility
- Why control parameters (`_success_exit_codes`, `_timeout`, `_get_pty`, `_stdin`) must be filtered before calling `make_unix_command_for_host()`
- Complete working example following PyInfra best practices
- References to built-in connectors (docker, chroot, ssh, local) as reference implementations

### Why This Matters

Without this guidance, custom connector developers may:
1. Pass control parameters directly to `make_unix_command_for_host()`, causing `TypeError: unexpected keyword argument`
2. Manually reimplement parameter filtering instead of using the existing `extract_control_arguments()` utility
3. Skip command wrapping entirely, causing shell operators to fail

This documentation evolved from debugging and fixing parameter handling bugs in the `pyinfra-orbstack` third-party connector.

### Real-World Impact

This pattern is already used by PyInfra's built-in connectors (docker, dockerssh, chroot), but isn't documented for third-party connector authors. Making this explicit will help prevent bugs and ensure consistency across the connector ecosystem.

---

## Checklist

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts *(N/A - documentation only)*
- [x] Pull request includes documentation for any new/updated operations/facts *(This IS the documentation)*
- [x] Tests pass (see `scripts/dev-test.sh`) *(Will run after PR submission)*
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`) *(Will run after PR submission)*

---

## Additional Context

The `extract_control_arguments()` utility function already exists in `pyinfra.connectors.util` and is used by several built-in connectors, but wasn't documented in the connector development guide. This PR makes that pattern explicit and recommended for all custom connectors.

### Example of the Problem

Without proper parameter filtering:

```python
# ❌ This will fail with TypeError
wrapped_command = make_unix_command_for_host(
    self.state,
    self.host,
    command,
    _success_exit_codes=[0, 1],  # ERROR: unexpected keyword argument
    **other_args,
)
```

With the documented pattern:

```python
# ✅ This works correctly
control_args = extract_control_arguments(arguments)
wrapped_command = make_unix_command_for_host(
    self.state,
    self.host,
    command,
    **arguments,  # control params already extracted
)
```