### PR TITLE
operations.docker: add support for custom command

### DIFF
--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -97,7 +97,7 @@ def container(
         docker.container(
             name="Run a custom command",
             container="alpine",
-            command="sh -c 'echo Whatever you want",
+            command="sh -c 'echo Whatever you want'",
         )
     """
 

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -36,7 +36,7 @@ def container(
     restart_policy: str | None = None,
     auto_remove: bool = False,
     dns: list[str] | None = None,
-    command: str = "",
+    command: str | None = None,
 ):
     """
     Manage Docker containers

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -36,6 +36,7 @@ def container(
     restart_policy: str | None = None,
     auto_remove: bool = False,
     dns: list[str] | None = None,
+    command: str = "",
 ):
     """
     Manage Docker containers
@@ -55,6 +56,7 @@ def container(
     + restart_policy: restart policy to apply when a container exits
     + auto_remove: automatically remove the container and its associated anonymous volumes when it exits
     + dns: list of dns servers to be used by the container
+    + command: custom command to run on container start
 
     **Examples:**
 
@@ -89,6 +91,14 @@ def container(
             container="nginx",
             start=True,
         )
+
+        # Run a custom command on container start
+        # Note: you can omit the shell (sh -c) to use the default shell of the container
+        docker.container(
+            name="Run a custom command",
+            container="alpine",
+            command="sh -c 'echo Whatever you want",
+        )
     """
 
     want_spec = ContainerSpec(
@@ -103,6 +113,7 @@ def container(
         restart_policy,
         auto_remove,
         dns or list(),
+        command,
     )
     existent_container = host.get_fact(DockerContainer, object_id=container)
 

--- a/src/pyinfra/operations/util/docker.py
+++ b/src/pyinfra/operations/util/docker.py
@@ -169,7 +169,7 @@ class ContainerSpec:
     restart_policy: str | None = None
     auto_remove: bool = False
     dns: list[str] = field(default_factory=list)
-    command: str = ""
+    command: str | None = None
 
     def container_create_args(self):
         args = []

--- a/src/pyinfra/operations/util/docker.py
+++ b/src/pyinfra/operations/util/docker.py
@@ -204,7 +204,8 @@ class ContainerSpec:
             args.append("--dns {0}".format(dns))
 
         args.append(self.image)
-        args.append(self.command)
+        if self.command:
+            args.append(self.command)
 
         return args
 

--- a/src/pyinfra/operations/util/docker.py
+++ b/src/pyinfra/operations/util/docker.py
@@ -169,6 +169,7 @@ class ContainerSpec:
     restart_policy: str | None = None
     auto_remove: bool = False
     dns: list[str] = field(default_factory=list)
+    command: str = ""
 
     def container_create_args(self):
         args = []
@@ -203,6 +204,7 @@ class ContainerSpec:
             args.append("--dns {0}".format(dns))
 
         args.append(self.image)
+        args.append(self.command)
 
         return args
 

--- a/tests/operations/docker.container/add_container_with_command.json
+++ b/tests/operations/docker.container/add_container_with_command.json
@@ -1,0 +1,17 @@
+{
+    "kwargs": {
+        "container": "nginx",
+        "image": "nginx:alpine",
+        "present": "true",
+        "start": false,
+        "command": "sh -c 'echo leroy jenkins'"
+    },
+    "facts": {
+        "docker.DockerContainer": {
+            "object_id=nginx": []
+        }
+    },
+    "commands": [
+        "docker container create --name nginx nginx:alpine sh -c 'echo leroy jenkins'"
+    ]
+}


### PR DESCRIPTION
<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)

Hi there! Noticed another thing missing from the docker container operation.
This adds support for custom commands to be run on container start.