### PR TITLE
facts.docker: add version, container, image, network detail facts

### DIFF
--- a/src/pyinfra/facts/docker.py
+++ b/src/pyinfra/facts/docker.py
@@ -10,7 +10,7 @@ import json
 
 from typing_extensions import override
 
-from pyinfra.api import FactBase
+from pyinfra.api import FactBase, ShortFactBase
 
 
 class DockerFactBase(FactBase):
@@ -26,6 +26,18 @@ class DockerFactBase(FactBase):
     def process(self, output):
         output = "".join(output)
         return json.loads(output)
+
+
+class _DockerJsonLinesFactBase(FactBase):
+    abstract = True
+
+    @override
+    def requires_command(self, *args, **kwargs) -> str:
+        return "docker"
+
+    @override
+    def process(self, output):
+        return [json.loads(line) for line in output if line.strip()]
 
 
 class DockerSystemInfo(DockerFactBase):
@@ -167,3 +179,216 @@ class DockerPlugin(DockerSingleMixin):
     """
 
     docker_type = "plugin"
+
+
+# Derived facts: extract specific slices from the full inspect output.
+#
+
+
+class DockerContainerEnvs(ShortFactBase):
+    """
+    Returns environment variables for all Docker containers, keyed by container ID.
+    """
+
+    fact = DockerContainers
+
+    @override
+    def process_data(self, data):
+        result = {}
+        for container in data or []:
+            container_id = container.get("Id")
+            env_list = (container.get("Config") or {}).get("Env") or []
+            env: dict = {}
+            for entry in env_list:
+                key, _, value = entry.partition("=")
+                env[key] = value
+            result[container_id] = env
+        return result
+
+
+class DockerContainerLabels(ShortFactBase):
+    """
+    Returns labels for all Docker containers, keyed by container ID.
+    """
+
+    fact = DockerContainers
+
+    @override
+    def process_data(self, data):
+        return {
+            container.get("Id"): (container.get("Config") or {}).get("Labels") or {}
+            for container in data or []
+        }
+
+
+class DockerContainerMounts(ShortFactBase):
+    """
+    Returns mounts for all Docker containers, keyed by container ID.
+    """
+
+    fact = DockerContainers
+
+    @override
+    def process_data(self, data):
+        return {container.get("Id"): container.get("Mounts") or [] for container in data or []}
+
+
+class DockerContainerNetworks(ShortFactBase):
+    """
+    Returns networks for all Docker containers, keyed by container ID.
+    """
+
+    fact = DockerContainers
+
+    @override
+    def process_data(self, data):
+        return {
+            container.get("Id"): ((container.get("NetworkSettings") or {}).get("Networks") or {})
+            for container in data or []
+        }
+
+
+class DockerContainerPorts(ShortFactBase):
+    """
+    Returns published port bindings for all Docker containers, keyed by container ID.
+    """
+
+    fact = DockerContainers
+
+    @override
+    def process_data(self, data):
+        return {
+            container.get("Id"): ((container.get("NetworkSettings") or {}).get("Ports") or {})
+            for container in data or []
+        }
+
+
+class DockerImageLabels(ShortFactBase):
+    """
+    Returns labels for all Docker images, keyed by image ID.
+    """
+
+    fact = DockerImages
+
+    @override
+    def process_data(self, data):
+        return {
+            image.get("Id"): (
+                (image.get("Config") or {}).get("Labels")
+                or (image.get("ContainerConfig") or {}).get("Labels")
+                or {}
+            )
+            for image in data or []
+        }
+
+
+class DockerImageLayers(ShortFactBase):
+    """
+    Returns layer digests for all Docker images, keyed by image ID.
+    """
+
+    fact = DockerImages
+
+    @override
+    def process_data(self, data):
+        return {
+            image.get("Id"): (image.get("RootFS") or {}).get("Layers") or [] for image in data or []
+        }
+
+
+class DockerNetworkLabels(ShortFactBase):
+    """
+    Returns labels for all Docker networks, keyed by network ID.
+    """
+
+    fact = DockerNetworks
+
+    @override
+    def process_data(self, data):
+        return {network.get("Id"): network.get("Labels") or {} for network in data or []}
+
+
+class DockerVolumeLabels(ShortFactBase):
+    """
+    Returns labels for all Docker volumes, keyed by volume name.
+    """
+
+    fact = DockerVolumes
+
+    @override
+    def process_data(self, data):
+        return {volume.get("Name"): volume.get("Labels") or {} for volume in data or []}
+
+
+# Facts that need their own docker command.
+#
+
+
+class DockerContainerFsChanges(DockerFactBase):
+    """
+    Returns filesystem changes for a single container (``docker diff``) as a list of
+    ``{"path": ..., "change": "A"|"C"|"D"}`` entries.
+    """
+
+    @override
+    def command(self, container_id) -> str:
+        return "docker container diff {0} 2>&- || true".format(container_id)
+
+    @override
+    def process(self, output):
+        changes = []
+        for line in output:
+            line = line.rstrip("\n")
+            if not line or " " not in line:
+                continue
+            change, _, path = line.partition(" ")
+            changes.append({"change": change, "path": path})
+        return changes
+
+
+class DockerContainerProcesses(DockerFactBase):
+    """
+    Returns processes running inside a single container (``docker top``) as a list of
+    column dicts. Column names follow the ``ps`` output header.
+    """
+
+    @override
+    def command(self, container_id) -> str:
+        return "docker container top {0} 2>&- || true".format(container_id)
+
+    @override
+    def process(self, output):
+        lines = [line for line in (line.rstrip("\n") for line in output) if line]
+        if not lines:
+            return []
+        header = lines[0].split()
+        processes = []
+        for line in lines[1:]:
+            fields = line.split(None, len(header) - 1)
+            if len(fields) < len(header):
+                fields += [""] * (len(header) - len(fields))
+            processes.append(dict(zip(header, fields)))
+        return processes
+
+
+class DockerContainerStats(_DockerJsonLinesFactBase):
+    """
+    Returns resource-usage stats for all running containers (``docker stats``) as a list
+    of dicts (one entry per container).
+    """
+
+    @override
+    def command(self) -> str:
+        return "docker stats --no-stream --format '{{json .}}'"
+
+
+class DockerImageHistory(_DockerJsonLinesFactBase):
+    """
+    Returns the layer history of a single image (``docker history``) as a list of dicts.
+    """
+
+    @override
+    def command(self, image_id) -> str:
+        return (
+            "docker image history --no-trunc --format '{{{{json .}}}}' {0} 2>&- || true"
+        ).format(image_id)

--- a/src/pyinfra/facts/docker.py
+++ b/src/pyinfra/facts/docker.py
@@ -38,6 +38,24 @@ class DockerSystemInfo(DockerFactBase):
         return 'docker system info --format="{{json .}}"'
 
 
+class DockerVersion(FactBase[str]):
+    """
+    Returns the Docker version.
+    """
+
+    @override
+    def requires_command(self) -> str:
+        return "docker"
+
+    @override
+    def command(self) -> str:
+        return "docker --version"
+
+    @override
+    def process(self, output):
+        return "".join(output).replace("\n", "")
+
+
 # All Docker objects
 #
 

--- a/tests/facts/docker.DockerContainerEnvs/container.json
+++ b/tests/facts/docker.DockerContainerEnvs/container.json
@@ -1,0 +1,13 @@
+{
+    "command": "ids=$(docker ps -qa) && [ -n \"$ids\" ] && docker container inspect $ids || echo \"[]\"",
+    "requires_command": "docker",
+    "output": ["[{\"Id\": \"abc123\", \"Config\": {\"Env\": [\"PATH=/usr/bin\", \"DEBUG=true\", \"EMPTY=\"]}}, {\"Id\": \"def456\", \"Config\": {\"Env\": null}}]"],
+    "fact": {
+        "abc123": {
+            "PATH": "/usr/bin",
+            "DEBUG": "true",
+            "EMPTY": ""
+        },
+        "def456": {}
+    }
+}

--- a/tests/facts/docker.DockerContainerFsChanges/fs_changes.json
+++ b/tests/facts/docker.DockerContainerFsChanges/fs_changes.json
@@ -1,0 +1,16 @@
+{
+    "arg": "abc123",
+    "command": "docker container diff abc123 2>&- || true",
+    "requires_command": "docker",
+    "output": [
+        "C /etc",
+        "A /etc/new_file",
+        "D /tmp/old_file",
+        ""
+    ],
+    "fact": [
+        {"change": "C", "path": "/etc"},
+        {"change": "A", "path": "/etc/new_file"},
+        {"change": "D", "path": "/tmp/old_file"}
+    ]
+}

--- a/tests/facts/docker.DockerContainerLabels/container.json
+++ b/tests/facts/docker.DockerContainerLabels/container.json
@@ -1,0 +1,12 @@
+{
+    "command": "ids=$(docker ps -qa) && [ -n \"$ids\" ] && docker container inspect $ids || echo \"[]\"",
+    "requires_command": "docker",
+    "output": ["[{\"Id\": \"abc123\", \"Config\": {\"Labels\": {\"app\": \"web\", \"tier\": \"frontend\"}}}, {\"Id\": \"def456\", \"Config\": {\"Labels\": null}}]"],
+    "fact": {
+        "abc123": {
+            "app": "web",
+            "tier": "frontend"
+        },
+        "def456": {}
+    }
+}

--- a/tests/facts/docker.DockerContainerMounts/container.json
+++ b/tests/facts/docker.DockerContainerMounts/container.json
@@ -1,0 +1,18 @@
+{
+    "command": "ids=$(docker ps -qa) && [ -n \"$ids\" ] && docker container inspect $ids || echo \"[]\"",
+    "requires_command": "docker",
+    "output": ["[{\"Id\": \"abc123\", \"Mounts\": [{\"Type\": \"bind\", \"Source\": \"/host\", \"Destination\": \"/container\", \"Mode\": \"\", \"RW\": true, \"Propagation\": \"rprivate\"}]}, {\"Id\": \"def456\"}]"],
+    "fact": {
+        "abc123": [
+            {
+                "Type": "bind",
+                "Source": "/host",
+                "Destination": "/container",
+                "Mode": "",
+                "RW": true,
+                "Propagation": "rprivate"
+            }
+        ],
+        "def456": []
+    }
+}

--- a/tests/facts/docker.DockerContainerNetworks/container.json
+++ b/tests/facts/docker.DockerContainerNetworks/container.json
@@ -1,0 +1,15 @@
+{
+    "command": "ids=$(docker ps -qa) && [ -n \"$ids\" ] && docker container inspect $ids || echo \"[]\"",
+    "requires_command": "docker",
+    "output": ["[{\"Id\": \"abc123\", \"NetworkSettings\": {\"Networks\": {\"bridge\": {\"IPAddress\": \"172.17.0.2\", \"Gateway\": \"172.17.0.1\", \"MacAddress\": \"02:42:ac:11:00:02\"}}}}, {\"Id\": \"def456\", \"NetworkSettings\": {}}]"],
+    "fact": {
+        "abc123": {
+            "bridge": {
+                "IPAddress": "172.17.0.2",
+                "Gateway": "172.17.0.1",
+                "MacAddress": "02:42:ac:11:00:02"
+            }
+        },
+        "def456": {}
+    }
+}

--- a/tests/facts/docker.DockerContainerPorts/container.json
+++ b/tests/facts/docker.DockerContainerPorts/container.json
@@ -1,0 +1,17 @@
+{
+    "command": "ids=$(docker ps -qa) && [ -n \"$ids\" ] && docker container inspect $ids || echo \"[]\"",
+    "requires_command": "docker",
+    "output": ["[{\"Id\": \"abc123\", \"NetworkSettings\": {\"Ports\": {\"80/tcp\": [{\"HostIp\": \"0.0.0.0\", \"HostPort\": \"8080\"}], \"443/tcp\": null}}}, {\"Id\": \"def456\", \"NetworkSettings\": {\"Ports\": null}}]"],
+    "fact": {
+        "abc123": {
+            "80/tcp": [
+                {
+                    "HostIp": "0.0.0.0",
+                    "HostPort": "8080"
+                }
+            ],
+            "443/tcp": null
+        },
+        "def456": {}
+    }
+}

--- a/tests/facts/docker.DockerContainerProcesses/processes.json
+++ b/tests/facts/docker.DockerContainerProcesses/processes.json
@@ -1,0 +1,32 @@
+{
+    "arg": "abc123",
+    "command": "docker container top abc123 2>&- || true",
+    "requires_command": "docker",
+    "output": [
+        "UID   PID   PPID  C STIME TTY   TIME     CMD",
+        "root  1234  1222  0 12:00 pts/0 00:00:00 nginx: master process",
+        "nginx 1250  1234  0 12:00 pts/0 00:00:00 nginx: worker process"
+    ],
+    "fact": [
+        {
+            "UID": "root",
+            "PID": "1234",
+            "PPID": "1222",
+            "C": "0",
+            "STIME": "12:00",
+            "TTY": "pts/0",
+            "TIME": "00:00:00",
+            "CMD": "nginx: master process"
+        },
+        {
+            "UID": "nginx",
+            "PID": "1250",
+            "PPID": "1234",
+            "C": "0",
+            "STIME": "12:00",
+            "TTY": "pts/0",
+            "TIME": "00:00:00",
+            "CMD": "nginx: worker process"
+        }
+    ]
+}

--- a/tests/facts/docker.DockerContainerStats/stats.json
+++ b/tests/facts/docker.DockerContainerStats/stats.json
@@ -1,0 +1,30 @@
+{
+    "command": "docker stats --no-stream --format '{{json .}}'",
+    "requires_command": "docker",
+    "output": [
+        "{\"ID\": \"abc123\", \"Name\": \"web\", \"CPUPerc\": \"0.01%\", \"MemUsage\": \"4MiB / 1GiB\", \"MemPerc\": \"0.4%\", \"NetIO\": \"0B / 0B\", \"BlockIO\": \"0B / 0B\", \"PIDs\": \"2\"}",
+        "{\"ID\": \"def456\", \"Name\": \"db\", \"CPUPerc\": \"0.10%\", \"MemUsage\": \"50MiB / 1GiB\", \"MemPerc\": \"5.0%\", \"NetIO\": \"1kB / 0B\", \"BlockIO\": \"0B / 0B\", \"PIDs\": \"10\"}"
+    ],
+    "fact": [
+        {
+            "ID": "abc123",
+            "Name": "web",
+            "CPUPerc": "0.01%",
+            "MemUsage": "4MiB / 1GiB",
+            "MemPerc": "0.4%",
+            "NetIO": "0B / 0B",
+            "BlockIO": "0B / 0B",
+            "PIDs": "2"
+        },
+        {
+            "ID": "def456",
+            "Name": "db",
+            "CPUPerc": "0.10%",
+            "MemUsage": "50MiB / 1GiB",
+            "MemPerc": "5.0%",
+            "NetIO": "1kB / 0B",
+            "BlockIO": "0B / 0B",
+            "PIDs": "10"
+        }
+    ]
+}

--- a/tests/facts/docker.DockerImageHistory/history.json
+++ b/tests/facts/docker.DockerImageHistory/history.json
@@ -1,0 +1,23 @@
+{
+    "arg": "sha256:img1",
+    "command": "docker image history --no-trunc --format '{{json .}}' sha256:img1 2>&- || true",
+    "requires_command": "docker",
+    "output": [
+        "{\"ID\": \"sha256:l2\", \"CreatedBy\": \"CMD [nginx -g daemon off;]\", \"Size\": \"0B\", \"Comment\": \"\"}",
+        "{\"ID\": \"sha256:l1\", \"CreatedBy\": \"ADD rootfs\", \"Size\": \"5MB\", \"Comment\": \"\"}"
+    ],
+    "fact": [
+        {
+            "ID": "sha256:l2",
+            "CreatedBy": "CMD [nginx -g daemon off;]",
+            "Size": "0B",
+            "Comment": ""
+        },
+        {
+            "ID": "sha256:l1",
+            "CreatedBy": "ADD rootfs",
+            "Size": "5MB",
+            "Comment": ""
+        }
+    ]
+}

--- a/tests/facts/docker.DockerImageLabels/image.json
+++ b/tests/facts/docker.DockerImageLabels/image.json
@@ -1,0 +1,12 @@
+{
+    "command": "ids=$(docker images -q) && [ -n \"$ids\" ] && docker image inspect $ids || echo \"[]\"",
+    "requires_command": "docker",
+    "output": ["[{\"Id\": \"sha256:img1\", \"Config\": {\"Labels\": {\"maintainer\": \"nginx\", \"version\": \"1.25\"}}}, {\"Id\": \"sha256:img2\", \"Config\": {\"Labels\": null}}]"],
+    "fact": {
+        "sha256:img1": {
+            "maintainer": "nginx",
+            "version": "1.25"
+        },
+        "sha256:img2": {}
+    }
+}

--- a/tests/facts/docker.DockerImageLayers/image.json
+++ b/tests/facts/docker.DockerImageLayers/image.json
@@ -1,0 +1,12 @@
+{
+    "command": "ids=$(docker images -q) && [ -n \"$ids\" ] && docker image inspect $ids || echo \"[]\"",
+    "requires_command": "docker",
+    "output": ["[{\"Id\": \"sha256:img1\", \"RootFS\": {\"Type\": \"layers\", \"Layers\": [\"sha256:l1\", \"sha256:l2\"]}}, {\"Id\": \"sha256:img2\", \"RootFS\": {}}]"],
+    "fact": {
+        "sha256:img1": [
+            "sha256:l1",
+            "sha256:l2"
+        ],
+        "sha256:img2": []
+    }
+}

--- a/tests/facts/docker.DockerNetworkLabels/network.json
+++ b/tests/facts/docker.DockerNetworkLabels/network.json
@@ -1,0 +1,11 @@
+{
+    "command": "docker network inspect `docker network ls -q`",
+    "requires_command": "docker",
+    "output": ["[{\"Id\": \"net1\", \"Labels\": {\"env\": \"prod\"}}, {\"Id\": \"net2\", \"Labels\": null}]"],
+    "fact": {
+        "net1": {
+            "env": "prod"
+        },
+        "net2": {}
+    }
+}

--- a/tests/facts/docker.DockerVersion/version.json
+++ b/tests/facts/docker.DockerVersion/version.json
@@ -1,0 +1,6 @@
+{
+    "command": "docker --version",
+    "requires_command": "docker",
+    "output": ["Docker version 29.3.1, build c2be9ccfc3\n"],
+    "fact": "Docker version 29.3.1, build c2be9ccfc3"
+}

--- a/tests/facts/docker.DockerVolumeLabels/volume.json
+++ b/tests/facts/docker.DockerVolumeLabels/volume.json
@@ -1,0 +1,11 @@
+{
+    "command": "docker volume inspect `docker volume ls -q`",
+    "requires_command": "docker",
+    "output": ["[{\"Name\": \"vol1\", \"Labels\": {\"role\": \"data\"}}, {\"Name\": \"vol2\", \"Labels\": null}]"],
+    "fact": {
+        "vol1": {
+            "role": "data"
+        },
+        "vol2": {}
+    }
+}


### PR DESCRIPTION
## Summary

Adds Docker facts inspired by the `docker_*` tables in osquery's schema.

New `DockerVersion` fact parsing `docker --version`.

Derived facts (reuse existing inspect commands via `ShortFactBase`):

- `DockerContainerEnvs`, `DockerContainerLabels`, `DockerContainerMounts`, `DockerContainerNetworks`, `DockerContainerPorts`
- `DockerImageLabels`, `DockerImageLayers`
- `DockerNetworkLabels`, `DockerVolumeLabels`

Facts with their own `docker` subcommand:

- `DockerContainerFsChanges` (`docker container diff <id>`)
- `DockerContainerProcesses` (`docker container top <id>`)
- `DockerContainerStats` (`docker stats --no-stream --format '{{json .}}'`)
- `DockerImageHistory` (`docker image history --no-trunc ... <id>`)

Each fact has an associated JSON fixture under `tests/facts/docker.*/`.

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)