### PR TITLE
facts.choco: remove invalid shell_executable on ChocoPackages

### DIFF
--- a/src/pyinfra/facts/choco.py
+++ b/src/pyinfra/facts/choco.py
@@ -28,8 +28,6 @@ class ChocoPackages(FactBase):
     def command(self) -> str:
         return "choco list"
 
-    shell_executable = "ps"
-
     default = dict
 
     @override


### PR DESCRIPTION
shell_executable was set to "ps" (Unix process status command) instead of a valid shell, causing commands to run as `ps -c 'choco list'` and fail on remote hosts.


- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)