### PR TITLE
facts.server: add AuthorizedKeys, make user_authorized_keys idempotent

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -810,6 +810,39 @@ class Users(FactBase):
         return users
 
 
+class AuthorizedKeys(FactBase[List[str]]):
+    """
+    Returns the SSH public keys listed in a user's ``~/.ssh/authorized_keys`` file as a
+    list of full key strings. Empty lines and lines starting with ``#`` are skipped; the
+    file's order is preserved.
+
+    .. code:: python
+
+        [
+            "ssh-ed25519 AAAAC3Nz... user@host",
+            "ssh-rsa AAAAB3Nz... other@host",
+        ]
+    """
+
+    default = list
+
+    @override
+    def command(self, user: str, path: Optional[str] = None) -> str:
+        # Tilde expansion resolves the user's home without another fact round-trip.
+        target = path if path is not None else "~{0}/.ssh/authorized_keys".format(user)
+        return "cat {0} 2>/dev/null || true".format(target)
+
+    @override
+    def process(self, output: Iterable[str]) -> List[str]:
+        keys: List[str] = []
+        for raw in output:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            keys.append(line)
+        return keys
+
+
 class LinuxDistributionDict(TypedDict):
     name: Optional[str]
     major: Optional[int]

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -17,6 +17,7 @@ from pyinfra.api.util import try_int
 from pyinfra.connectors.util import remove_any_sudo_askpass_file
 from pyinfra.facts.files import Directory, FindInFile, Link
 from pyinfra.facts.server import (
+    AuthorizedKeys,
     Groups,
     Home,
     Hostname,
@@ -794,25 +795,36 @@ def user_authorized_keys(
 
     authorized_key_file = f"{authorized_key_directory}/{authorized_key_filename}"
 
-    if delete_keys:
-        # Create a whole new authorized_keys file
-        keys_file = StringIO(
-            "{0}\n".format(
-                "\n".join(public_keys),
-            ),
-        )
+    # Pull the currently installed keys once; individual files.line calls otherwise
+    # issue one FindInFile fact per key, which dominates the cost for users with many
+    # keys.
+    current_keys = host.get_fact(AuthorizedKeys, user=user, path=authorized_key_file)
 
-        # And ensure it exists
-        yield from files.put._inner(
-            src=keys_file,
-            dest=authorized_key_file,
-            user=user,
-            group=group or user,
-            mode=600,
-        )
+    if delete_keys:
+        if current_keys == public_keys:
+            # Still ensure the file and its ownership/mode stay correct.
+            yield from files.file._inner(
+                path=authorized_key_file,
+                user=user,
+                group=group or user,
+                mode=600,
+            )
+        else:
+            keys_file = StringIO(
+                "{0}\n".format(
+                    "\n".join(public_keys),
+                ),
+            )
+            yield from files.put._inner(
+                src=keys_file,
+                dest=authorized_key_file,
+                user=user,
+                group=group or user,
+                mode=600,
+            )
 
     else:
-        # Ensure authorized_keys exists
+        # Ensure authorized_keys exists with the right ownership and mode.
         yield from files.file._inner(
             path=authorized_key_file,
             user=user,
@@ -820,8 +832,12 @@ def user_authorized_keys(
             mode=600,
         )
 
-        # And every public key is present
+        # Only append the keys that the fact says are missing; an empty fact result
+        # also covers the "file does not exist yet" case.
+        current_key_set = set(current_keys)
         for key in public_keys:
+            if key in current_key_set:
+                continue
             yield from files.line._inner(path=authorized_key_file, line=key, ensure_newline=True)
 
 

--- a/tests/facts/server.AuthorizedKeys/custom_path.json
+++ b/tests/facts/server.AuthorizedKeys/custom_path.json
@@ -1,0 +1,9 @@
+{
+    "arg": {
+        "user": "alice",
+        "path": "/etc/ssh/keys/alice"
+    },
+    "command": "cat /etc/ssh/keys/alice 2>/dev/null || true",
+    "output": [],
+    "fact": []
+}

--- a/tests/facts/server.AuthorizedKeys/default_path.json
+++ b/tests/facts/server.AuthorizedKeys/default_path.json
@@ -1,0 +1,17 @@
+{
+    "arg": {
+        "user": "alice"
+    },
+    "command": "cat ~alice/.ssh/authorized_keys 2>/dev/null || true",
+    "output": [
+        "# some comment",
+        "",
+        "ssh-ed25519 AAAAC3Nz...key1 user@host",
+        "   ",
+        "ssh-rsa AAAAB3Nz...key2 other@host"
+    ],
+    "fact": [
+        "ssh-ed25519 AAAAC3Nz...key1 user@host",
+        "ssh-rsa AAAAB3Nz...key2 other@host"
+    ]
+}

--- a/tests/operations/server.user/key_files.json
+++ b/tests/operations/server.user/key_files.json
@@ -43,6 +43,9 @@
             "interpolate_variables=False, path=homedir/.ssh/authorized_keys, pattern=^.*somekeydata.*$": ["somekeydata"],
             "interpolate_variables=False, path=homedir/.ssh/authorized_keys, pattern=^.*someotherkeydata.*$": []
         },
+        "server.AuthorizedKeys": {
+            "path=homedir/.ssh/authorized_keys, user=someuser": ["somekeydata"]
+        },
         "server.Groups": {}
     },
     "commands": [

--- a/tests/operations/server.user/keys.json
+++ b/tests/operations/server.user/keys.json
@@ -34,6 +34,9 @@
         "files.FindInFile": {
             "interpolate_variables=False, path=homedir/.ssh/authorized_keys, pattern=^.*abc.*$": []
         },
+        "server.AuthorizedKeys": {
+            "path=homedir/.ssh/authorized_keys, user=someuser": []
+        },
         "server.Groups": {}
     },
     "commands": [

--- a/tests/operations/server.user/keys_delete.json
+++ b/tests/operations/server.user/keys_delete.json
@@ -45,7 +45,10 @@
             "path=homedir/.ssh/authorized_keys": null
         },
         "files.FileContents": {
-            "path=homedir/.ssh/authorized_keys": null 
+            "path=homedir/.ssh/authorized_keys": null
+        },
+        "server.AuthorizedKeys": {
+            "path=homedir/.ssh/authorized_keys, user=someuser": []
         },
         "server.Groups": {}
     },

--- a/tests/operations/server.user/keys_nohome.json
+++ b/tests/operations/server.user/keys_nohome.json
@@ -33,6 +33,9 @@
         "files.FindInFile": {
             "interpolate_variables=False, path=/root/.ssh/authorized_keys, pattern=^.*abc.*$": []
         },
+        "server.AuthorizedKeys": {
+            "path=/root/.ssh/authorized_keys, user=root": []
+        },
         "server.Groups": {}
     },
     "commands": [

--- a/tests/operations/server.user/keys_single.json
+++ b/tests/operations/server.user/keys_single.json
@@ -34,6 +34,9 @@
         "files.FindInFile": {
             "interpolate_variables=False, path=homedir/.ssh/authorized_keys, pattern=^.*abc.*$": []
         },
+        "server.AuthorizedKeys": {
+            "path=homedir/.ssh/authorized_keys, user=someuser": []
+        },
         "server.Groups": {}
     },
     "commands": [

--- a/tests/operations/server.user_authorized_keys/all_keys_present.json
+++ b/tests/operations/server.user_authorized_keys/all_keys_present.json
@@ -1,0 +1,33 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "public_keys": ["ssh-ed25519 AAAAkey1 alice", "ssh-rsa AAAAkey2 bob"]
+    },
+    "facts": {
+        "server.Home": {
+            "user=someuser": "/home/someuser"
+        },
+        "files.Directory": {
+            "path=/home/someuser/.ssh": {
+                "user": "someuser",
+                "group": "someuser",
+                "mode": 700
+            }
+        },
+        "files.File": {
+            "path=/home/someuser/.ssh/authorized_keys": {
+                "user": "someuser",
+                "group": "someuser",
+                "mode": 600
+            }
+        },
+        "server.AuthorizedKeys": {
+            "path=/home/someuser/.ssh/authorized_keys, user=someuser": [
+                "ssh-ed25519 AAAAkey1 alice",
+                "ssh-rsa AAAAkey2 bob"
+            ]
+        }
+    },
+    "commands": [],
+    "noop_description": "file /home/someuser/.ssh/authorized_keys already exists"
+}

--- a/tests/operations/server.user_authorized_keys/append_missing_only.json
+++ b/tests/operations/server.user_authorized_keys/append_missing_only.json
@@ -1,0 +1,36 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "public_keys": ["ssh-ed25519 AAAAkey1 alice", "ssh-rsa AAAAkey2 bob"]
+    },
+    "facts": {
+        "server.Home": {
+            "user=someuser": "/home/someuser"
+        },
+        "files.Directory": {
+            "path=/home/someuser/.ssh": {
+                "user": "someuser",
+                "group": "someuser",
+                "mode": 700
+            }
+        },
+        "files.File": {
+            "path=/home/someuser/.ssh/authorized_keys": {
+                "user": "someuser",
+                "group": "someuser",
+                "mode": 600
+            }
+        },
+        "server.AuthorizedKeys": {
+            "path=/home/someuser/.ssh/authorized_keys, user=someuser": [
+                "ssh-ed25519 AAAAkey1 alice"
+            ]
+        },
+        "files.FindInFile": {
+            "interpolate_variables=False, path=/home/someuser/.ssh/authorized_keys, pattern=^.*ssh-rsa AAAAkey2 bob.*$": []
+        }
+    },
+    "commands": [
+        "( [ $(tail -c1 /home/someuser/.ssh/authorized_keys | wc -l) -eq 0 ] && echo ; echo 'ssh-rsa AAAAkey2 bob' ) >> /home/someuser/.ssh/authorized_keys"
+    ]
+}

--- a/tests/operations/server.user_authorized_keys/delete_match.json
+++ b/tests/operations/server.user_authorized_keys/delete_match.json
@@ -1,0 +1,34 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "public_keys": ["ssh-ed25519 AAAAkey1 alice", "ssh-rsa AAAAkey2 bob"],
+        "delete_keys": true
+    },
+    "facts": {
+        "server.Home": {
+            "user=someuser": "/home/someuser"
+        },
+        "files.Directory": {
+            "path=/home/someuser/.ssh": {
+                "user": "someuser",
+                "group": "someuser",
+                "mode": 700
+            }
+        },
+        "files.File": {
+            "path=/home/someuser/.ssh/authorized_keys": {
+                "user": "someuser",
+                "group": "someuser",
+                "mode": 600
+            }
+        },
+        "server.AuthorizedKeys": {
+            "path=/home/someuser/.ssh/authorized_keys, user=someuser": [
+                "ssh-ed25519 AAAAkey1 alice",
+                "ssh-rsa AAAAkey2 bob"
+            ]
+        }
+    },
+    "commands": [],
+    "noop_description": "file /home/someuser/.ssh/authorized_keys already exists"
+}

--- a/tests/operations/server.user_authorized_keys/delete_mismatch.json
+++ b/tests/operations/server.user_authorized_keys/delete_mismatch.json
@@ -1,0 +1,48 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "public_keys": ["ssh-ed25519 new alice"],
+        "delete_keys": true
+    },
+    "facts": {
+        "server.Home": {
+            "user=someuser": "/home/someuser"
+        },
+        "files.Directory": {
+            "path=/home/someuser/.ssh": {
+                "user": "someuser",
+                "group": "someuser",
+                "mode": 700
+            }
+        },
+        "files.File": {
+            "path=/home/someuser/.ssh/authorized_keys": {
+                "user": "someuser",
+                "group": "someuser",
+                "mode": 600
+            }
+        },
+        "server.AuthorizedKeys": {
+            "path=/home/someuser/.ssh/authorized_keys, user=someuser": [
+                "ssh-ed25519 old bob"
+            ]
+        },
+        "files.Sha1File": {
+            "path=/home/someuser/.ssh/authorized_keys": null
+        },
+        "files.Md5File": {
+            "path=/home/someuser/.ssh/authorized_keys": null
+        },
+        "files.Sha256File": {
+            "path=/home/someuser/.ssh/authorized_keys": null
+        },
+        "files.FileContents": {
+            "path=/home/someuser/.ssh/authorized_keys": null
+        }
+    },
+    "commands": [
+        ["upload", "ssh-ed25519 new alice\n", "/home/someuser/.ssh/authorized_keys"],
+        "chown someuser:someuser /home/someuser/.ssh/authorized_keys",
+        "chmod 600 /home/someuser/.ssh/authorized_keys"
+    ]
+}


### PR DESCRIPTION
Adds a `server.AuthorizedKeys` fact and refactors the `server.user_authorized_keys` operation to drive idempotency from that single fact lookup instead of one `FindInFile` round-trip per key.

### `server.AuthorizedKeys` (fact)

Reads a user's `~/.ssh/authorized_keys` (or a custom `path`) and returns the list of key strings with comments and blank lines stripped; tilde expansion resolves the home directory so there is no extra fact call for `Home`. Order is preserved.

```python
host.get_fact(AuthorizedKeys, user="alice")
# ["ssh-ed25519 AAAAC3Nz... user@host",
#  "ssh-rsa AAAAB3Nz... other@host"]

host.get_fact(AuthorizedKeys, user="alice", path="/etc/ssh/keys/alice")
```

Command: `cat ~<user>/.ssh/authorized_keys 2>/dev/null || true`, or `cat <path> ...` when `path` is given. Missing files resolve to an empty list. Verified live against Arch (`util-linux`) and FreeBSD.

### `server.user_authorized_keys` (refactor)

Previously: one `files.line` per requested key, which internally issued one `FindInFile` fact call per key. For a user with many keys, that dominated runtime.

Now: a single `AuthorizedKeys` call feeds the decision.

- `delete_keys=True`
  - **match**: file already lists exactly the requested keys in order, so the operation only ensures owner/mode via `files.file` (noop for content).
  - **mismatch**: rewrites through `files.put` exactly as before.
- Default mode (`delete_keys=False`)
  - `files.file` ensures the `authorized_keys` file with the right owner/mode.
  - `files.line` is only emitted for keys that the fact says are missing; keys already present are a noop.

### Tests

- Facts: `tests/facts/server.AuthorizedKeys/` covers the default-path tilde-expansion case and a custom-path empty-file case.
- Operation: `tests/operations/server.user_authorized_keys/` covers all-present noop, append-missing-only, `delete_keys=True` match noop, and `delete_keys=True` mismatch rewrite.
- Existing `server.user` key fixtures extended with the new `server.AuthorizedKeys` fact stub (behaviour unchanged).

Full suite passes (1551 tests), lint clean.

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)