### PR TITLE
operations.docker: add login/logout operations

### DIFF
--- a/src/pyinfra/facts/docker.py
+++ b/src/pyinfra/facts/docker.py
@@ -149,3 +149,27 @@ class DockerPlugin(DockerSingleMixin):
     """
 
     docker_type = "plugin"
+
+
+class DockerAuths(FactBase):
+    """
+    Returns the list of registry servers the current user is authenticated
+    against, read from ``${DOCKER_CONFIG:-$HOME/.docker}/config.json``.
+
+    Returns an empty list if no config file exists or no auths are stored.
+    """
+
+    @override
+    def command(self) -> str:
+        return (
+            'config="${DOCKER_CONFIG:-$HOME/.docker}/config.json"; '
+            '[ -r "$config" ] && cat "$config" || echo "{}"'
+        )
+
+    @override
+    def process(self, output):
+        try:
+            data = json.loads("".join(output))
+        except json.JSONDecodeError:
+            return []
+        return list(data.get("auths", {}).keys())

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -11,12 +11,15 @@ from shlex import quote as shlex_quote
 from pyinfra import host
 from pyinfra.api import MaskString, OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.docker import (
+    DockerAuths,
     DockerContainer,
     DockerImage,
     DockerNetwork,
     DockerPlugin,
     DockerVolume,
 )
+
+DOCKER_HUB_SERVER = "https://index.docker.io/v1/"
 
 from .util.docker import ContainerSpec, handle_docker, parse_image_reference
 
@@ -508,11 +511,12 @@ def plugin(
         )
 
 
-@operation(is_idempotent=False)
+@operation()
 def login(
     username: str,
     password: str,
     server: str = "",
+    force: bool = False,
 ):
     """
     Log in to a Docker registry.
@@ -520,14 +524,15 @@ def login(
     + username: username to authenticate with
     + password: password to authenticate with
     + server: registry server to log in to (defaults to Docker Hub)
+    + force: log in even if ``~/.docker/config.json`` already has an entry for the server
+
+    Idempotency is checked against the ``auths`` section of
+    ``${DOCKER_CONFIG:-$HOME/.docker}/config.json``: if the server is already
+    present, the operation is a no-op. Use ``force=True`` to re-run ``docker
+    login`` (e.g. after rotating credentials).
 
     The password is piped to ``docker login --password-stdin`` so it is not
     exposed on the command line, and is masked in pyinfra's command log.
-
-    This operation is not idempotent: ``docker login`` is run every time,
-    because the on-disk credential store can be delegated to an external
-    helper (``credsStore``), so pyinfra cannot reliably detect an existing
-    session.
 
     **Examples:**
 
@@ -555,6 +560,14 @@ def login(
     if not password:
         raise OperationError("docker.login requires a password")
 
+    target_server = server or DOCKER_HUB_SERVER
+
+    if not force:
+        existing_auths = host.get_fact(DockerAuths)
+        if target_server in existing_auths:
+            host.noop(f"Already logged in to Docker registry {target_server}")
+            return
+
     command_bits: list = [
         "printf '%s'",
         MaskString(shlex_quote(password)),
@@ -562,6 +575,45 @@ def login(
         QuoteString(username),
         "--password-stdin",
     ]
+    if server:
+        command_bits.append(QuoteString(server))
+
+    yield StringCommand(*command_bits)
+
+
+@operation()
+def logout(server: str = ""):
+    """
+    Log out of a Docker registry.
+
+    + server: registry server to log out of (defaults to Docker Hub)
+
+    No-ops when the server is not present in
+    ``${DOCKER_CONFIG:-$HOME/.docker}/config.json``.
+
+    **Examples:**
+
+    .. code:: python
+
+        from pyinfra.operations import docker
+
+        # Log out of a private registry
+        docker.logout(
+            name="Log out of private registry",
+            server="myregistry.io:5000",
+        )
+
+        # Log out of Docker Hub
+        docker.logout(name="Log out of Docker Hub")
+    """
+    target_server = server or DOCKER_HUB_SERVER
+
+    existing_auths = host.get_fact(DockerAuths)
+    if target_server not in existing_auths:
+        host.noop(f"Not logged in to Docker registry {target_server}")
+        return
+
+    command_bits: list = ["docker logout"]
     if server:
         command_bits.append(QuoteString(server))
 

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -515,7 +515,7 @@ def plugin(
 def login(
     username: str,
     password: str,
-    server: str = "",
+    server: str | None = None,
     force: bool = False,
 ):
     """
@@ -582,7 +582,7 @@ def login(
 
 
 @operation()
-def logout(server: str = ""):
+def logout(server: str | None = None):
     """
     Log out of a Docker registry.
 

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -6,8 +6,10 @@ as inventory directly.
 
 from __future__ import annotations
 
+from shlex import quote as shlex_quote
+
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import MaskString, OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.docker import (
     DockerContainer,
     DockerImage,
@@ -504,3 +506,63 @@ def plugin(
             command="remove",
             plugin=plugin_name,
         )
+
+
+@operation(is_idempotent=False)
+def login(
+    username: str,
+    password: str,
+    server: str = "",
+):
+    """
+    Log in to a Docker registry.
+
+    + username: username to authenticate with
+    + password: password to authenticate with
+    + server: registry server to log in to (defaults to Docker Hub)
+
+    The password is piped to ``docker login --password-stdin`` so it is not
+    exposed on the command line, and is masked in pyinfra's command log.
+
+    This operation is not idempotent: ``docker login`` is run every time,
+    because the on-disk credential store can be delegated to an external
+    helper (``credsStore``), so pyinfra cannot reliably detect an existing
+    session.
+
+    **Examples:**
+
+    .. code:: python
+
+        from pyinfra.operations import docker
+
+        # Log in to a private registry
+        docker.login(
+            name="Log in to private registry",
+            server="myregistry.io:5000",
+            username="ci",
+            password="s3cret",
+        )
+
+        # Log in to Docker Hub
+        docker.login(
+            name="Log in to Docker Hub",
+            username="ci",
+            password="s3cret",
+        )
+    """
+    if not username:
+        raise OperationError("docker.login requires a username")
+    if not password:
+        raise OperationError("docker.login requires a password")
+
+    command_bits: list = [
+        "printf '%s'",
+        MaskString(shlex_quote(password)),
+        "| docker login --username",
+        QuoteString(username),
+        "--password-stdin",
+    ]
+    if server:
+        command_bits.append(QuoteString(server))
+
+    yield StringCommand(*command_bits)

--- a/tests/facts/docker.DockerAuths/malformed_config.json
+++ b/tests/facts/docker.DockerAuths/malformed_config.json
@@ -1,0 +1,5 @@
+{
+    "command": "config=\"${DOCKER_CONFIG:-$HOME/.docker}/config.json\"; [ -r \"$config\" ] && cat \"$config\" || echo \"{}\"",
+    "output": ["not json at all"],
+    "fact": []
+}

--- a/tests/facts/docker.DockerAuths/no_config_file.json
+++ b/tests/facts/docker.DockerAuths/no_config_file.json
@@ -1,0 +1,5 @@
+{
+    "command": "config=\"${DOCKER_CONFIG:-$HOME/.docker}/config.json\"; [ -r \"$config\" ] && cat \"$config\" || echo \"{}\"",
+    "output": ["{}"],
+    "fact": []
+}

--- a/tests/facts/docker.DockerAuths/with_auths.json
+++ b/tests/facts/docker.DockerAuths/with_auths.json
@@ -1,0 +1,7 @@
+{
+    "command": "config=\"${DOCKER_CONFIG:-$HOME/.docker}/config.json\"; [ -r \"$config\" ] && cat \"$config\" || echo \"{}\"",
+    "output": [
+        "{\"auths\": {\"https://index.docker.io/v1/\": {\"auth\": \"xxx\"}, \"myregistry.io:5000\": {\"auth\": \"yyy\"}}}"
+    ],
+    "fact": ["https://index.docker.io/v1/", "myregistry.io:5000"]
+}

--- a/tests/operations/docker.login/login_force_reauth.json
+++ b/tests/operations/docker.login/login_force_reauth.json
@@ -1,0 +1,14 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "newpw",
+        "server": "myregistry.io:5000",
+        "force": true
+    },
+    "commands": [
+        {
+            "raw": "printf '%s' newpw | docker login --username ci --password-stdin myregistry.io:5000",
+            "masked": "printf '%s' *** | docker login --username ci --password-stdin myregistry.io:5000"
+        }
+    ]
+}

--- a/tests/operations/docker.login/login_noop_docker_hub_when_already_authenticated.json
+++ b/tests/operations/docker.login/login_noop_docker_hub_when_already_authenticated.json
@@ -1,0 +1,11 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s3cret"
+    },
+    "facts": {
+        "docker.DockerAuths": ["https://index.docker.io/v1/"]
+    },
+    "commands": [],
+    "noop_description": "Already logged in to Docker registry https://index.docker.io/v1/"
+}

--- a/tests/operations/docker.login/login_noop_when_already_authenticated.json
+++ b/tests/operations/docker.login/login_noop_when_already_authenticated.json
@@ -1,0 +1,12 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s3cret",
+        "server": "myregistry.io:5000"
+    },
+    "facts": {
+        "docker.DockerAuths": ["myregistry.io:5000"]
+    },
+    "commands": [],
+    "noop_description": "Already logged in to Docker registry myregistry.io:5000"
+}

--- a/tests/operations/docker.login/login_to_docker_hub.json
+++ b/tests/operations/docker.login/login_to_docker_hub.json
@@ -1,0 +1,12 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s3cret"
+    },
+    "commands": [
+        {
+            "raw": "printf '%s' s3cret | docker login --username ci --password-stdin",
+            "masked": "printf '%s' *** | docker login --username ci --password-stdin"
+        }
+    ]
+}

--- a/tests/operations/docker.login/login_to_docker_hub.json
+++ b/tests/operations/docker.login/login_to_docker_hub.json
@@ -3,6 +3,9 @@
         "username": "ci",
         "password": "s3cret"
     },
+    "facts": {
+        "docker.DockerAuths": []
+    },
     "commands": [
         {
             "raw": "printf '%s' s3cret | docker login --username ci --password-stdin",

--- a/tests/operations/docker.login/login_to_private_registry.json
+++ b/tests/operations/docker.login/login_to_private_registry.json
@@ -1,0 +1,13 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s3cret",
+        "server": "myregistry.io:5000"
+    },
+    "commands": [
+        {
+            "raw": "printf '%s' s3cret | docker login --username ci --password-stdin myregistry.io:5000",
+            "masked": "printf '%s' *** | docker login --username ci --password-stdin myregistry.io:5000"
+        }
+    ]
+}

--- a/tests/operations/docker.login/login_to_private_registry.json
+++ b/tests/operations/docker.login/login_to_private_registry.json
@@ -4,6 +4,9 @@
         "password": "s3cret",
         "server": "myregistry.io:5000"
     },
+    "facts": {
+        "docker.DockerAuths": []
+    },
     "commands": [
         {
             "raw": "printf '%s' s3cret | docker login --username ci --password-stdin myregistry.io:5000",

--- a/tests/operations/docker.login/login_with_special_chars_password.json
+++ b/tests/operations/docker.login/login_with_special_chars_password.json
@@ -1,0 +1,13 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s!%^&$",
+        "server": "myregistry.io:5000"
+    },
+    "commands": [
+        {
+            "raw": "printf '%s' 's!%^&$' | docker login --username ci --password-stdin myregistry.io:5000",
+            "masked": "printf '%s' *** | docker login --username ci --password-stdin myregistry.io:5000"
+        }
+    ]
+}

--- a/tests/operations/docker.login/login_with_special_chars_password.json
+++ b/tests/operations/docker.login/login_with_special_chars_password.json
@@ -4,6 +4,9 @@
         "password": "s!%^&$",
         "server": "myregistry.io:5000"
     },
+    "facts": {
+        "docker.DockerAuths": []
+    },
     "commands": [
         {
             "raw": "printf '%s' 's!%^&$' | docker login --username ci --password-stdin myregistry.io:5000",

--- a/tests/operations/docker.logout/logout_from_docker_hub.json
+++ b/tests/operations/docker.logout/logout_from_docker_hub.json
@@ -1,0 +1,8 @@
+{
+    "facts": {
+        "docker.DockerAuths": ["https://index.docker.io/v1/"]
+    },
+    "commands": [
+        "docker logout"
+    ]
+}

--- a/tests/operations/docker.logout/logout_from_private_registry.json
+++ b/tests/operations/docker.logout/logout_from_private_registry.json
@@ -1,0 +1,11 @@
+{
+    "kwargs": {
+        "server": "myregistry.io:5000"
+    },
+    "facts": {
+        "docker.DockerAuths": ["myregistry.io:5000"]
+    },
+    "commands": [
+        "docker logout myregistry.io:5000"
+    ]
+}

--- a/tests/operations/docker.logout/logout_noop_when_not_authenticated.json
+++ b/tests/operations/docker.logout/logout_noop_when_not_authenticated.json
@@ -1,0 +1,10 @@
+{
+    "kwargs": {
+        "server": "myregistry.io:5000"
+    },
+    "facts": {
+        "docker.DockerAuths": []
+    },
+    "commands": [],
+    "noop_description": "Not logged in to Docker registry myregistry.io:5000"
+}


### PR DESCRIPTION
Closes #1548.

Adds `docker.login` / `docker.logout` operations so private registry authentication can be expressed as a deploy step instead of a raw `server.shell('docker login ...')` call.

## Summary

### `docker.login(username, password, server=\"\", force=False)`

- Pipes the password to `docker login --password-stdin`, so it does not appear in the target's process list.
- Password is wrapped in `MaskString`, so pyinfra's command log shows `***`.
- Idempotent via the new `DockerAuths` fact (see below): no-ops when the server is already present in `auths`. `force=True` re-runs login (for credential rotation).
- `server` defaults to Docker Hub (`https://index.docker.io/v1/`).
- Raises `OperationError` if `username` or `password` is empty.

### `docker.logout(server=\"\")`

- Runs `docker logout [SERVER]`.
- No-ops when the server is not present in `auths`.
- `server` defaults to Docker Hub.

### `DockerAuths` fact

- Reads `${DOCKER_CONFIG:-$HOME/.docker}/config.json`.
- Returns the list of registry server keys under `auths` (empty list if the file is missing or malformed).
- Works with `credsStore` / `credHelpers` setups: the `auths` key is still present in that case, even when the credential itself lives in an external helper.

## Notes

- No new dependencies.
- No changes to existing operations.

## Tests

- 6 operation fixtures for `docker.login` covering: basic login, Docker Hub default server, special-character password (masking + shlex quoting), noop-when-already-authenticated for both private and Docker Hub servers, `force=True` bypass.
- 3 operation fixtures for `docker.logout` covering: private registry, Docker Hub, noop when not authenticated.
- 3 fact fixtures for `DockerAuths` covering: populated config, missing config file, malformed JSON.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)