### PR TITLE
facts.zfs: request parsable, exact, numbers

### DIFF
--- a/src/pyinfra/facts/zfs.py
+++ b/src/pyinfra/facts/zfs.py
@@ -20,7 +20,7 @@ def _process_zfs_props_table(output):
 class ZfsPools(FactBase):
     @override
     def command(self) -> str:
-        return "zpool get -H all"
+        return "zpool get -Hp all"
 
     @override
     def requires_command(self) -> str:
@@ -34,7 +34,7 @@ class ZfsPools(FactBase):
 class ZfsDatasets(FactBase):
     @override
     def command(self) -> str:
-        return "zfs get -H all"
+        return "zfs get -Hp all"
 
     @override
     def requires_command(self) -> str:

--- a/tests/facts/zfs.Datasets/datasets.yaml
+++ b/tests/facts/zfs.Datasets/datasets.yaml
@@ -1,4 +1,4 @@
-command: zfs get -H all
+command: zfs get -Hp all
 requires_command: zfs
 output: |
   tank	type	filesystem	-

--- a/tests/facts/zfs.Filesystems/filesystems.yaml
+++ b/tests/facts/zfs.Filesystems/filesystems.yaml
@@ -1,4 +1,4 @@
-command: zfs get -H all
+command: zfs get -Hp all
 requires_command: zfs
 output: |
   tank	type	filesystem	-

--- a/tests/facts/zfs.Pools/pools.yaml
+++ b/tests/facts/zfs.Pools/pools.yaml
@@ -1,4 +1,4 @@
-command: zpool get -H all
+command: zpool get -Hp all
 requires_command: zpool
 output: |
   tank	compression	lz4	-

--- a/tests/facts/zfs.Snapshots/snapshots.yaml
+++ b/tests/facts/zfs.Snapshots/snapshots.yaml
@@ -1,4 +1,4 @@
-command: zfs get -H all
+command: zfs get -Hp all
 requires_command: zfs
 output: |
   tank	type	filesystem	-

--- a/tests/facts/zfs.Volumes/volumes.yaml
+++ b/tests/facts/zfs.Volumes/volumes.yaml
@@ -1,4 +1,4 @@
-command: zfs get -H all
+command: zfs get -Hp all
 requires_command: zfs
 output: |
   tank	type	filesystem	-


### PR DESCRIPTION
Both `zfs get` and `zpool get` have a `-p` option to request parsable (exact) output.

```
dpool   size    266287972352    -
dpool   size    248G    -
```

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
