### PR TITLE
Fix systemd-state-detection

### DIFF
--- a/src/pyinfra/facts/systemd.py
+++ b/src/pyinfra/facts/systemd.py
@@ -41,6 +41,11 @@ def _make_systemctl_cmd(user_mode=False, machine=None, user_name=None):
     return StringCommand(*systemctl_cmd)
 
 
+SYSTEMD_ACTIVE_STATE_KEY = "ActiveState"
+SYSTEMD_ACTIVE_STATES = ("active", "activating", "reloading")
+SYSTEMD_FAILED_STATES = ("failed",)
+
+
 class SystemdStatus(FactBase[Dict[str, bool]]):
     """
     Returns a dictionary map of systemd units to booleans indicating whether they are active.
@@ -65,6 +70,9 @@ class SystemdStatus(FactBase[Dict[str, bool]]):
 
     state_key = "SubState"
     state_values = ["running", "waiting", "exited", "listening", "mounted"]
+    active_state_key = SYSTEMD_ACTIVE_STATE_KEY
+    active_state_values = SYSTEMD_ACTIVE_STATES
+    failed_state_values = SYSTEMD_FAILED_STATES
 
     @override
     def command(
@@ -87,14 +95,22 @@ class SystemdStatus(FactBase[Dict[str, bool]]):
         elif isinstance(services, Iterable):
             service_strs = [QuoteString(s) for s in services]
 
+        properties = [
+            "Id",
+            self.state_key,
+        ]
+        if self.state_key == "SubState":
+            properties.append(self.active_state_key)
+
+        property_args: list[str] = []
+        for property_name in properties:
+            property_args.extend(["--property", property_name])
+
         return StringCommand(
             fact_cmd,
             "show",
             "--all",
-            "--property",
-            "Id",
-            "--property",
-            self.state_key,
+            *property_args,
             *service_strs,
         )
 
@@ -103,6 +119,8 @@ class SystemdStatus(FactBase[Dict[str, bool]]):
         services: Dict[str, bool] = {}
 
         current_unit = None
+        active_states: Dict[str, str] = {}
+        sub_states: Dict[str, str] = {}
         for line in output:
             line = line.strip()
 
@@ -117,7 +135,25 @@ class SystemdStatus(FactBase[Dict[str, bool]]):
                 continue
 
             if key == self.state_key and current_unit:
-                services[current_unit] = value in self.state_values
+                if self.state_key == "SubState":
+                    sub_states[current_unit] = value
+                else:
+                    services[current_unit] = value in self.state_values
+                continue
+
+            if key == self.active_state_key and current_unit:
+                active_states[current_unit] = value
+
+        if self.state_key == "SubState":
+            for unit in set(sub_states) | set(active_states):
+                active_state = active_states.get(unit)
+                sub_state = sub_states.get(unit)
+                if active_state in self.failed_state_values:
+                    services[unit] = False
+                elif active_state in self.active_state_values:
+                    services[unit] = True
+                else:
+                    services[unit] = sub_state in self.state_values
 
         return services
 

--- a/src/pyinfra/operations/systemd.py
+++ b/src/pyinfra/operations/systemd.py
@@ -28,7 +28,6 @@ def daemon_reload(user_mode=False, machine: str | None = None, user_name: str | 
         machine=machine,
         user_name=user_name,
     )
-
     yield StringCommand(systemctl_cmd, "daemon-reload")
 
 
@@ -89,6 +88,9 @@ def service(
         machine=machine,
         user_name=user_name,
     )
+    status_check_cmd = "{0} is-active --quiet {{service}}".format(
+        systemctl_cmd.get_raw_value()
+    )
 
     if not service.endswith(
         (
@@ -129,6 +131,7 @@ def service(
         restarted,
         reloaded,
         command,
+        status_command=status_check_cmd,
     )
 
     if isinstance(enabled, bool):

--- a/src/pyinfra/operations/util/service.py
+++ b/src/pyinfra/operations/util/service.py
@@ -15,32 +15,47 @@ def handle_service_control(
     reloaded: bool | None = None,
     command: str | None = None,
     status_argument="status",
+    status_command: str | None = None,
+    status_command_actions: tuple[str, ...] = ("start", "restart", "reload"),
 ):
     is_running = statuses.get(name, None)
+    quoted_name = shlex.quote(name)
+
+    def _format_status_command() -> str | None:
+        if not status_command:
+            return None
+        return status_command.format(service=quoted_name)
+
+    def _format_action_command(action: str) -> str:
+        action_command = formatter.format(quoted_name, action)
+        status_cmd = _format_status_command()
+        if status_cmd and action in status_command_actions:
+            return "{0} && {1}".format(action_command, status_cmd)
+        return action_command
 
     # Need down but running
     if running is False:
         if is_running:
-            yield formatter.format(shlex.quote(name), "stop")
+            yield _format_action_command("stop")
         else:
             host.noop("service {0} is stopped".format(name))
 
     # Need running but down
     if running is True:
         if not is_running:
-            yield formatter.format(shlex.quote(name), "start")
+            yield _format_action_command("start")
         else:
             host.noop("service {0} is running".format(name))
 
     # Only restart if the service is already running
     if restarted and is_running:
-        yield formatter.format(shlex.quote(name), "restart")
+        yield _format_action_command("restart")
 
     # Only reload if the service is already reloaded
     if reloaded and is_running:
-        yield formatter.format(shlex.quote(name), "reload")
+        yield _format_action_command("reload")
 
     # Always execute arbitrary commands as these may or may not rely on the service
     # being up or down
     if command:
-        yield formatter.format(shlex.quote(name), command)
+        yield _format_action_command(command)

--- a/tests/operations/systemd.service/machine_start.json
+++ b/tests/operations/systemd.service/machine_start.json
@@ -12,6 +12,6 @@
         }
     },
     "commands": [
-        "systemctl --machine=testmachine start redis-server.service"
+        "systemctl --machine=testmachine start redis-server.service && systemctl --machine=testmachine is-active --quiet redis-server.service"
     ]
 }

--- a/tests/operations/systemd.service/running_ambiguous_unit.json
+++ b/tests/operations/systemd.service/running_ambiguous_unit.json
@@ -8,6 +8,6 @@
         }
     },
     "commands": [
-        "systemctl start redis-server.service"
+        "systemctl start redis-server.service && systemctl is-active --quiet redis-server.service"
     ]
 }

--- a/tests/operations/systemd.service/running_timer.json
+++ b/tests/operations/systemd.service/running_timer.json
@@ -8,6 +8,6 @@
         }
     },
     "commands": [
-        "systemctl start some-timer.timer"
+        "systemctl start some-timer.timer && systemctl is-active --quiet some-timer.timer"
     ]
 }

--- a/tests/operations/systemd.service/start.json
+++ b/tests/operations/systemd.service/start.json
@@ -8,6 +8,6 @@
         }
     },
     "commands": [
-        "systemctl start redis-server.service"
+        "systemctl start redis-server.service && systemctl is-active --quiet redis-server.service"
     ]
 }

--- a/tests/operations/systemd.service/timer.json
+++ b/tests/operations/systemd.service/timer.json
@@ -8,6 +8,6 @@
         }
     },
     "commands": [
-        "systemctl start logrotate.timer"
+        "systemctl start logrotate.timer && systemctl is-active --quiet logrotate.timer"
     ]
 }

--- a/tests/operations/systemd.service/user_machine_start.json
+++ b/tests/operations/systemd.service/user_machine_start.json
@@ -13,6 +13,6 @@
         }
     },
     "commands": [
-        "systemctl --user --machine=testuser@testmachine start redis-server.service"
+        "systemctl --user --machine=testuser@testmachine start redis-server.service && systemctl --user --machine=testuser@testmachine is-active --quiet redis-server.service"
     ]
 }

--- a/tests/operations/systemd.service/user_start.json
+++ b/tests/operations/systemd.service/user_start.json
@@ -11,6 +11,6 @@
         }
     },
     "commands": [
-        "systemctl --user start redis-server.service"
+        "systemctl --user start redis-server.service && systemctl --user is-active --quiet redis-server.service"
     ]
 }


### PR DESCRIPTION
Short description:

Make systemd.service detect failures immediately by appending systemctl is-active --quiet after start/restart/reload, and improve SystemdStatus parsing with ActiveState/failed state handling.

#issue : https://github.com/pyinfra-dev/pyinfra/issues/1154 

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [ ] Tests pass (see `scripts/dev-test.sh`)
- [ ] Type checking & code style passes (see `scripts/dev-lint.sh`)
