### PR TITLE
server.reboot: survive dead SSH session during askpass cleanup

### DIFF
--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -233,14 +233,24 @@ def write_stdin(stdin, buffer):
 
 
 def remove_any_sudo_askpass_file(host) -> None:
+    # Best-effort cleanup: this is called from host.disconnect(), and the
+    # connection may already be broken (e.g. after `server.reboot`). Swallow
+    # any errors from the remote ``rm`` and still clear the local state so a
+    # reconnect will regenerate a fresh askpass file.
     sudo_askpass_path = host.connector_data.get("sudo_askpass_path")
     if sudo_askpass_path:
-        host.run_shell_command("rm -f {0}".format(sudo_askpass_path))
+        try:
+            host.run_shell_command("rm -f {0}".format(sudo_askpass_path))
+        except Exception as e:
+            logger.debug("Could not remove sudo askpass file %s: %s", sudo_askpass_path, e)
         host.connector_data["sudo_askpass_path"] = None
 
     su_askpass_path = host.connector_data.get("su_askpass_path")
     if su_askpass_path:
-        host.run_shell_command("rm -f {0}".format(su_askpass_path))
+        try:
+            host.run_shell_command("rm -f {0}".format(su_askpass_path))
+        except Exception as e:
+            logger.debug("Could not remove su askpass file %s: %s", su_askpass_path, e)
         host.connector_data["su_askpass_path"] = None
 
 

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -91,6 +91,13 @@ def reboot(delay=10, interval=1, reboot_timeout=300):
         sleep(delay)
         max_retries = round(reboot_timeout / interval)
 
+        # The remote askpass files (if any) live on a host that has just
+        # rebooted — the SSH session is dead and there is nothing to clean up.
+        # Clear the stored paths before disconnecting so the disconnect path
+        # does not attempt an ``rm -f`` over the broken connection.
+        host.connector_data["sudo_askpass_path"] = None
+        host.connector_data["su_askpass_path"] = None
+
         host.disconnect()  # make sure we are properly disconnected
         retries = 0
 

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -1,9 +1,14 @@
 # encoding: utf-8
 
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from pyinfra.api import Config, State
-from pyinfra.connectors.util import make_unix_command, make_unix_command_for_host
+from pyinfra.connectors.util import (
+    make_unix_command,
+    make_unix_command_for_host,
+    remove_any_sudo_askpass_file,
+)
 
 from ..util import make_inventory
 
@@ -130,3 +135,59 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
         host = state.inventory.get_host("somehost")
         command = make_unix_command_for_host(state, host, "echo Šablony")
         assert command.get_raw_value() == "sh -c 'echo Šablony'"
+
+
+class TestRemoveAnySudoAskpassFile(TestCase):
+    def test_clears_state_and_runs_rm(self):
+        commands = []
+        host = MagicMock()
+        host.connector_data = {
+            "sudo_askpass_path": "/tmp/sudo-askpass",
+            "su_askpass_path": "/tmp/su-askpass",
+        }
+        host.run_shell_command = lambda cmd: commands.append(cmd)
+
+        remove_any_sudo_askpass_file(host)
+
+        assert commands == [
+            "rm -f /tmp/sudo-askpass",
+            "rm -f /tmp/su-askpass",
+        ]
+        assert host.connector_data["sudo_askpass_path"] is None
+        assert host.connector_data["su_askpass_path"] is None
+
+    def test_swallows_errors_and_clears_state(self):
+        """
+        Regression test for #1645: `host.disconnect()` → `remove_any_sudo_askpass_file`
+        is called after ``server.reboot`` when the SSH session is already dead.
+        The remote ``rm`` must fail gracefully and the stored path must still
+        be cleared so a reconnect will regenerate a fresh askpass file.
+        """
+        host = MagicMock()
+        host.connector_data = {
+            "sudo_askpass_path": "/tmp/sudo-askpass",
+            "su_askpass_path": "/tmp/su-askpass",
+        }
+
+        def failing_run(cmd):
+            raise Exception("SSH session not active")
+
+        host.run_shell_command = failing_run
+
+        # Must not raise — this is a best-effort cleanup.
+        remove_any_sudo_askpass_file(host)
+
+        assert host.connector_data["sudo_askpass_path"] is None
+        assert host.connector_data["su_askpass_path"] is None
+
+    def test_noop_when_no_state(self):
+        host = MagicMock()
+        host.connector_data = {
+            "sudo_askpass_path": None,
+            "su_askpass_path": None,
+        }
+        host.run_shell_command = MagicMock()
+
+        remove_any_sudo_askpass_file(host)
+
+        host.run_shell_command.assert_not_called()


### PR DESCRIPTION
Fixes #1645  When ``server.reboot`` is used with a sudo password, the sequence was:

  1. reboot() yields remove_any_askpass_file : clears sudo_askpass_path
  2. reboot() yields StringCommand("reboot") : runs under sudo, which re-creates the askpass file on the target and repopulates connector_data["sudo_askpass_path"]
  3. server reboots, SSH session dies
  4. wait_and_reconnect() calls host.disconnect(), which unconditionally runs remove_any_sudo_askpass_file over the dead session, crashing with SSHException('SSH session not active')

Fix both layers:

- remove_any_sudo_askpass_file is a best-effort cleanup; swallow any exception from the remote ``rm`` and still clear the local state so a subsequent reconnect regenerates a fresh askpass file.
- wait_and_reconnect clears sudo_askpass_path / su_askpass_path before disconnecting so the cleanup is a no-op in the common case (no warning log and no wasted round-trip).

Add regression tests covering all three remove_any_sudo_askpass_file code paths: happy path, error tolerance, and empty-state no-op.

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)