### PR TITLE
ci: upgrade default Python to 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - uses: astral-sh/ruff-action@v3
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv sync --group test --no-default-groups
@@ -57,9 +57,11 @@ jobs:
     strategy:
       matrix:
         os: [macos-26, macos-15, macos-14, windows-2025, windows-2022, ubuntu-24.04, ubuntu-22.04]
-        # Test every OS vs. Python 3.13, and only one for 3.1[012]
-        python-version: ["3.13"]
+        # Test every OS vs. Python 3.14, and only one for 3.1[012]
+        python-version: ["3.14"]
         include:
+          - os: ubuntu-24.04
+            python-version: "3.13"
           - os: ubuntu-24.04
             python-version: "3.12"
           - os: ubuntu-24.04
@@ -77,7 +79,7 @@ jobs:
       - run: uv sync --group test --no-default-groups --python=${{ matrix.python-version }}
       - run: uv run pytest --cov --disable-warnings
       - name: Upload coverage report to codecov
-        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.13' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.14' }}
         uses: codecov/codecov-action@v5
 
   # End-to-end tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: System :: Systems Administration",
     "Topic :: System :: Installation/Setup",
     "Topic :: Utilities",
@@ -134,7 +135,6 @@ markers = [
 ]
 
 [tool.coverage.run]
-concurrency = ["gevent"]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
Update lint, type-check and unit-test matrix to use Python 3.14 as the default version. Add 3.13 as an explicit include entry so it remains tested on ubuntu-24.04, alongside the already-present 3.12, 3.11 and 3.10 matrix entries. Flip the codecov upload condition to the new default. Leave end-to-end-test and docs-build on 3.13 for now, matches the narrow scope of the original change.

Also add the Python 3.14 trove classifier to pyproject.toml and drop ``concurrency = ["gevent"]`` from ``[tool.coverage.run]``; gevent's coverage concurrency integration is incompatible with 3.14 and the pytest-cov run does not need it.

This is PR #1599 re-applied on 3.x without the uv.lock bump.


- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
