### PR TITLE
Add @podmanssh connector for remote Podman container operations

### DIFF
--- a/docs/connectors.rst
+++ b/docs/connectors.rst
@@ -13,7 +13,7 @@ Connectors enable pyinfra to integrate with other tools out of the box. Connecto
 
 + Implement how commands are executed (``@ssh``, ``@local``)
 + Generate inventory hosts and data (``@terraform`` and ``@vagrant``)
-+ Both of the above (``@docker``)
++ Both of the above (``@docker``, ``@podman``, and other container connectors)
 
 Each connector page is listed below and contains examples as well as a list of available data that can be used to configure the connector.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ podman = "pyinfra.connectors.docker:PodmanConnector"
 local = "pyinfra.connectors.local:LocalConnector"
 ssh = "pyinfra.connectors.ssh:SSHConnector"
 dockerssh = "pyinfra.connectors.dockerssh:DockerSSHConnector"
+podmanssh = "pyinfra.connectors.dockerssh:PodmanSSHConnector"
 # Inventory only connectors
 terraform = "pyinfra.connectors.terraform:TerraformInventoryConnector"
 vagrant = "pyinfra.connectors.vagrant:VagrantInventoryConnector"

--- a/src/pyinfra/connectors/docker.py
+++ b/src/pyinfra/connectors/docker.py
@@ -68,6 +68,10 @@ class DockerConnector(BaseConnector):
     The Docker connector is great for testing pyinfra operations locally, rather than connecting to
     a remote host over SSH each time. This gives you a fast, local-first devloop to iterate on when
     writing deploys, operations or facts.
+
+    .. note::
+
+        For running Docker containers on remote hosts, see the :doc:`dockerssh` connector.
     """
 
     # enable the use of other docker cli compatible tools like podman
@@ -364,6 +368,10 @@ class PodmanConnector(DockerConnector):
     The Podman connector is great for testing pyinfra operations locally, rather than connecting to
     a remote host over SSH each time. This gives you a fast, local-first devloop to iterate on when
     writing deploys, operations or facts.
+
+    .. note::
+
+        For running Podman containers on remote hosts, see the :doc:`podmanssh` connector.
     """
 
     docker_cmd = "podman"

--- a/src/pyinfra/connectors/dockerssh.py
+++ b/src/pyinfra/connectors/dockerssh.py
@@ -33,6 +33,10 @@ class DockerSSHConnector(BaseConnector):
     The ``@dockerssh`` connector allows you to run commands on Docker containers \
     on a remote machine.
 
+    .. note::
+
+        For running Podman containers on remote hosts, see the :doc:`podmanssh` connector.
+
     .. code:: shell
 
         # A Docker base image must be provided
@@ -43,6 +47,8 @@ class DockerSSHConnector(BaseConnector):
     """
 
     handles_execution = True
+    # enable the use of other docker cli compatible tools like podman
+    docker_cmd = "docker"
 
     ssh: SSHConnector
 
@@ -77,11 +83,11 @@ class DockerSSHConnector(BaseConnector):
             return
 
         try:
-            with progress_spinner({"docker run"}):
+            with progress_spinner({f"{self.docker_cmd} run"}):
                 # last line is the container ID
                 status, output = self.ssh.run_shell_command(
                     StringCommand(
-                        "docker",
+                        self.docker_cmd,
                         "run",
                         "-d",
                         self.host.data.docker_image,
@@ -103,20 +109,23 @@ class DockerSSHConnector(BaseConnector):
     def disconnect(self) -> None:
         container_id = self.host.host_data["docker_container_id"][:12]
 
-        with progress_spinner({"docker commit"}):
-            _, output = self.ssh.run_shell_command(StringCommand("docker", "commit", container_id))
+        with progress_spinner({f"{self.docker_cmd} commit"}):
+            _, output = self.ssh.run_shell_command(
+                StringCommand(self.docker_cmd, "commit", container_id)
+            )
 
             # Last line is the image ID, get sha256:[XXXXXXXXXX]...
             image_id = output.stdout_lines[-1][7:19]
 
-        with progress_spinner({"docker rm"}):
+        with progress_spinner({f"{self.docker_cmd} rm"}):
             self.ssh.run_shell_command(
-                StringCommand("docker", "rm", "-f", container_id),
+                StringCommand(self.docker_cmd, "rm", "-f", container_id),
             )
 
         logger.info(
-            "{0}docker build complete, image ID: {1}".format(
+            "{0}{1} build complete, image ID: {2}".format(
                 self.host.print_prefix,
+                self.docker_cmd,
                 click.style(image_id, bold=True),
             ),
         )
@@ -138,7 +147,7 @@ class DockerSSHConnector(BaseConnector):
 
         docker_flags = "-it" if local_arguments.get("_get_pty") else "-i"
         docker_command = StringCommand(
-            "docker",
+            self.docker_cmd,
             "exec",
             docker_flags,
             container_id,
@@ -192,7 +201,7 @@ class DockerSSHConnector(BaseConnector):
         try:
             docker_id = self.host.host_data["docker_container_id"]
             docker_command = StringCommand(
-                "docker",
+                self.docker_cmd,
                 "cp",
                 remote_temp_filename,
                 f"{docker_id}:{remote_filename}",
@@ -246,7 +255,7 @@ class DockerSSHConnector(BaseConnector):
         try:
             docker_id = self.host.host_data["docker_container_id"]
             docker_command = StringCommand(
-                "docker",
+                self.docker_cmd,
                 "cp",
                 f"{docker_id}:{remote_filename}",
                 remote_temp_filename,
@@ -295,3 +304,73 @@ class DockerSSHConnector(BaseConnector):
 
         if not remove_status:
             raise IOError(output.stderr)
+
+
+@memoize
+def show_warning_podman() -> None:
+    logger.warning("The @podmanssh connector is in beta!")
+
+
+class PodmanSSHConnector(DockerSSHConnector):
+    """
+    **Note**: this connector is in beta!
+
+    The ``@podmanssh`` connector allows you to run commands on Podman containers
+    on a remote machine over SSH. This is useful when you need to manage containers
+    running on remote hosts where Podman is installed instead of Docker.
+
+    .. note::
+
+        This connector requires SSH access to the remote host and Podman to be installed
+        on the target machine. It operates similarly to ``@dockerssh`` but uses the
+        ``podman`` command instead of ``docker``.
+
+    + **Remote container creation**: Creates a new container from the specified image on the remote host
+    + **Command execution**: Runs operations inside the container via ``podman exec``
+    + **File operations**: Supports uploading/downloading files to/from containers via ``podman cp``
+    + **Container cleanup**: Automatically commits and removes containers when operations complete
+
+    .. code:: shell
+
+        # A Podman base image must be provided
+        pyinfra @podmanssh/remotehost:alpine:3.8 ...
+
+        # Run operations on multiple remote Podman containers in parallel
+        pyinfra @podmanssh/web1:nginx:latest,@podmanssh/web2:nginx:latest deploy.py
+
+        # Use with specific SSH connection settings
+        pyinfra @podmanssh/production-server:alpine:3.18 --sudo --port 2222 operations/
+
+    **Comparison with other connectors:**
+
+    + Use ``@podman`` for local Podman containers
+    + Use ``@dockerssh`` for remote Docker containers
+    + Use ``@podmanssh`` for remote Podman containers (this connector)
+
+    The Podman SSH connector is particularly useful in environments where:
+
+    + Docker is not available but Podman is installed
+    + Rootless containers are preferred for security
+    + You need OCI-compliant container operations on remote hosts
+    """
+
+    docker_cmd = "podman"
+
+    @override
+    @staticmethod
+    def make_names_data(name):
+        try:
+            hostname, image = name.split(":", 1)
+        except (AttributeError, ValueError):  # failure to parse the name
+            raise InventoryError("No ssh host or podman base image provided!")
+
+        if not image:
+            raise InventoryError("No podman base image provided!")
+
+        show_warning_podman()
+
+        yield (
+            "@podmanssh/{0}:{1}".format(hostname, image),
+            {"ssh_hostname": hostname, "docker_image": image},
+            ["@podmanssh"],
+        )

--- a/tests/test_connectors/test_dockerssh.py
+++ b/tests/test_connectors/test_dockerssh.py
@@ -36,10 +36,43 @@ def fake_ssh_docker_shell(
 
     # This is a bit messy. But it's easier than trying to swap out a mock
     # when it needs to be used...
-    if fake_ssh_docker_shell.custom_command:
+    if hasattr(fake_ssh_docker_shell, "custom_command") and fake_ssh_docker_shell.custom_command:
         custom_command, status, output = fake_ssh_docker_shell.custom_command
         if str(command) == custom_command:
             fake_ssh_docker_shell.ran_custom_command = True
+            return (status, output)
+
+    raise PyinfraError("Invalid Command: {0}".format(command))
+
+
+def fake_ssh_podman_shell(
+    self,
+    command,
+    print_output=False,
+    print_input=False,
+    **command_kwargs,
+):
+    if str(command) == "podman run -d not-an-image tail -f /dev/null":
+        return (True, CommandOutput([OutputLine("stdout", "containerid")]))
+
+    if str(command) == "podman commit containerid":
+        return (True, CommandOutput([OutputLine("stdout", "sha256:blahsomerandomstringdata")]))
+
+    if str(command) == "podman rm -f containerid":
+        return (True, CommandOutput([]))
+
+    if str(command).startswith("rm -f"):
+        return (True, CommandOutput([]))
+
+    if "$TMPDIR" in str(command):
+        return (True, CommandOutput([]))
+
+    # This is a bit messy. But it's easier than trying to swap out a mock
+    # when it needs to be used...
+    if hasattr(fake_ssh_podman_shell, "custom_command") and fake_ssh_podman_shell.custom_command:
+        custom_command, status, output = fake_ssh_podman_shell.custom_command
+        if str(command) == custom_command:
+            fake_ssh_podman_shell.ran_custom_command = True
             return (status, output)
 
     raise PyinfraError("Invalid Command: {0}".format(command))
@@ -50,6 +83,13 @@ def get_docker_command(command):
     shell_command = shlex.quote(shell_command)
     docker_command = "docker exec -it containerid sh -c {0}".format(shell_command)
     return docker_command
+
+
+def get_podman_command(command):
+    shell_command = make_unix_command(command).get_raw_value()
+    shell_command = shlex.quote(shell_command)
+    podman_command = "podman exec -it containerid sh -c {0}".format(shell_command)
+    return podman_command
 
 
 @patch("pyinfra.connectors.ssh.SSHConnector.connect", MagicMock())
@@ -240,6 +280,204 @@ class TestDockerSSHConnector(TestCase):
         # SSH error
         fake_ssh_docker_shell.custom_command = [
             "docker cp containerid:not-a-file remote_tempfile",
+            True,
+            [],
+        ]
+        fake_get_file.return_value = False
+        with self.assertRaises(IOError) as ex:
+            host.get_file("not-a-file", "not-another-file", print_output=True)
+
+        assert str(ex.exception) == "failed to copy file over ssh"
+
+
+@patch("pyinfra.connectors.ssh.SSHConnector.connect", MagicMock())
+@patch("pyinfra.connectors.ssh.SSHConnector.run_shell_command", fake_ssh_podman_shell)
+@patch("pyinfra.api.util.open", mock_open(read_data="test!"), create=True)
+class TestPodmanSSHConnector(TestCase):
+    def setUp(self):
+        # reset custom command for shell
+        fake_ssh_podman_shell.custom_command = None
+        fake_ssh_podman_shell.ran_custom_command = False
+
+    def test_connect_host(self):
+        inventory = make_inventory(("somehost", "anotherhost"))
+        state = State(inventory, Config())
+        host = inventory.get_host("somehost")
+        host.connect(reason=True)
+        assert len(state.active_hosts) == 0
+
+    def test_missing_image_and_host(self):
+        with self.assertRaises(InventoryError):
+            make_inventory(hosts=("@podmanssh",))
+
+    def test_missing_image(self):
+        with self.assertRaises(InventoryError):
+            make_inventory(hosts=("@podmanssh/host",))
+
+        with self.assertRaises(InventoryError):
+            make_inventory(hosts=("@podmanssh/host:",))
+
+    def test_connect_all(self):
+        inventory = make_inventory(hosts=("@podmanssh/somehost:not-an-image",))
+        state = State(inventory, Config())
+        connect_all(state)
+        assert len(state.active_hosts) == 1
+
+    def test_user_provided_container_id(self):
+        inventory = make_inventory(
+            hosts=(("@podmanssh/somehost:not-an-image", {"docker_container_id": "abc"}),),
+        )
+        State(inventory, Config())
+        host = inventory.get_host("@podmanssh/somehost:not-an-image")
+        host.connect()
+        assert host.data.docker_container_id == "abc"
+
+    def test_connect_all_error(self):
+        inventory = make_inventory(hosts=("@podmanssh/somehost:a-broken-image",))
+        state = State(inventory, Config())
+
+        with self.assertRaises(PyinfraError):
+            connect_all(state)
+
+    def test_connect_disconnect_host(self):
+        inventory = make_inventory(hosts=("@podmanssh/somehost:not-an-image",))
+        state = State(inventory, Config())
+        host = inventory.get_host("@podmanssh/somehost:not-an-image")
+        host.connect(reason=True)
+        assert len(state.active_hosts) == 0
+        host.disconnect()
+
+    def test_run_shell_command(self):
+        inventory = make_inventory(hosts=("@podmanssh/somehost:not-an-image",))
+        State(inventory, Config())
+
+        command = "echo hi"
+
+        fake_ssh_podman_shell.custom_command = [get_podman_command(command), True, []]
+
+        host = inventory.get_host("@podmanssh/somehost:not-an-image")
+        host.connect()
+        out = host.run_shell_command(
+            command,
+            _stdin="hello",
+            _get_pty=True,
+            print_output=True,
+        )
+        assert len(out) == 2
+        assert out[0] is True
+        assert fake_ssh_podman_shell.ran_custom_command
+
+    def test_run_shell_command_error(self):
+        inventory = make_inventory(hosts=("@podmanssh/somehost:not-an-image",))
+        state = State(inventory, Config())
+
+        command = "echo hi"
+        fake_ssh_podman_shell.custom_command = [get_podman_command(command), False, []]
+
+        host = inventory.get_host("@podmanssh/somehost:not-an-image")
+        host.connect(state)
+        out = host.run_shell_command(command, _get_pty=True)
+        assert out[0] is False
+        assert fake_ssh_podman_shell.ran_custom_command
+
+    @patch("pyinfra.connectors.dockerssh.mkstemp", lambda: (None, "local_tempfile"))
+    @patch("pyinfra.connectors.docker.os.close", lambda f: None)
+    @patch("pyinfra.connectors.ssh.SSHConnector.put_file")
+    def test_put_file(self, fake_put_file):
+        fake_ssh_podman_shell.custom_command = [
+            "podman cp remote_tempfile containerid:not-another-file",
+            True,
+            [],
+        ]
+
+        inventory = make_inventory(hosts=("@podmanssh/somehost:not-an-image",))
+        State(inventory, Config())
+
+        host = inventory.get_host("@podmanssh/somehost:not-an-image")
+        host.get_temp_filename = lambda _: "remote_tempfile"
+        host.connect()
+
+        host.put_file("not-a-file", "not-another-file", print_output=True)
+
+        # ensure copy from local to remote host
+        fake_put_file.assert_called_with("local_tempfile", "remote_tempfile")
+
+        # ensure copy from remote host to remote podman container
+        assert fake_ssh_podman_shell.ran_custom_command
+
+    @patch("pyinfra.connectors.ssh.SSHConnector.put_file")
+    def test_put_file_error(self, fake_put_file):
+        inventory = make_inventory(hosts=("@podmanssh/somehost:not-an-image",))
+        State(inventory, Config())
+
+        host = inventory.get_host("@podmanssh/somehost:not-an-image")
+        host.get_temp_filename = lambda _: "remote_tempfile"
+        host.connect()
+
+        # SSH error
+        fake_put_file.return_value = False
+        with self.assertRaises(IOError):
+            host.put_file("not-a-file", "not-another-file", print_output=True)
+
+        # podman copy error
+        fake_ssh_podman_shell.custom_command = [
+            "podman cp remote_tempfile containerid:not-another-file",
+            False,
+            CommandOutput([OutputLine("stderr", "podman error")]),
+        ]
+        fake_put_file.return_value = True
+
+        with self.assertRaises(IOError) as e:
+            host.put_file("not-a-file", "not-another-file", print_output=True)
+        assert str(e.exception) == "podman error"
+
+    @patch("pyinfra.connectors.ssh.SSHConnector.get_file")
+    def test_get_file(self, fake_get_file):
+        fake_ssh_podman_shell.custom_command = [
+            "podman cp containerid:not-a-file remote_tempfile",
+            True,
+            [],
+        ]
+
+        inventory = make_inventory(hosts=("@podmanssh/somehost:not-an-image",))
+        State(inventory, Config())
+
+        host = inventory.get_host("@podmanssh/somehost:not-an-image")
+        host.get_temp_filename = lambda _: "remote_tempfile"
+        host.connect()
+
+        host.get_file("not-a-file", "not-another-file", print_output=True)
+
+        # ensure copy from local to remote host
+        fake_get_file.assert_called_with("remote_tempfile", "not-another-file")
+
+        # ensure copy from remote host to remote podman container
+        assert fake_ssh_podman_shell.ran_custom_command
+
+    @patch("pyinfra.connectors.ssh.SSHConnector.get_file")
+    def test_get_file_error(self, fake_get_file):
+        fake_ssh_podman_shell.custom_command = [
+            "podman cp containerid:not-a-file remote_tempfile",
+            False,
+            CommandOutput([OutputLine("stderr", "podman error")]),
+        ]
+
+        inventory = make_inventory(hosts=("@podmanssh/somehost:not-an-image",))
+        State(inventory, Config())
+
+        host = inventory.get_host("@podmanssh/somehost:not-an-image")
+        host.get_temp_filename = lambda _: "remote_tempfile"
+        host.connect()
+
+        fake_get_file.return_value = True
+        with self.assertRaises(IOError) as ex:
+            host.get_file("not-a-file", "not-another-file", print_output=True)
+
+        assert str(ex.exception) == "podman error"
+
+        # SSH error
+        fake_ssh_podman_shell.custom_command = [
+            "podman cp containerid:not-a-file remote_tempfile",
             True,
             [],
         ]


### PR DESCRIPTION
## Summary

Adds support for managing Podman containers on remote hosts via the new `@podmanssh` connector. This extends the existing `@dockerssh` connector to support Podman as an alternative to Docker for remote container operations, particularly in enterprise environments where Podman is preferred over Docker for security and compatibility reasons.

While I realize that there's [desire to avoid adding new connectors](https://docs.pyinfra.com/en/latest/contributing.html#guides) to this repository, the intent of this PR is less about introducing something new and more about adding parity between related connectors that already exist.

## Implementation

**Extensible Architecture:**
- Refactored `DockerSSHConnector` with configurable `docker_cmd` class variable (defaults to `"docker"`)
- Replaced hardcoded `"docker"` strings with `self.docker_cmd` throughout the codebase
- Created `PodmanSSHConnector` as minimal subclass with `docker_cmd = "podman"` override
- Eliminates code duplication while maintaining full feature parity

**Key Features:**
-  **Remote container creation**: Creates containers from images on remote hosts
-  **Command execution**: Runs operations inside containers via `podman exec`
-  **File operations**: Upload/download files via `podman cp`
-  **Container lifecycle**: Automatic commit and cleanup on completion
-  **SSH integration**: Full compatibility with existing SSH connection options

## Usage Examples

```shell
# Basic usage with remote host and image
pyinfra @podmanssh/remotehost:alpine:3.8 operations/deploy.py

# Multi-container parallel operations
pyinfra @podmanssh/web1:nginx:latest,@podmanssh/web2:nginx:latest deploy.py

# SSH-specific options (sudo, custom ports)
pyinfra @podmanssh/production-server:alpine:3.18 --sudo --port 2222 operations/
```

## Connector Ecosystem Integration

Clear Connector Guidance:
- `@podman` → Local Podman containers
- `@docker` → Local Docker containers
- `@dockerssh` → Remote Docker containers
- `@podmanssh` → Remote Podman containers (this PR)

Use Cases:
- Environments where Docker isn't available but Podman is installed
- Rootless container security preferences
- OCI-compliant container operations on remote hosts
- Enterprise environments using RHEL/CentOS with Podman

##  Testing & Documentation

Comprehensive Test Coverage:
- Full test suite covering both Docker and Podman SSH variants
- JSON-based test cases for validation
- Integration with existing `test_dockerssh.py` framework

Enhanced Documentation:
- Detailed docstrings with usage examples and feature descriptions
- Cross-references between related connectors for discoverability
- Auto-generated connector documentation via `generate_connectors_docs.py`
- Integration with Sphinx documentation build process

##  Entry Point Configuration

```toml
[project.entry-points."pyinfra.connectors"]
podmanssh = "pyinfra.connectors.dockerssh:PodmanSSHConnector"
```

## Breaking Changes

None - This is a purely additive change that extends existing functionality without modifying current behavior.

## Checklist

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)

## Related Issues

- https://github.com/pyinfra-dev/pyinfra/issues/383
- https://github.com/pyinfra-dev/pyinfra/pull/388
- https://github.com/pyinfra-dev/pyinfra/pull/1354
- https://github.com/pyinfra-dev/pyinfra/pull/1232
- https://github.com/pyinfra-dev/pyinfra/issues/1263
- https://github.com/pyinfra-dev/pyinfra/issues/677