### PR TITLE
fix: command injection in server.home fact

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import shutil
+import shlex
 from datetime import datetime
 from tempfile import mkdtemp
 from typing import Dict, Iterable, List, Optional, Tuple, Union
@@ -37,7 +38,19 @@ class Home(FactBase[Optional[str]]):
 
     @override
     def command(self, user=""):
-        return f"echo ~{user}"
+        if not user:
+            return "echo ~"
+        else:
+            # getent passwd returns: username:password:uid:gid:gecos:home_directory:shell
+            # We want the 6th field (index 5)
+            return f"getent passwd {shlex.quote(user)} | cut -d: -f6"
+
+    @override
+    def process(self, output: list[str]) -> Optional[str]:
+        if not output:
+            return None
+        home_dir = output[0].strip()
+        return home_dir if home_dir else None
 
 
 class Path(FactBase):


### PR DESCRIPTION
### Problem

The `Home` fact constructs a shell command using an f-string with the `user` argument directly (`f"echo ~{user}"`). If the `user` argument is controlled by an attacker (e.g., via inventory data or a custom operation), they can inject arbitrary shell commands. The `~` expansion happens in the shell, meaning input like `"; rm -rf /"` would be interpreted as a separate command, leading to remote code execution on the target host.


### Changes

Use `shlex.quote` to properly escape the `user` input when constructing the shell command. For retrieving a user's home directory, `getent passwd` is a more robust and safer approach than relying on shell `~` expansion.


**Modified files:**
- `src/pyinfra/facts/server.py` (modified)



- [ ] Pull request is based on the default branch (`3.x` at this time)
- [ ] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [ ] Tests pass (see `scripts/dev-test.sh`)
- [ ] Type checking & code style passes (see `scripts/dev-lint.sh`)


Closes #1641