### PR TITLE
fix(operations.locale): fix operation create duplicate entries and add is_defaul…

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -1090,11 +1090,11 @@ class Locales(FactBase[list[str]]):
 
     @override
     def command(self) -> str:
-        return "locale -a"
-
-    @override
-    def requires_command(self) -> str:
-        return "locale"
+        return (
+            "(command -v locale >/dev/null && locale -a) "
+            "|| (command -v localectl >/dev/null && localectl list-locales) "
+            "|| true"
+        )
 
     default = list
 

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -5,6 +5,7 @@ Linux/BSD.
 
 from __future__ import annotations
 
+import re
 from io import StringIO
 from itertools import filterfalse, tee
 from os import path
@@ -15,7 +16,7 @@ from pyinfra import host, logger, state
 from pyinfra.api import FunctionCommand, OperationError, QuoteString, StringCommand, operation
 from pyinfra.api.util import try_int
 from pyinfra.connectors.util import clear_askpass_cache, remove_any_sudo_askpass_file
-from pyinfra.facts.files import Directory, FileContents, FindInFile, Link
+from pyinfra.facts.files import Directory, File, FileContents, Link
 from pyinfra.facts.server import (
     AuthorizedKeys,
     EtcHosts,
@@ -34,7 +35,6 @@ from pyinfra.facts.server import (
     Which,
 )
 from pyinfra.operations import crontab as crontab_
-
 from . import (
     apk,
     apt,
@@ -1234,16 +1234,36 @@ def user(
         )
 
 
+# Matches a POSIX locale name: <lang>[_<TERRITORY>][.<charset>][@<modifier>]
+# Examples: ``C``, ``C.UTF-8``, ``en_US.UTF-8``, ``de_DE@euro``, ``de_DE.UTF-8@euro``
+_LOCALE_NAME_RE = re.compile(
+    r"^[A-Za-z]+"  # language (e.g. en, fr, C, POSIX)
+    r"(?:_[A-Za-z]+)?"  # optional territory (e.g. _US)
+    r"(?:\.[A-Za-z0-9-]+)?"  # optional charset (e.g. .UTF-8)
+    r"(?:@[A-Za-z0-9]+)?$"  # optional modifier (e.g. @euro)
+)
+
+
 @operation()
 def locale(
     locale: str,
-    present=True,
+    present: bool = True,
+    is_default: bool = False,
 ):
     """
-    Enable/Disable locale.
+    Enable/Disable a locale via ``/etc/locale.gen`` and ``locale-gen``.
 
-    + locale: name of the locale to enable/disable
+    + locale: name of the locale to enable/disable. Accepts either the locale
+      name alone (``"en_US.UTF-8"``) or the full ``locale.gen`` entry with an
+      explicit charset suffix (``"en_US.UTF-8 UTF-8"``). When the suffix is
+      omitted, the charset is derived from the locale name (``en_US.UTF-8`` →
+      ``UTF-8``) or defaults to ``UTF-8``.
     + present: whether this locale should be present or not
+    + is_default: whether to set this locale as the system default in
+      ``/etc/locale.conf``
+
+    Currently only supports systems providing ``locale-gen`` (Debian, Ubuntu,
+    Arch). Raises ``OperationError`` on other distributions.
 
     **Examples:**
 
@@ -1256,52 +1276,107 @@ def locale(
         )
 
         server.locale(
-            name="Ensure en_GB.UTF-8 locale is present",
+            name="Ensure en_GB.UTF-8 locale is present and default",
             locale="en_GB.UTF-8",
+            is_default=True,
         )
 
+        # Explicit charset (useful when the name does not embed it)
+        server.locale(
+            name="Ensure de_DE@euro locale with ISO-8859-15 charset",
+            locale="de_DE@euro ISO-8859-15",
+        )
     """
+
+    if not present and is_default:
+        raise OperationError("Setting a locale as not present requires is_default=False")
+
+    # Accept both "fr_FR.UTF-8" and "fr_FR.UTF-8 UTF-8" forms. The first token
+    # is the locale name (matched against the Locales fact, which uses
+    # `locale -a` output and contains no charset suffix). The second token is
+    # the charset required by /etc/locale.gen entries; derive it from the name
+    # when omitted.
+    parts = locale.split(maxsplit=1)
+    locale_name = parts[0]
+    if not _LOCALE_NAME_RE.match(locale_name):
+        raise OperationError(
+            f"Invalid locale name {locale_name!r}: expected "
+            "<lang>[_<TERRITORY>][.<charset>][@<modifier>] "
+            "(e.g. 'en_US.UTF-8', 'de_DE@euro', 'C.UTF-8')"
+        )
+    if len(parts) > 1:
+        charset = parts[1]
+    elif "." in locale_name:
+        charset = locale_name.split(".", 1)[1]
+    else:
+        charset = "UTF-8"
+    locale_entry = f"{locale_name} {charset}"
 
     locales = host.get_fact(Locales)
 
     logger.debug(f"Enabled locales: {locales}")
 
     locales_definitions_file = "/etc/locale.gen"
+    default_locale_file = "/etc/locale.conf"
+    locale_gen_exists = host.get_fact(File, path=locales_definitions_file)
 
-    # Find the matching line in /etc/locale.gen
-    matching_lines = host.get_fact(
-        FindInFile, path=locales_definitions_file, pattern=rf"^.*{locale}[[:space:]]\+.*$"
-    )
+    if present and locale_name in locales and not is_default:
+        host.noop(f"Locale {locale_name} already enabled")
+        return
 
-    if not matching_lines:
-        raise OperationError(f"Locale {locale} not found in {locales_definitions_file}")
+    if not present and locale_name not in locales:
+        host.noop(f"Locale {locale_name} already disabled")
+        return
 
-    if len(matching_lines) > 1:
-        raise OperationError(f"Multiple locales matches for {locale} in {locales_definitions_file}")
+    if locale_gen_exists:
+        has_locale_gen = host.get_fact(Which, command="locale-gen")
+    else:
+        has_locale_gen = None
 
-    matching_line = matching_lines[0]
+    if locale_gen_exists and has_locale_gen:
+        # Remove locale
+        if not present and locale_name in locales:
+            logger.debug(f"Removing locale {locale_name}")
 
-    # Remove locale
-    if not present and locale in locales:
-        logger.debug(f"Removing locale {locale}")
+            yield from files.line._inner(
+                path=locales_definitions_file,
+                line=rf"^{re.escape(locale_name)} {re.escape(charset)}$",
+                present=False,
+            )
 
-        yield from files.line._inner(
-            path=locales_definitions_file, line=f"^{matching_line}$", replace=f"# {matching_line}"
-        )
+            yield "locale-gen"
 
-        yield "locale-gen"
+        # Add locale
+        if present and locale_name not in locales:
+            logger.debug(f"Adding locale {locale_name}")
 
-    # Add locale
-    if present and locale not in locales:
-        logger.debug(f"Adding locale {locale}")
+            yield from files.line._inner(
+                path=locales_definitions_file,
+                line=rf"^#* *{re.escape(locale_name)} {re.escape(charset)}$",
+                replace=locale_entry,
+                present=True,
+            )
 
-        yield from files.replace._inner(
-            path=locales_definitions_file,
-            text=f"^{matching_line}$",
-            replace=f"{matching_line}".replace("# ", ""),
-        )
+            if is_default:
+                yield from files.line._inner(
+                    line="LANG=.*",
+                    replace=f"LANG={locale_name}",
+                    path=default_locale_file,
+                )
 
-        yield "locale-gen"
+            yield "locale-gen"
+
+        # Set as default when locale already present (no locale-gen needed)
+        elif present and is_default:
+            yield from files.line._inner(
+                line="LANG=.*",
+                replace=f"LANG={locale_name}",
+                path=default_locale_file,
+            )
+
+        return
+
+    raise OperationError("Locale management requires locale-gen on this system.")
 
 
 @operation(is_idempotent=False)

--- a/tests/operations/server.locale/add_and_set_as_default.json
+++ b/tests/operations/server.locale/add_and_set_as_default.json
@@ -2,6 +2,7 @@
     "args": [
         "fr_FR.UTF-8"
     ],
+    "kwargs": {"is_default": true},
     "facts": {
         "files.File": {
             "path=/etc/locale.gen": {
@@ -12,6 +13,9 @@
             "command=locale-gen": "/usr/sbin/locale-gen"
         },
         "files.FindInFile": {
+            "extended_regex=False, interpolate_variables=False, path=/etc/locale.conf, pattern=^.*LANG=.*.*$": [
+                "LANG=en_US.UTF-8"
+            ],
             "extended_regex=False, interpolate_variables=False, path=/etc/locale.gen, pattern=^#* *fr_FR\\.UTF\\-8 UTF\\-8$": [
                 "# fr_FR.UTF-8 UTF-8"
             ]
@@ -25,6 +29,7 @@
     },
     "commands": [
         "sed -i.a-timestamp 's/^#* *fr_FR\\.UTF\\-8 UTF\\-8$/fr_FR.UTF-8 UTF-8/' /etc/locale.gen && rm -f /etc/locale.gen.a-timestamp",
+        "sed -i.a-timestamp 's/^.*LANG=.*.*$/LANG=fr_FR.UTF-8/' /etc/locale.conf && rm -f /etc/locale.conf.a-timestamp",
         "locale-gen"
     ],
     "second_output_commands": [

--- a/tests/operations/server.locale/add_with_charset_suffix.json
+++ b/tests/operations/server.locale/add_with_charset_suffix.json
@@ -1,6 +1,6 @@
 {
     "args": [
-        "fr_FR.UTF-8"
+        "fr_FR.UTF-8 UTF-8"
     ],
     "facts": {
         "files.File": {

--- a/tests/operations/server.locale/invalid_name.json
+++ b/tests/operations/server.locale/invalid_name.json
@@ -1,0 +1,9 @@
+{
+    "args": [
+        "123-bad"
+    ],
+    "exception": {
+        "name": "OperationError",
+        "message": "Invalid locale name '123-bad': expected <lang>[_<TERRITORY>][.<charset>][@<modifier>] (e.g. 'en_US.UTF-8', 'de_DE@euro', 'C.UTF-8')"
+    }
+}

--- a/tests/operations/server.locale/remove.json
+++ b/tests/operations/server.locale/remove.json
@@ -2,28 +2,33 @@
     "args": [
         "fr_FR.UTF-8"
     ],
+    "kwargs": {
+        "present": false
+    },
     "facts": {
+        "files.File": {
+            "path=/etc/locale.gen": {
+                "mode": 644
+            }
+        },
+        "server.Which": {
+            "command=locale-gen": "/usr/sbin/locale-gen"
+        },
         "files.FindInFile": {
-            "extended_regex=False, interpolate_variables=False, path=/etc/locale.gen, pattern=^.*fr_FR.UTF-8[[:space:]]\\+.*$": [
-                "# fr_FR.UTF-8 UTF-8"
-            ],
-            "extended_regex=False, interpolate_variables=False, path=/etc/locale.gen, pattern=^.*fr_FR.UTF-8[[:space:]]\\+.*": [
-                "# fr_FR.UTF-8 UTF-8"
-            ],
-            "extended_regex=False, interpolate_variables=False, path=/etc/locale.gen, pattern=^# fr_FR.UTF-8 UTF-8$": [
-                "# fr_FR.UTF-8 UTF-8"
+            "extended_regex=False, interpolate_variables=False, path=/etc/locale.gen, pattern=^fr_FR\\.UTF\\-8 UTF\\-8$": [
+                "fr_FR.UTF-8 UTF-8"
             ]
         },
         "server.Locales": [
             "C",
             "C.UTF-8",
-            "fr_FR.utf8",
+            "fr_FR.UTF-8",
             "en_US.utf8",
             "POSIX"
         ]
     },
     "commands": [
-        "sed -i.a-timestamp 's/^# fr_FR.UTF-8 UTF-8$/fr_FR.UTF-8 UTF-8/' /etc/locale.gen && rm -f /etc/locale.gen.a-timestamp",
+        "sed -i.a-timestamp '/^fr_FR\\.UTF\\-8 UTF\\-8$/d' /etc/locale.gen && rm -f /etc/locale.gen.a-timestamp",
         "locale-gen"
     ],
     "second_output_commands": [

--- a/tests/operations/server.locale/set_default_when_already_present.json
+++ b/tests/operations/server.locale/set_default_when_already_present.json
@@ -2,6 +2,7 @@
     "args": [
         "fr_FR.UTF-8"
     ],
+    "kwargs": {"is_default": true},
     "facts": {
         "files.File": {
             "path=/etc/locale.gen": {
@@ -12,23 +13,23 @@
             "command=locale-gen": "/usr/sbin/locale-gen"
         },
         "files.FindInFile": {
-            "extended_regex=False, interpolate_variables=False, path=/etc/locale.gen, pattern=^#* *fr_FR\\.UTF\\-8 UTF\\-8$": [
-                "# fr_FR.UTF-8 UTF-8"
+            "extended_regex=False, interpolate_variables=False, path=/etc/locale.conf, pattern=^.*LANG=.*.*$": [
+                "LANG=en_US.UTF-8"
             ]
         },
         "server.Locales": [
             "C",
             "C.UTF-8",
+            "fr_FR.UTF-8",
             "en_US.utf8",
             "POSIX"
         ]
     },
     "commands": [
-        "sed -i.a-timestamp 's/^#* *fr_FR\\.UTF\\-8 UTF\\-8$/fr_FR.UTF-8 UTF-8/' /etc/locale.gen && rm -f /etc/locale.gen.a-timestamp",
-        "locale-gen"
+        "sed -i.a-timestamp 's/^.*LANG=.*.*$/LANG=fr_FR.UTF-8/' /etc/locale.conf && rm -f /etc/locale.conf.a-timestamp"
     ],
     "second_output_commands": [
-        "locale-gen"
+        "sed -i.a-timestamp 's/^.*LANG=.*.*$/LANG=fr_FR.UTF-8/' /etc/locale.conf && rm -f /etc/locale.conf.a-timestamp"
     ],
     "idempotent": false,
     "disable_idempotent_warning_reason": "localgen is always executed"


### PR DESCRIPTION
- Better handling of locale names and charsets,
- Support for setting the system default locale
-  Improved idempotency, 
-  Better error handling. 

The test suite is also expanded to cover new behaviors and edge cases.

**Enhancements to locale management:**

* The `server.locale` operation now accepts both simple locale names (e.g., `"fr_FR.UTF-8"`) and full `locale.gen` entries with explicit charset suffixes (e.g., `"de_DE@euro ISO-8859-15"`). If the charset is omitted, it is derived from the locale name or defaults to `UTF-8`. (`src/pyinfra/operations/server.py` [[1]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37R1237-R1266) [[2]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37L1259-R1380)
* Added the `is_default` argument, allowing users to set a locale as the system default in `/etc/locale.conf`. This is supported both when enabling a new locale and when the locale is already present. (`src/pyinfra/operations/server.py` [[1]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37R1237-R1266) [[2]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37L1259-R1380)

**Idempotency and error handling improvements:**

* Improved idempotency: the operation now checks if the locale is already enabled/disabled and avoids unnecessary changes. It also validates locale names using a regular expression and raises a clear `OperationError` for invalid names. (`src/pyinfra/operations/server.py` [[1]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37R1237-R1266) [[2]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37L1259-R1380); `tests/operations/server.locale/invalid_name.json` [[3]](diffhunk://#diff-3fae00df8c5ec59a5618fe4b0e689d8bba55f0aec6ba4bf548362f9104c96f14R1-R9)
* The operation now requires `locale-gen` to be present and raises an error on unsupported systems. (`src/pyinfra/operations/server.py` [[1]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37R1237-R1266) [[2]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37L1259-R1380)

**Compatibility and test updates:**

* The `Locales` fact now detects available locales using `locale -a`, `localectl list-locales`, or falls back gracefully if neither is available. (`src/pyinfra/facts/server.py` [src/pyinfra/facts/server.pyL1093-R1097](diffhunk://#diff-fa77067c4f42361ce891acb58d2b1824c265bd79754209db30835c508d5f621eL1093-R1097))
* Tests are updated and expanded to cover new behaviors, including adding locales with/without charset suffixes, setting as default, removing locales, and handling invalid input. (`tests/operations/server.locale/add.json` [[1]](diffhunk://#diff-b6306c8249019042382e4dda0e6b4ba3ad4db5e4bbf364042c9f378ad3e942e8R6-R15) [[2]](diffhunk://#diff-b6306c8249019042382e4dda0e6b4ba3ad4db5e4bbf364042c9f378ad3e942e8L25-R27); `tests/operations/server.locale/remove.json` [[3]](diffhunk://#diff-7438c9a9ac428c9f6e2e0fa07f524367851d4b9717dc6e234c643f7270b4969cR5-R31); `tests/operations/server.locale/add_and_set_as_default.json` [[4]](diffhunk://#diff-bdc3e91e8823c51b3c783685dc8dacaa321e2a54810c67a9c5d6ec7830263a4dR1-R40); `tests/operations/server.locale/add_with_charset_suffix.json` [[5]](diffhunk://#diff-528d1ef7b56d0152fef011d0c79604c18da8a1cb61f1c283bbdcfc688b194acaR1-R35); `tests/operations/server.locale/set_default_when_already_present.json` [[6]](diffhunk://#diff-2f7327b1536aa2edfbbb52c7a65e0da0af94d9d18a46bb6e2112e0d0310b3ec1R1-R36); `tests/operations/server.locale/invalid_name.json` [[7]](diffhunk://#diff-3fae00df8c5ec59a5618fe4b0e689d8bba55f0aec6ba4bf548362f9104c96f14R1-R9)

**Internal code improvements:**

* Refactored and clarified code for locale parsing, file handling, and command generation. Added imports and cleaned up unused code. (`src/pyinfra/operations/server.py` [[1]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37R8) [[2]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37L18-R19) [[3]](diffhunk://#diff-0b4cd7d825207df7fdd6be5da2df59285bc12bb62e4238cf51013ed9142aba37L37)

These changes make locale management more reliable, flexible, and user-friendly, while ensuring robust error handling and improved test coverage.…ocale support

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
