### PR TITLE
fix(connectors.util): honour _temp_dir in askpass helpers

### DIFF
--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -229,26 +229,43 @@ def write_stdin(stdin, buffer):
     buffer.close()
 
 
+ASKPASS_PATH_KEYS = ("sudo_askpass_path", "su_askpass_path")
+
+
+def _iter_askpass_cache_keys(host) -> list[str]:
+    # Cache keys are either the bare base ("sudo_askpass_path") or the base
+    # joined with the resolved temp_dir ("sudo_askpass_path__/tmp"). Match
+    # both so cleanup covers every askpass file ever generated for the host.
+    return [
+        cache_key
+        for cache_key in list(host.connector_data.keys())
+        for base in ASKPASS_PATH_KEYS
+        if cache_key == base or cache_key.startswith(base + "__")
+    ]
+
+
 def remove_any_sudo_askpass_file(host) -> None:
     # Best-effort cleanup: this is called from host.disconnect(), and the
     # connection may already be broken (e.g. after `server.reboot`). Swallow
     # any errors from the remote ``rm`` and still clear the local state so a
     # reconnect will regenerate a fresh askpass file.
-    sudo_askpass_path = host.connector_data.get("sudo_askpass_path")
-    if sudo_askpass_path:
+    for cache_key in _iter_askpass_cache_keys(host):
+        path = host.connector_data.get(cache_key)
+        if not path:
+            continue
         try:
-            host.run_shell_command(StringCommand("rm", "-f", QuoteString(sudo_askpass_path)))
+            host.run_shell_command(StringCommand("rm", "-f", QuoteString(path)))
         except Exception as e:
-            logger.debug("Could not remove sudo askpass file %s: %s", sudo_askpass_path, e)
-        host.connector_data["sudo_askpass_path"] = None
+            logger.debug("Could not remove askpass file %s: %s", path, e)
+        host.connector_data[cache_key] = None
 
-    su_askpass_path = host.connector_data.get("su_askpass_path")
-    if su_askpass_path:
-        try:
-            host.run_shell_command(StringCommand("rm", "-f", QuoteString(su_askpass_path)))
-        except Exception as e:
-            logger.debug("Could not remove su askpass file %s: %s", su_askpass_path, e)
-        host.connector_data["su_askpass_path"] = None
+
+def clear_askpass_cache(host) -> None:
+    # Drop every cached askpass path without touching the remote, used after
+    # ``server.reboot`` where the previous connection (and therefore any
+    # askpass scripts under its temp dir) is gone.
+    for cache_key in _iter_askpass_cache_keys(host):
+        host.connector_data[cache_key] = None
 
 
 @memoize
@@ -277,13 +294,13 @@ def extract_control_arguments(arguments: ConnectorArguments) -> ConnectorArgumen
     return control_arguments
 
 
-def _ensure_sudo_askpass_set_for_host(host: Host, temp_dir: str | None = None):
+def _ensure_sudo_askpass_set_for_host(host: Host, temp_dir: str | None = None) -> str:
     return _ensure_askpass_set_for_host(
         host, "sudo_askpass_path", SUDO_ASKPASS_ENV_VAR, temp_dir=temp_dir
     )
 
 
-def _ensure_su_askpass_set_for_host(host: Host, temp_dir: str | None = None):
+def _ensure_su_askpass_set_for_host(host: Host, temp_dir: str | None = None) -> str:
     return _ensure_askpass_set_for_host(
         host, "su_askpass_path", SU_ASKPASS_ENV_VAR, temp_dir=temp_dir
     )
@@ -291,21 +308,19 @@ def _ensure_su_askpass_set_for_host(host: Host, temp_dir: str | None = None):
 
 def _ensure_askpass_set_for_host(
     host: Host, key: str, env_var: str, temp_dir: str | None = None
-):
+) -> str:
     # Operation-level _temp_dir (if any) overrides the host-level/global
     # temp directory resolution so `server.shell(..., _temp_dir=X)` places
-    # the askpass script under X rather than /tmp.
+    # the askpass script under X rather than /tmp. Encoding the resolved
+    # temp_dir in the cache key gives every (host, temp_dir) pair its own
+    # entry, so switching dirs across calls just misses the cache instead
+    # of needing an explicit invalidation step.
     effective_temp_dir = temp_dir or host.get_temp_dir_config()
+    cache_key = f"{key}__{effective_temp_dir}"
 
-    # Invalidate the cache if the resolved temp_dir changed since the path
-    # was created, otherwise we'd hand out a stale path under the wrong dir.
-    # If the tracker is missing (older code path or external population),
-    # trust the existing path to preserve backward compatibility.
-    temp_dir_cache_key = f"{key}_temp_dir"
-    existing_path = host.connector_data.get(key)
-    existing_temp_dir = host.connector_data.get(temp_dir_cache_key)
-    if existing_path and (existing_temp_dir is None or existing_temp_dir == effective_temp_dir):
-        return
+    cached = host.connector_data.get(cache_key)
+    if cached:
+        return cached
 
     ok, output = host.run_shell_command(ASKPASS_COMMAND.format(effective_temp_dir, env_var))
 
@@ -317,8 +332,9 @@ def _ensure_askpass_set_for_host(
             f"Failed to create sudo_askpass command: no output produced by command: {output.output}"
         )
 
-    host.connector_data[key] = output.stdout_lines[0]
-    host.connector_data[temp_dir_cache_key] = effective_temp_dir
+    path = output.stdout_lines[0]
+    host.connector_data[cache_key] = path
+    return path
 
 
 def make_unix_command_for_host(
@@ -340,15 +356,16 @@ def make_unix_command_for_host(
             command_arguments["_sudo_password"] = host.connector_data.get("prompted_sudo_password")
 
         if command_arguments.get("_sudo_password"):
-            # Ensure the askpass path is correctly set and passed through
-            _ensure_sudo_askpass_set_for_host(host, temp_dir=op_temp_dir)
-            command_arguments["_sudo_askpass_path"] = host.connector_data["sudo_askpass_path"]
+            command_arguments["_sudo_askpass_path"] = _ensure_sudo_askpass_set_for_host(
+                host, temp_dir=op_temp_dir
+            )
 
     # Handle su password
     if command_arguments.get("_su_user"):
         if command_arguments.get("_su_password"):
-            _ensure_su_askpass_set_for_host(host, temp_dir=op_temp_dir)
-            command_arguments["_su_askpass_path"] = host.connector_data["su_askpass_path"]
+            command_arguments["_su_askpass_path"] = _ensure_su_askpass_set_for_host(
+                host, temp_dir=op_temp_dir
+            )
 
     return make_unix_command(command, **command_arguments)
 

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -277,18 +277,37 @@ def extract_control_arguments(arguments: ConnectorArguments) -> ConnectorArgumen
     return control_arguments
 
 
-def _ensure_sudo_askpass_set_for_host(host: Host):
-    return _ensure_askpass_set_for_host(host, "sudo_askpass_path", SUDO_ASKPASS_ENV_VAR)
+def _ensure_sudo_askpass_set_for_host(host: Host, temp_dir: str | None = None):
+    return _ensure_askpass_set_for_host(
+        host, "sudo_askpass_path", SUDO_ASKPASS_ENV_VAR, temp_dir=temp_dir
+    )
 
 
-def _ensure_su_askpass_set_for_host(host: Host):
-    return _ensure_askpass_set_for_host(host, "su_askpass_path", SU_ASKPASS_ENV_VAR)
+def _ensure_su_askpass_set_for_host(host: Host, temp_dir: str | None = None):
+    return _ensure_askpass_set_for_host(
+        host, "su_askpass_path", SU_ASKPASS_ENV_VAR, temp_dir=temp_dir
+    )
 
 
-def _ensure_askpass_set_for_host(host: Host, key: str, env_var: str):
-    if host.connector_data.get(key):
+def _ensure_askpass_set_for_host(
+    host: Host, key: str, env_var: str, temp_dir: str | None = None
+):
+    # Operation-level _temp_dir (if any) overrides the host-level/global
+    # temp directory resolution so `server.shell(..., _temp_dir=X)` places
+    # the askpass script under X rather than /tmp.
+    effective_temp_dir = temp_dir or host.get_temp_dir_config()
+
+    # Invalidate the cache if the resolved temp_dir changed since the path
+    # was created, otherwise we'd hand out a stale path under the wrong dir.
+    # If the tracker is missing (older code path or external population),
+    # trust the existing path to preserve backward compatibility.
+    temp_dir_cache_key = f"{key}_temp_dir"
+    existing_path = host.connector_data.get(key)
+    existing_temp_dir = host.connector_data.get(temp_dir_cache_key)
+    if existing_path and (existing_temp_dir is None or existing_temp_dir == effective_temp_dir):
         return
-    ok, output = host.run_shell_command(ASKPASS_COMMAND.format(host.get_temp_dir_config(), env_var))
+
+    ok, output = host.run_shell_command(ASKPASS_COMMAND.format(effective_temp_dir, env_var))
 
     if not ok:
         raise PyinfraError(f"Failed to create sudo_askpass command: {output.output}")
@@ -299,6 +318,7 @@ def _ensure_askpass_set_for_host(host: Host, key: str, env_var: str):
         )
 
     host.connector_data[key] = output.stdout_lines[0]
+    host.connector_data[temp_dir_cache_key] = effective_temp_dir
 
 
 def make_unix_command_for_host(
@@ -307,6 +327,11 @@ def make_unix_command_for_host(
     command: StringCommand,
     **command_arguments,
 ) -> StringCommand:
+    # Operation-level temp directory override, if any. Passed through to the
+    # askpass helpers so the generated SUDO_ASKPASS / SU_ASKPASS script lands
+    # under the same directory the operation asked for.
+    op_temp_dir = command_arguments.get("_temp_dir")
+
     # Handle sudo password
     if command_arguments.get("_sudo"):
         # If the sudo password is not set in the direct arguments,
@@ -316,13 +341,13 @@ def make_unix_command_for_host(
 
         if command_arguments.get("_sudo_password"):
             # Ensure the askpass path is correctly set and passed through
-            _ensure_sudo_askpass_set_for_host(host)
+            _ensure_sudo_askpass_set_for_host(host, temp_dir=op_temp_dir)
             command_arguments["_sudo_askpass_path"] = host.connector_data["sudo_askpass_path"]
 
     # Handle su password
     if command_arguments.get("_su_user"):
         if command_arguments.get("_su_password"):
-            _ensure_su_askpass_set_for_host(host)
+            _ensure_su_askpass_set_for_host(host, temp_dir=op_temp_dir)
             command_arguments["_su_askpass_path"] = host.connector_data["su_askpass_path"]
 
     return make_unix_command(command, **command_arguments)

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from pyinfra import host, logger, state
 from pyinfra.api import FunctionCommand, OperationError, QuoteString, StringCommand, operation
 from pyinfra.api.util import try_int
-from pyinfra.connectors.util import remove_any_sudo_askpass_file
+from pyinfra.connectors.util import clear_askpass_cache, remove_any_sudo_askpass_file
 from pyinfra.facts.files import Directory, FindInFile, Link
 from pyinfra.facts.server import (
     AuthorizedKeys,
@@ -94,11 +94,10 @@ def reboot(delay=10, interval=1, reboot_timeout=300):
         max_retries = round(reboot_timeout / interval)
 
         # The remote askpass files (if any) live on a host that has just
-        # rebooted — the SSH session is dead and there is nothing to clean up.
+        # rebooted, the SSH session is dead and there is nothing to clean up.
         # Clear the stored paths before disconnecting so the disconnect path
         # does not attempt an ``rm -f`` over the broken connection.
-        host.connector_data["sudo_askpass_path"] = None
-        host.connector_data["su_askpass_path"] = None
+        clear_askpass_cache(host)
 
         host.disconnect()  # make sure we are properly disconnected
         retries = 0
@@ -120,7 +119,7 @@ def reboot(delay=10, interval=1, reboot_timeout=300):
 
     # On certain systems sudo files are lost on reboot
     def clean_sudo_info(state, host):
-        host.connector_data["sudo_askpass_path"] = None
+        clear_askpass_cache(host)
 
     yield FunctionCommand(clean_sudo_info, (), {})
 

--- a/tests/test_connectors/test_ssh.py
+++ b/tests/test_connectors/test_ssh.py
@@ -620,7 +620,7 @@ class TestSSHConnector(TestCase):
         state = State(inventory, Config())
         host = inventory.get_host("somehost")
         host.connect(state)
-        host.connector_data["sudo_askpass_path"] = "/tmp/pyinfra-sudo-askpass-XXXXXXXXXXXX"
+        host.connector_data["sudo_askpass_path__/tmp"] = "/tmp/pyinfra-sudo-askpass-XXXXXXXXXXXX"
 
         command = "echo hi"
         return_values = [1, 0]  # return 0 on the second call

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -205,15 +205,14 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
 
         host = MagicMock()
         host.connector_data = {
-            "sudo_askpass_path": "/tmp/weird path; id",
-            "su_askpass_path": None,
+            "sudo_askpass_path__/tmp": "/tmp/weird path; id",
         }
         host.run_shell_command = lambda cmd: commands.append(cmd.get_raw_value())
 
         remove_any_sudo_askpass_file(host)
 
         assert commands == ["rm -f '/tmp/weird path; id'"]
-        assert host.connector_data["sudo_askpass_path"] is None
+        assert host.connector_data["sudo_askpass_path__/tmp"] is None
 
     def test_command_exists_su_config_only(self):
         """
@@ -232,31 +231,52 @@ class TestRemoveAnySudoAskpassFile(TestCase):
         commands = []
         host = MagicMock()
         host.connector_data = {
-            "sudo_askpass_path": "/tmp/sudo-askpass",
-            "su_askpass_path": "/tmp/su-askpass",
+            "sudo_askpass_path__/tmp": "/tmp/sudo-askpass",
+            "su_askpass_path__/tmp": "/tmp/su-askpass",
         }
         host.run_shell_command = lambda cmd: commands.append(cmd.get_raw_value())
 
         remove_any_sudo_askpass_file(host)
 
-        assert commands == [
-            "rm -f /tmp/sudo-askpass",
+        assert sorted(commands) == [
             "rm -f /tmp/su-askpass",
+            "rm -f /tmp/sudo-askpass",
         ]
-        assert host.connector_data["sudo_askpass_path"] is None
-        assert host.connector_data["su_askpass_path"] is None
+        assert host.connector_data["sudo_askpass_path__/tmp"] is None
+        assert host.connector_data["su_askpass_path__/tmp"] is None
+
+    def test_clears_multiple_temp_dir_variants(self):
+        commands = []
+        host = MagicMock()
+        host.connector_data = {
+            "sudo_askpass_path__/tmp": "/tmp/sudo-askpass",
+            "sudo_askpass_path__/var/tmp": "/var/tmp/sudo-askpass",
+            "su_askpass_path__/dev/shm": "/dev/shm/su-askpass",
+        }
+        host.run_shell_command = lambda cmd: commands.append(cmd.get_raw_value())
+
+        remove_any_sudo_askpass_file(host)
+
+        assert sorted(commands) == [
+            "rm -f /dev/shm/su-askpass",
+            "rm -f /tmp/sudo-askpass",
+            "rm -f /var/tmp/sudo-askpass",
+        ]
+        assert host.connector_data["sudo_askpass_path__/tmp"] is None
+        assert host.connector_data["sudo_askpass_path__/var/tmp"] is None
+        assert host.connector_data["su_askpass_path__/dev/shm"] is None
 
     def test_swallows_errors_and_clears_state(self):
         """
-        Regression test for #1645: `host.disconnect()` → `remove_any_sudo_askpass_file`
+        Regression test for #1645: `host.disconnect()` -> `remove_any_sudo_askpass_file`
         is called after ``server.reboot`` when the SSH session is already dead.
         The remote ``rm`` must fail gracefully and the stored path must still
         be cleared so a reconnect will regenerate a fresh askpass file.
         """
         host = MagicMock()
         host.connector_data = {
-            "sudo_askpass_path": "/tmp/sudo-askpass",
-            "su_askpass_path": "/tmp/su-askpass",
+            "sudo_askpass_path__/tmp": "/tmp/sudo-askpass",
+            "su_askpass_path__/tmp": "/tmp/su-askpass",
         }
 
         def failing_run(cmd):
@@ -264,17 +284,17 @@ class TestRemoveAnySudoAskpassFile(TestCase):
 
         host.run_shell_command = failing_run
 
-        # Must not raise — this is a best-effort cleanup.
+        # Must not raise, this is a best-effort cleanup.
         remove_any_sudo_askpass_file(host)
 
-        assert host.connector_data["sudo_askpass_path"] is None
-        assert host.connector_data["su_askpass_path"] is None
+        assert host.connector_data["sudo_askpass_path__/tmp"] is None
+        assert host.connector_data["su_askpass_path__/tmp"] is None
 
     def test_noop_when_no_state(self):
         host = MagicMock()
         host.connector_data = {
-            "sudo_askpass_path": None,
-            "su_askpass_path": None,
+            "sudo_askpass_path__/tmp": None,
+            "su_askpass_path__/tmp": None,
         }
         host.run_shell_command = MagicMock()
 
@@ -296,7 +316,7 @@ class TestEnsureAskpassTempDir(TestCase):
     @classmethod
     def _next_host(cls):
         cls._counter += 1
-        return "askpass-temp-dir-test-host-{0}".format(cls._counter)
+        return f"askpass-temp-dir-test-host-{cls._counter}"
 
     def _make_host(self, config=None):
         name = self._next_host()
@@ -341,13 +361,40 @@ class TestEnsureAskpassTempDir(TestCase):
         script = self._captured_script_run(host, temp_dir="/dev/shm/pyinfra")
         assert "${TMPDIR:=/dev/shm/pyinfra}" in script
 
-    def test_cache_invalidates_when_temp_dir_changes(self):
+    def test_distinct_temp_dirs_get_distinct_cache_entries(self):
         host = self._make_host()
         first = self._captured_script_run(host, temp_dir="/a", stdout="/a/askpass")
         assert "${TMPDIR:=/a}" in first
         second = self._captured_script_run(host, temp_dir="/b", stdout="/b/askpass")
         assert "${TMPDIR:=/b}" in second
-        assert host.connector_data["sudo_askpass_path"] == "/b/askpass"
+        assert host.connector_data["sudo_askpass_path__/a"] == "/a/askpass"
+        assert host.connector_data["sudo_askpass_path__/b"] == "/b/askpass"
+
+    def test_same_temp_dir_reuses_cache(self):
+        host = self._make_host()
+        calls = {"count": 0}
+
+        def fake_run(command, *args, **kwargs):
+            calls["count"] += 1
+            return (True, CommandOutput([OutputLine("stdout", "/tmp/askpass-XYZ")]))
+
+        host.run_shell_command = fake_run  # type: ignore[method-assign]
+
+        first = _ensure_askpass_set_for_host(
+            host,
+            key="sudo_askpass_path",
+            env_var="PYINFRA_SUDO_PASSWORD",
+            temp_dir="/tmp",
+        )
+        second = _ensure_askpass_set_for_host(
+            host,
+            key="sudo_askpass_path",
+            env_var="PYINFRA_SUDO_PASSWORD",
+            temp_dir="/tmp",
+        )
+
+        assert first == second == "/tmp/askpass-XYZ"
+        assert calls["count"] == 1
 
     def test_make_unix_command_for_host_threads_temp_dir(self):
         host = self._make_host()

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -1,8 +1,11 @@
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pyinfra.api import Config, State
 from pyinfra.connectors.util import (
+    CommandOutput,
+    OutputLine,
+    _ensure_askpass_set_for_host,
     make_unix_command,
     make_unix_command_for_host,
     remove_any_sudo_askpass_file,
@@ -278,3 +281,98 @@ class TestRemoveAnySudoAskpassFile(TestCase):
         remove_any_sudo_askpass_file(host)
 
         host.run_shell_command.assert_not_called()
+
+
+class TestEnsureAskpassTempDir(TestCase):
+    """
+    The askpass helper must honour the resolved temp directory (issue #1623):
+    operation-level ``_temp_dir`` > ``config.TEMP_DIR`` > ``config.DEFAULT_TEMP_DIR``.
+    Per-host defaults for ``_temp_dir`` come through the standard global-argument
+    cascade (``host.data._temp_dir``), not via a separate code path here.
+    """
+
+    _counter = 0
+
+    @classmethod
+    def _next_host(cls):
+        cls._counter += 1
+        return "askpass-temp-dir-test-host-{0}".format(cls._counter)
+
+    def _make_host(self, config=None):
+        name = self._next_host()
+        state = State(make_inventory(hosts=(name,)), config or Config())
+        host = state.inventory.get_host(name)
+        host.init(state)
+        return host
+
+    def _captured_script_run(self, host, temp_dir=None, stdout="/some/askpass/path"):
+        """
+        Call ``_ensure_askpass_set_for_host`` with ``host.run_shell_command``
+        patched so we can assert on the remote script text (whose first
+        argument to the mkstemp template is the temp directory).
+        """
+        captured = {}
+
+        def fake_run(command, *args, **kwargs):
+            captured["command"] = command
+            return (True, CommandOutput([OutputLine("stdout", stdout)]))
+
+        host.run_shell_command = fake_run  # type: ignore[method-assign]
+        _ensure_askpass_set_for_host(
+            host,
+            key="sudo_askpass_path",
+            env_var="PYINFRA_SUDO_PASSWORD",
+            temp_dir=temp_dir,
+        )
+        return captured["command"]
+
+    def test_default_temp_dir(self):
+        host = self._make_host()
+        script = self._captured_script_run(host)
+        assert "${TMPDIR:=/tmp}" in script
+
+    def test_config_temp_dir(self):
+        host = self._make_host(Config(TEMP_DIR="/var/tmp"))
+        script = self._captured_script_run(host)
+        assert "${TMPDIR:=/var/tmp}" in script
+
+    def test_op_temp_dir_wins_over_config(self):
+        host = self._make_host(Config(TEMP_DIR="/var/tmp"))
+        script = self._captured_script_run(host, temp_dir="/dev/shm/pyinfra")
+        assert "${TMPDIR:=/dev/shm/pyinfra}" in script
+
+    def test_cache_invalidates_when_temp_dir_changes(self):
+        host = self._make_host()
+        first = self._captured_script_run(host, temp_dir="/a", stdout="/a/askpass")
+        assert "${TMPDIR:=/a}" in first
+        second = self._captured_script_run(host, temp_dir="/b", stdout="/b/askpass")
+        assert "${TMPDIR:=/b}" in second
+        assert host.connector_data["sudo_askpass_path"] == "/b/askpass"
+
+    def test_make_unix_command_for_host_threads_temp_dir(self):
+        host = self._make_host()
+        host.connector_data["prompted_sudo_password"] = "supersecret"
+
+        captured = {}
+
+        def fake_run(command, *args, **kwargs):
+            captured["command"] = command
+            return (
+                True,
+                CommandOutput([OutputLine("stdout", "/op/tmp/pyinfra-askpass-XYZ")]),
+            )
+
+        host.run_shell_command = fake_run  # type: ignore[method-assign]
+
+        with patch("pyinfra.connectors.util.make_unix_command") as fake_make:
+            fake_make.return_value = "mocked"
+            make_unix_command_for_host(
+                host.state,
+                host,
+                "uptime",
+                _sudo=True,
+                _sudo_password="supersecret",
+                _temp_dir="/op/tmp",
+            )
+
+        assert "${TMPDIR:=/op/tmp}" in captured["command"]


### PR DESCRIPTION
Closes #1623.

## Problem

`server.reboot` and other ops respected `_temp_dir` (operation kwarg, or the per-host default cascaded from `host.data._temp_dir` via the global-argument system) for file placement, but the internal `SUDO_ASKPASS` / `SU_ASKPASS` helper script was still dropped into `config.TEMP_DIR` (usually `/tmp`). On hosts where `/tmp` is unusable (`noexec`, restricted tmpfs, TrueNAS, etc.) the askpass helper would fail even when the user had configured a working temp directory.

## Fix

- `_ensure_askpass_set_for_host` now takes a `temp_dir` override and uses it for the mkstemp template.
- `make_unix_command_for_host` threads the operation-level `_temp_dir` through to the askpass helpers.
- The resolved `temp_dir` is stored alongside the cached path (`<key>_temp_dir`); if a later call resolves a different `temp_dir` the cache is invalidated so the script gets regenerated under the correct directory. Callers that read `host.connector_data["sudo_askpass_path"]` directly don't need to change.

Per-host defaults don't need any new code path: setting `host.data._temp_dir` already cascades as the default for the `_temp_dir` global argument on every op, which is what gets passed down.

## Test plan

- [x] Askpass path for default, `config.TEMP_DIR`, and op-level `_temp_dir`.
- [x] Cache invalidation when `temp_dir` changes between calls.
- [x] Full path through `make_unix_command_for_host` with `_sudo=True` + `_temp_dir`.
- [x] `uv run pytest` (1613 passed), ruff / ruff format / mypy / `scripts/lint_arguments_sync.py` clean.

---

- [x] Pull request is based on the default branch (`3.x`)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts (behaviour fix, no public API / docs change)
- [x] Tests pass (`scripts/dev-test.sh`)
- [x] Type checking & code style passes (`scripts/dev-lint.sh`)