### PR TITLE
security: quote untrusted values in command construction across connectors, operations, and util

### DIFF
--- a/src/pyinfra/connectors/chroot.py
+++ b/src/pyinfra/connectors/chroot.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 from tempfile import mkstemp
 from typing import TYPE_CHECKING, Optional
 
@@ -64,7 +65,7 @@ class ChrootConnector(BaseConnector):
         try:
             with progress_spinner({"chroot run"}):
                 local.shell(
-                    "chroot {0} ls".format(chroot_directory),
+                    "chroot {0} ls".format(shlex.quote(chroot_directory)),
                     splitlines=True,
                 )
         except PyinfraError as e:
@@ -91,7 +92,7 @@ class ChrootConnector(BaseConnector):
 
         chroot_command = StringCommand(
             "chroot",
-            chroot_directory,
+            QuoteString(chroot_directory),
             "sh",
             "-c",
             command,
@@ -130,8 +131,8 @@ class ChrootConnector(BaseConnector):
             chroot_directory = self.host.connector_data["chroot_directory"]
             chroot_command = StringCommand(
                 "cp",
-                temp_filename,
-                f"{chroot_directory}/{remote_filename}",
+                QuoteString(temp_filename),
+                QuoteString(f"{chroot_directory}/{remote_filename}"),
             )
 
             status, output = self.local.run_shell_command(
@@ -172,8 +173,8 @@ class ChrootConnector(BaseConnector):
             chroot_directory = self.host.connector_data["chroot_directory"]
             chroot_command = StringCommand(
                 "cp",
-                f"{chroot_directory}/{remote_filename}",
-                temp_filename,
+                QuoteString(f"{chroot_directory}/{remote_filename}"),
+                QuoteString(temp_filename),
             )
 
             status, output = self.local.run_shell_command(

--- a/src/pyinfra/connectors/docker.py
+++ b/src/pyinfra/connectors/docker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 from tempfile import mkstemp
 from typing import TYPE_CHECKING
 
@@ -106,12 +107,13 @@ class DockerConnector(BaseConnector):
 
     # 2 helper functions
     def _find_start_docker_container(self, container_id) -> tuple[str, bool]:
-        docker_info = local.shell(f"{self.docker_cmd} container inspect {container_id}")
+        quoted_container_id = shlex.quote(container_id)
+        docker_info = local.shell(f"{self.docker_cmd} container inspect {quoted_container_id}")
         assert isinstance(docker_info, str)
         docker_info = json.loads(docker_info)[0]
         if docker_info["State"]["Running"] is False:
             logger.info(f"Starting stopped container: {container_id}")
-            local.shell(f"{self.docker_cmd} container start {container_id}")
+            local.shell(f"{self.docker_cmd} container start {quoted_container_id}")
             return container_id, False
         return container_id, True
 
@@ -123,13 +125,13 @@ class DockerConnector(BaseConnector):
         ]
 
         if self.data.get("docker_platform"):
-            docker_cmd_parts.extend(["--platform", self.data["docker_platform"]])
+            docker_cmd_parts.extend(["--platform", shlex.quote(self.data["docker_platform"])])
         if self.data.get("docker_architecture"):
-            docker_cmd_parts.extend(["--arch", self.data["docker_architecture"]])
+            docker_cmd_parts.extend(["--arch", shlex.quote(self.data["docker_architecture"])])
 
         docker_cmd_parts.extend(
             [
-                image_name,
+                shlex.quote(image_name),
                 "tail",
                 "-f",
                 "/dev/null",
@@ -173,14 +175,16 @@ class DockerConnector(BaseConnector):
             )
             return
 
+        quoted_container_id = shlex.quote(container_id)
+
         with progress_spinner({f"{self.docker_cmd} commit"}):
-            image_id = local.shell(f"{self.docker_cmd} commit {container_id}", splitlines=True)[-1][
-                7:19
-            ]  # last line is the image ID, get sha256:[XXXXXXXXXX]...
+            image_id = local.shell(
+                f"{self.docker_cmd} commit {quoted_container_id}", splitlines=True
+            )[-1][7:19]  # last line is the image ID, get sha256:[XXXXXXXXXX]...
 
         with progress_spinner({f"{self.docker_cmd} rm"}):
             local.shell(
-                f"{self.docker_cmd} rm -f {container_id}",
+                f"{self.docker_cmd} rm -f {quoted_container_id}",
             )
 
         logger.info(
@@ -255,8 +259,8 @@ class DockerConnector(BaseConnector):
             docker_command = StringCommand(
                 self.docker_cmd,
                 "cp",
-                temp_filename,
-                f"{self.container_id}:{remote_filename}",
+                QuoteString(temp_filename),
+                QuoteString(f"{self.container_id}:{remote_filename}"),
             )
 
             status, output = self.local.run_shell_command(
@@ -303,8 +307,8 @@ class DockerConnector(BaseConnector):
             docker_command = StringCommand(
                 self.docker_cmd,
                 "cp",
-                f"{self.container_id}:{remote_filename}",
-                temp_filename,
+                QuoteString(f"{self.container_id}:{remote_filename}"),
+                QuoteString(temp_filename),
             )
 
             status, output = self.local.run_shell_command(

--- a/src/pyinfra/connectors/dockerssh.py
+++ b/src/pyinfra/connectors/dockerssh.py
@@ -90,7 +90,7 @@ class DockerSSHConnector(BaseConnector):
                         self.docker_cmd,
                         "run",
                         "-d",
-                        self.host.data.docker_image,
+                        QuoteString(self.host.data.docker_image),
                         "tail",
                         "-f",
                         "/dev/null",
@@ -111,7 +111,7 @@ class DockerSSHConnector(BaseConnector):
 
         with progress_spinner({f"{self.docker_cmd} commit"}):
             _, output = self.ssh.run_shell_command(
-                StringCommand(self.docker_cmd, "commit", container_id)
+                StringCommand(self.docker_cmd, "commit", QuoteString(container_id))
             )
 
             # Last line is the image ID, get sha256:[XXXXXXXXXX]...
@@ -119,7 +119,7 @@ class DockerSSHConnector(BaseConnector):
 
         with progress_spinner({f"{self.docker_cmd} rm"}):
             self.ssh.run_shell_command(
-                StringCommand(self.docker_cmd, "rm", "-f", container_id),
+                StringCommand(self.docker_cmd, "rm", "-f", QuoteString(container_id)),
             )
 
         logger.info(
@@ -150,7 +150,7 @@ class DockerSSHConnector(BaseConnector):
             self.docker_cmd,
             "exec",
             docker_flags,
-            container_id,
+            QuoteString(container_id),
             "sh",
             "-c",
             command,
@@ -203,8 +203,8 @@ class DockerSSHConnector(BaseConnector):
             docker_command = StringCommand(
                 self.docker_cmd,
                 "cp",
-                remote_temp_filename,
-                f"{docker_id}:{remote_filename}",
+                QuoteString(remote_temp_filename),
+                QuoteString(f"{docker_id}:{remote_filename}"),
             )
 
             status, output = self.ssh.run_shell_command(
@@ -257,8 +257,8 @@ class DockerSSHConnector(BaseConnector):
             docker_command = StringCommand(
                 self.docker_cmd,
                 "cp",
-                f"{docker_id}:{remote_filename}",
-                remote_temp_filename,
+                QuoteString(f"{docker_id}:{remote_filename}"),
+                QuoteString(remote_temp_filename),
             )
 
             status, output = self.ssh.run_shell_command(

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -235,12 +235,12 @@ def write_stdin(stdin, buffer):
 def remove_any_sudo_askpass_file(host) -> None:
     sudo_askpass_path = host.connector_data.get("sudo_askpass_path")
     if sudo_askpass_path:
-        host.run_shell_command("rm -f {0}".format(sudo_askpass_path))
+        host.run_shell_command(StringCommand("rm", "-f", QuoteString(sudo_askpass_path)))
         host.connector_data["sudo_askpass_path"] = None
 
     su_askpass_path = host.connector_data.get("su_askpass_path")
     if su_askpass_path:
-        host.run_shell_command("rm -f {0}".format(su_askpass_path))
+        host.run_shell_command(StringCommand("rm", "-f", QuoteString(su_askpass_path)))
         host.connector_data["su_askpass_path"] = None
 
 
@@ -293,7 +293,7 @@ def _ensure_askpass_set_for_host(host: "Host", key: str, env_var: str):
             )
         )
 
-    host.connector_data[key] = StringCommand(QuoteString(output.stdout_lines[0])).get_raw_value()
+    host.connector_data[key] = output.stdout_lines[0]
 
 
 def make_unix_command_for_host(
@@ -367,11 +367,18 @@ def make_unix_command(
         _shell_executable = "sh"
 
     if _env:
-        env_string = " ".join(['"{0}={1}"'.format(key, value) for key, value in _env.items()])
-        command = StringCommand("export", env_string, "&&", command)
+        env_bits: list[Union[str, StringCommand, QuoteString]] = ["export"]
+        for key, value in _env.items():
+            # Quote the whole `key=value` pair so arbitrary values cannot break
+            # out into additional shell tokens. Invalid identifiers in `key` will
+            # fail safely when the shell rejects the resulting `export` statement.
+            env_bits.append(QuoteString("{0}={1}".format(key, value)))
+        env_bits.append("&&")
+        env_bits.append(command)
+        command = StringCommand(*env_bits)
 
     if _chdir:
-        command = StringCommand("cd", _chdir, "&&", command)
+        command = StringCommand("cd", QuoteString(_chdir), "&&", command)
 
     command_bits: list[Union[str, StringCommand, QuoteString]] = []
 
@@ -379,19 +386,19 @@ def make_unix_command(
         command_bits.extend(["doas", "-n"])
 
         if _doas_user:
-            command_bits.extend(["-u", _doas_user])
+            command_bits.extend(["-u", QuoteString(_doas_user)])
 
     if _dzdo:
         command_bits.extend(["dzdo", "-H", "-n"])
 
         if _dzdo_user:
-            command_bits.extend(["-u", _dzdo_user])
+            command_bits.extend(["-u", QuoteString(_dzdo_user)])
 
     if _sudo_password and _sudo_askpass_path:
         command_bits.extend(
             [
                 "env",
-                "SUDO_ASKPASS={0}".format(_sudo_askpass_path),
+                StringCommand("SUDO_ASKPASS=", QuoteString(_sudo_askpass_path), _separator=""),
                 MaskString(
                     "{0}={1}".format(
                         SUDO_ASKPASS_ENV_VAR,
@@ -416,7 +423,7 @@ def make_unix_command(
             command_bits.append("-E")
 
         if _sudo_user:
-            command_bits.extend(("-u", _sudo_user))
+            command_bits.extend(("-u", QuoteString(_sudo_user)))
 
     if _su_user:
         if _su_password and _su_askpass_path:
@@ -429,7 +436,7 @@ def make_unix_command(
                             StringCommand(QuoteString(_su_password)).get_raw_value(),
                         )
                     ),
-                    _su_askpass_path,
+                    QuoteString(_su_askpass_path),
                     "|",
                 ],
             )
@@ -444,9 +451,16 @@ def make_unix_command(
             command_bits.append("-m")
 
         if _su_shell:
-            command_bits.extend(["-s", "`which {0}`".format(_su_shell)])
+            # Resolve the shell via `command -v`, with the user-supplied shell
+            # name safely quoted so it cannot inject extra shell syntax.
+            command_bits.extend(
+                [
+                    "-s",
+                    StringCommand("$(command -v ", QuoteString(_su_shell), ")", _separator=""),
+                ]
+            )
 
-        command_bits.extend([_su_user, "-c"])
+        command_bits.extend([QuoteString(_su_user), "-c"])
 
         if _shell_executable is not None:
             # Quote the whole shell -c 'command' as BSD `su` does not have a shell option

--- a/src/pyinfra/operations/selinux.py
+++ b/src/pyinfra/operations/selinux.py
@@ -60,8 +60,12 @@ def boolean(bool_name: str, value: Boolean, persistent=False):
         raise OperationValueError(f"Invalid value '{value}' for boolean operation")
 
     if host.get_fact(SEBoolean, boolean=bool_name) != value_str:
-        persist = "-P " if persistent else ""
-        yield StringCommand("setsebool", f"{persist}{bool_name}", value_str)
+        command_bits: list = ["setsebool"]
+        if persistent:
+            command_bits.append("-P")
+        command_bits.append(QuoteString(bool_name))
+        command_bits.append(value_str)
+        yield StringCommand(*command_bits)
     else:
         host.noop(f"boolean '{bool_name}' already had the value '{value_str}'")
 

--- a/src/pyinfra/operations/util/files.py
+++ b/src/pyinfra/operations/util/files.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Callable, Generator
 
-from pyinfra.api import QuoteString, StringCommand
+from pyinfra.api import OperationError, QuoteString, StringCommand
 from pyinfra.api.output import format_text
 
 
@@ -158,7 +158,8 @@ def chown(
         command = "chgrp"
         user_group = group
 
-    assert user_group is not None, "chown() requires at least one of user or group"
+    if user_group is None:
+        raise OperationError("chown() requires at least one of user or group")
 
     args = [command]
     if recursive:

--- a/src/pyinfra/operations/util/files.py
+++ b/src/pyinfra/operations/util/files.py
@@ -146,7 +146,7 @@ def chown(
     dereference=True,
 ) -> StringCommand:
     command = "chown"
-    user_group = None
+    user_group: str | None = None
 
     if user and group:
         user_group = "{0}:{1}".format(user, group)
@@ -158,6 +158,8 @@ def chown(
         command = "chgrp"
         user_group = group
 
+    assert user_group is not None, "chown() requires at least one of user or group"
+
     args = [command]
     if recursive:
         args.append("-R")
@@ -165,7 +167,7 @@ def chown(
     if not dereference:
         args.append("-h")
 
-    return StringCommand(" ".join(args), user_group, QuoteString(target))
+    return StringCommand(" ".join(args), QuoteString(user_group), QuoteString(target))
 
 
 # like the touch command, but only supports setting one field at a time, and expects any

--- a/tests/operations/files.file/add_user_group_with_metachars.json
+++ b/tests/operations/files.file/add_user_group_with_metachars.json
@@ -1,0 +1,18 @@
+{
+    "args": ["testfile"],
+    "kwargs": {
+        "user": "root; rm -rf /",
+        "group": "wheel$(id)",
+        "mode": "777"
+    },
+    "facts": {
+        "files.File": {
+            "path=testfile": null
+        }
+    },
+    "commands": [
+        "touch testfile",
+        "chmod 777 testfile",
+        "chown 'root; rm -rf /:wheel$(id)' testfile"
+    ]
+}

--- a/tests/operations/selinux.boolean/change_bool_name_with_metachars.json
+++ b/tests/operations/selinux.boolean/change_bool_name_with_metachars.json
@@ -1,0 +1,14 @@
+{
+    "args": ["httpd`id`", "on"],
+    "kwargs": {
+        "persistent": true
+    },
+    "facts": {
+        "selinux.SEBoolean": {
+            "boolean=httpd`id`": "off"
+        }
+    },
+    "commands": [
+        "setsebool -P 'httpd`id`' on"
+    ]
+}

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -67,7 +67,15 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
 
     def test_su_shell_command(self):
         command = make_unix_command("uptime", _su_user="pyinfra", _su_shell="bash")
-        assert command.get_raw_value() == "su -s `which bash` pyinfra -c 'sh -c uptime'"
+        assert command.get_raw_value() == "su -s $(command -v bash) pyinfra -c 'sh -c uptime'"
+
+    def test_su_shell_command_with_injection_attempt(self):
+        command = make_unix_command("uptime", _su_user="pyinfra", _su_shell="bash$(id)")
+        # The injected `$(id)` must be safely quoted as a literal argument to
+        # `command -v` rather than executed as a subshell.
+        assert (
+            command.get_raw_value() == "su -s $(command -v 'bash$(id)') pyinfra -c 'sh -c uptime'"
+        )
 
     def test_su_password_command(self):
         command = make_unix_command(
@@ -90,9 +98,21 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
             },
         )
         assert command.get_raw_value() in [
-            'sh -c \'export "key=value" "anotherkey=anothervalue" && uptime\'',
-            'sh -c \'export "anotherkey=anothervalue" "key=value" && uptime\'',
+            "sh -c 'export key=value anotherkey=anothervalue && uptime'",
+            "sh -c 'export anotherkey=anothervalue key=value && uptime'",
         ]
+
+    def test_command_env_injection_attempt(self):
+        command = make_unix_command(
+            "uptime",
+            _env={"KEY": 'value"; id; echo "'},
+        )
+        # The value contains shell metacharacters; it must be quoted as a
+        # single literal token so it cannot inject additional commands.
+        assert (
+            command.get_raw_value()
+            == "sh -c 'export '\"'\"'KEY=value\"; id; echo \"'\"'\"' && uptime'"
+        )
 
     def test_command_chdir(self):
         command = make_unix_command("uptime", _chdir="/opt/somedir")
@@ -116,7 +136,7 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
         assert command.get_raw_value() == (
             "sudo -H -n -E -u root "  # sudo bit
             "su pyinfra -c "  # su bit
-            "'bash -c '\"'\"'cd /opt/somedir && export \"key=value\" "  # shell and export bit
+            "'bash -c '\"'\"'cd /opt/somedir && export key=value "  # shell and export bit
             "&& echo hi'\"'\"''"  # command bit
         )
 

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -1,9 +1,14 @@
 # encoding: utf-8
 
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from pyinfra.api import Config, State
-from pyinfra.connectors.util import make_unix_command, make_unix_command_for_host
+from pyinfra.connectors.util import (
+    make_unix_command,
+    make_unix_command_for_host,
+    remove_any_sudo_askpass_file,
+)
 
 from ..util import make_inventory
 
@@ -21,6 +26,10 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
         command = make_unix_command("uptime", _doas=True, _doas_user="pyinfra")
         assert command.get_raw_value() == "doas -n -u pyinfra sh -c uptime"
 
+    def test_doas_user_command_with_injection_attempt(self):
+        command = make_unix_command("uptime", _doas=True, _doas_user="root; rm -rf /")
+        assert command.get_raw_value() == ("doas -n -u 'root; rm -rf /' sh -c uptime")
+
     def test_dzdo_command(self):
         command = make_unix_command("uptime", _dzdo=True)
         assert command.get_raw_value() == "dzdo -H -n sh -c uptime"
@@ -28,6 +37,10 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
     def test_dzdo_user_command(self):
         command = make_unix_command("uptime", _dzdo=True, _dzdo_user="pyinfra")
         assert command.get_raw_value() == "dzdo -H -n -u pyinfra sh -c uptime"
+
+    def test_dzdo_user_command_with_injection_attempt(self):
+        command = make_unix_command("uptime", _dzdo=True, _dzdo_user="root`id`")
+        assert command.get_raw_value() == ("dzdo -H -n -u 'root`id`' sh -c uptime")
 
     def test_sudo_command(self):
         command = make_unix_command("uptime", _sudo=True)
@@ -49,9 +62,28 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
         command = make_unix_command("uptime", _sudo=True, _sudo_user="pyinfra")
         assert command.get_raw_value() == "sudo -H -n -u pyinfra sh -c uptime"
 
+    def test_sudo_user_command_with_injection_attempt(self):
+        command = make_unix_command("uptime", _sudo=True, _sudo_user="root; touch /tmp/pwn")
+        assert command.get_raw_value() == ("sudo -H -n -u 'root; touch /tmp/pwn' sh -c uptime")
+
+    def test_sudo_password_askpass_path_quoted(self):
+        command = make_unix_command(
+            "uptime",
+            _sudo=True,
+            _sudo_password="secret",
+            _sudo_askpass_path="/tmp/weird path; id",
+        )
+        # The askpass path contains shell metacharacters and must be quoted
+        # so it cannot inject commands into the SUDO_ASKPASS env assignment.
+        assert "SUDO_ASKPASS='/tmp/weird path; id'" in command.get_raw_value()
+
     def test_su_command(self):
         command = make_unix_command("uptime", _su_user="pyinfra")
         assert command.get_raw_value() == "su pyinfra -c 'sh -c uptime'"
+
+    def test_su_command_with_injection_attempt(self):
+        command = make_unix_command("uptime", _su_user="root$(id)")
+        assert command.get_raw_value() == ("su 'root$(id)' -c 'sh -c uptime'")
 
     def test_su_multi_arg_command(self):
         command = make_unix_command("echo hi", _su_user="pyinfra")
@@ -118,6 +150,10 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
         command = make_unix_command("uptime", _chdir="/opt/somedir")
         assert command.get_raw_value() == "sh -c 'cd /opt/somedir && uptime'"
 
+    def test_command_chdir_injection_attempt(self):
+        command = make_unix_command("uptime", _chdir="/tmp; rm -rf / #")
+        assert command.get_raw_value() == ("sh -c 'cd '\"'\"'/tmp; rm -rf / #'\"'\"' && uptime'")
+
     def test_custom_shell_command(self):
         command = make_unix_command("uptime", _shell_executable="bash")
         assert command.get_raw_value() == "bash -c uptime"
@@ -139,6 +175,44 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
             "'bash -c '\"'\"'cd /opt/somedir && export key=value "  # shell and export bit
             "&& echo hi'\"'\"''"  # command bit
         )
+
+    def test_mixed_command_with_injection_attempts(self):
+        command = make_unix_command(
+            "echo hi",
+            _chdir="/tmp; id",
+            _env={"K": "v; id"},
+            _sudo=True,
+            _sudo_user="root$(id)",
+            _su_user="pyinfra`id`",
+            _su_shell="bash$(id)",
+        )
+        raw = command.get_raw_value()
+        # None of the injected strings should appear unquoted. Every one of
+        # them must be inside single-quotes somewhere in the output.
+        assert "'root$(id)'" in raw
+        assert "'pyinfra`id`'" in raw
+        assert "'bash$(id)'" in raw
+        # The chdir and env are embedded inside a nested sh -c, so check for
+        # the escaped-single-quote form that shlex.quote produces.
+        assert "/tmp; id" in raw
+        assert "K=v; id" in raw
+        # And the inner commands should survive through the layers of quoting.
+        assert raw.endswith("'\"'\"''")
+
+    def test_remove_any_sudo_askpass_file_quotes_path(self):
+        commands = []
+
+        host = MagicMock()
+        host.connector_data = {
+            "sudo_askpass_path": "/tmp/weird path; id",
+            "su_askpass_path": None,
+        }
+        host.run_shell_command = lambda cmd: commands.append(cmd.get_raw_value())
+
+        remove_any_sudo_askpass_file(host)
+
+        assert commands == ["rm -f '/tmp/weird path; id'"]
+        assert host.connector_data["sudo_askpass_path"] is None
 
     def test_command_exists_su_config_only(self):
         """


### PR DESCRIPTION
# Summary

Hardening of every place pyinfra builds a shell command by interpolating inventory- or caller-supplied strings without passing them through `QuoteString` / `shlex.quote`. `api.command.StringCommand` only shell-escapes bits wrapped in `QuoteString`; raw string bits are pasted verbatim. Several call sites relied on raw bits, which made them injectable when the surrounding value was not strictly trusted (dynamic inventories, data loaded from external systems, etc.).

## Fixed injection surfaces

**`connectors/util.py` -- `make_unix_command`**
- `_env` was built with `'"{0}={1}"'.format(key, value)`; double-quoted shell context still interprets `"`, `$`, `` ` ``. Now each `key=value` is wrapped in `QuoteString` so values with metacharacters become a single literal token.
- `_chdir`, `_sudo_user`, `_doas_user`, `_dzdo_user`, `_su_user` were pasted as raw bits -- now wrapped in `QuoteString`.
- `_su_shell` used unquoted backtick command substitution (``-s `which {shell}` ``) which executed the user value as a subshell. Replaced with `$(command -v 'shell')` via `StringCommand` + `QuoteString` so injection attempts fail safely inside `command -v`.
- `_sudo_askpass_path` / `_su_askpass_path` were pre-quoted once when stored in `connector_data` and then concatenated back unquoted. Switched to storing the raw path and quoting it at each use site (including `remove_any_sudo_askpass_file`, which previously used `"rm -f {0}".format(path)`).

**`operations/util/files.py` -- `chown()`**
- `user_group` (`"user:group"`) was passed as a raw bit. Wrapped in `QuoteString` and added a `None` assertion so callers that pass neither user nor group fail loudly instead of emitting `chown None <target>`.

**`connectors/docker.py`, `connectors/dockerssh.py`, `connectors/chroot.py`**
- Docker/Podman container IDs and image names were interpolated directly into `f"{self.docker_cmd} container inspect {container_id}"` style `local.shell()` calls -- this is RCE on the *controller* machine, not the target, because `local.shell()` executes via `run_local_process` with `shell=True`. Now `shlex.quote`'d / wrapped in `QuoteString` throughout `connect`, `disconnect`, `run_shell_command`, `put_file`, and `get_file`.
- Same pattern fixed for `dockerssh` (`ssh.run_shell_command`) and `chroot` (container `chroot` directory and `cp` target paths).

**`operations/selinux.py` -- `selinux.boolean()`**
- `yield StringCommand(""setsebool"", f""{persist}{bool_name}"", value_str)` concatenated the `-P` flag with the boolean name into a single raw bit. Split the flag out into its own argument and wrapped `bool_name` in `QuoteString`.

## Tests

- `tests/test_connectors/test_util.py` -- regression/injection-attempt tests for `_doas_user`, `_dzdo_user`, `_sudo_user`, `_su_user`, `_su_shell`, `_chdir`, `_env`, the `SUDO_ASKPASS=` env assignment, and `remove_any_sudo_askpass_file`, plus a mixed scenario. Expected outputs for the existing `test_su_shell_command`, `test_command_env`, and `test_mixed_command` were updated for the new, stricter quoting.
- `tests/operations/files.file/add_user_group_with_metachars.json` :  fixture proving `chown` quotes `user:group` when it contains `;` and `$()`.
- `tests/operations/selinux.boolean/change_bool_name_with_metachars.json` : fixture proving `setsebool -P` quotes a bool name containing backticks.
- All existing chown/docker/chroot fixtures remained valid because their test inputs use characters that are identity under `shlex.quote`.

## Threat model note

Most of these are only exploitable when the injected argument comes from untrusted inventory / dynamic data (e.g. a `@terraform` output used as a host name, a fact result fed into a subsequent operation). For fully hand-authored static inventory the risk is lower -- but the fixes are purely defensive and the audit trail through `StringCommand` is now consistent: **every bit that reaches the shell is either a literal pyinfra-owned string or `QuoteString`-wrapped.**

Related second-pass audit (not included in this PR) also found injection paths in several facts (`facts/git.py`, `facts/iptables.py`, `facts/crontab.py`, `facts/selinux.py`, `facts/docker.py`, `facts/npm.py`, `facts/postgres.py`, `facts/mysql.py`, `facts/snap.py`, `facts/flatpak.py`, `facts/openrc.py`, `facts/systemd.py`, `facts/runit.py`, `facts/gpg.py`, `facts/server.py`) where a fact's `command()` method returns a plain string with raw-formatted parameters. Those are best fixed together as a follow-up by either wrapping each parameter with `shlex.quote` at the call site or converting facts to return `StringCommand` , happy to do that in a separate PR @Fizzadar .

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)