### PR TITLE
fix: Add timeout support in FunctionCommand

### DIFF
--- a/src/pyinfra/api/operations.py
+++ b/src/pyinfra/api/operations.py
@@ -103,7 +103,12 @@ def _run_host_op(state: "State", host: "Host", op_hash: str) -> bool:
 
             if isinstance(command, FunctionCommand):
                 try:
-                    status = command.execute(state, host, connector_arguments)
+                    with gevent.Timeout(timeout, exception=TimeoutError):
+                        status = command.execute(state, host, connector_arguments)
+
+                except TimeoutError as e:
+                    log_host_command_error(host, e, timeout=timeout)
+
                 except NestedOperationError:
                     host.log_styled("Error in nested operation", fg="red", log_func=logger.error)
                 except Exception as e:

--- a/src/pyinfra/api/util.py
+++ b/src/pyinfra/api/util.py
@@ -261,7 +261,7 @@ def log_error_or_warning(
 
 
 def log_host_command_error(host: "Host", e: Exception, timeout: int | None = 0) -> None:
-    if isinstance(e, timeout_error):
+    if isinstance(e, (TimeoutError, timeout_error)):
         logger.error(
             "{0}{1}".format(
                 host.print_prefix,

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from os import path
 from unittest import TestCase
 from unittest.mock import mock_open, patch
+import time
 
 import pyinfra
 from pyinfra.api import (
@@ -257,6 +258,23 @@ class TestOperationsApi(PatchSSHTestCase):
         run_ops(state)
 
         assert is_called
+
+    def test_function_call_op_timeout(self):
+        inventory = make_inventory()
+        state = State(inventory, Config())
+        state.current_stage = StateStage.Prepare
+        connect_all(state)
+
+        timeout = 1
+
+        def mocked_function(*args, **kwargs):
+            time.sleep(timeout + 1)
+
+        add_op(state, python.call, mocked_function, _timeout=timeout)
+
+        # Timeout should cause the operation to fail and hosts to be removed
+        with self.assertRaises(PyinfraError) as context:
+            run_ops(state)
 
     def test_run_once_serial_op(self):
         inventory = make_inventory()


### PR DESCRIPTION
This PR closes issue #1622 by:

- Applying gevent timeouts to all function commands
- Ensuring consistent logging of timeouts
- Adding minimal unit test coverage for timeout handling

-----

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
