### PR TITLE
connectors: use gevent.subprocess in util for macOS + Python 3.13 compatibility (#1653)

### DIFF
--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from getpass import getpass
 from queue import Queue
 from socket import timeout as timeout_error
-from subprocess import PIPE, Popen
+from gevent.subprocess import PIPE, Popen
 from typing import TYPE_CHECKING, Callable, Iterable, Optional, Union
 
 import click


### PR DESCRIPTION
## Problem

On macOS with Python 3.13, the `@local` connector fails with:

```
File ".../subprocess.py", line 1902, in _execute_child
    self.pid = _fork_exec(...)
TypeError: 'NoneType' object is not callable
```

`_fork_exec` is intentionally set to `None` by gevent (it uses its own `fork_and_watch` instead). The issue is that inside pyinfra's greenlet operation execution context, CPython's original `Popen.__init__` gets called instead of gevent's override, which then calls CPython's `_execute_child` that depends on `_fork_exec`.

## Root Cause

`connectors/util.py` imports `from subprocess import Popen`. After `monkey.patch_all()`, `subprocess.Popen` points to `gevent.subprocess.Popen`, but in the greenlet execution context during operation runs, the resolution falls back to CPython's original implementation.

## Fix

Import `Popen` and `PIPE` directly from `gevent.subprocess` instead of relying on the monkey-patched `subprocess` module. Since pyinfra already imports `gevent` in this same file, there is no additional dependency cost.

## Testing

Before:
\`\`\`bash
$ pyinfra -y @local server.shell -- "echo hello"
# TypeError: 'NoneType' object is not callable
\`\`\`

After:
\`\`\`bash
$ pyinfra -y @local server.shell -- "echo hello"
# [@local] Success
\`\`\`

Tested on:
- Python 3.13.7 and 3.13.12, macOS arm64
- gevent 25.9.1, pyinfra 3.7

Fixes #1652