### PR TITLE
operations.docker: add compose operation

### DIFF
--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -509,9 +509,9 @@ def plugin(
 @operation(is_idempotent=False)
 def compose(
     src: str | list[str],
-    project: str = "",
+    project: str | None = None,
     present: bool = True,
-    pull: str = "",
+    pull: str | None = None,
     build: bool = False,
     force_recreate: bool = False,
     remove_orphans: bool = True,
@@ -524,7 +524,7 @@ def compose(
     + src: path (or list of paths) to compose file(s) already present on the target
     + project: compose project name (maps to ``--project-name``; defaults to compose's own default)
     + present: ``True`` runs ``up -d``, ``False`` runs ``down``
-    + pull: policy for ``up -d --pull`` (``""``, ``"always"``, ``"missing"``, ``"never"``)
+    + pull: policy for ``up -d --pull`` (``None``, ``"always"``, ``"missing"``, ``"never"``)
     + build: pass ``--build`` on ``up``
     + force_recreate: pass ``--force-recreate`` on ``up``
     + remove_orphans: pass ``--remove-orphans`` on ``up`` / ``down``
@@ -570,9 +570,9 @@ def compose(
     if not src:
         raise OperationError("docker.compose requires at least one compose file via src")
 
-    if pull and pull not in ("always", "missing", "never"):
+    if pull is not None and pull not in ("always", "missing", "never"):
         raise OperationError(
-            'docker.compose pull must be one of "", "always", "missing", "never"',
+            'docker.compose pull must be one of None, "always", "missing", "never"',
         )
 
     srcs = [src] if isinstance(src, str) else list(src)

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -7,7 +7,7 @@ as inventory directly.
 from __future__ import annotations
 
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.docker import (
     DockerContainer,
     DockerImage,
@@ -504,3 +504,100 @@ def plugin(
             command="remove",
             plugin=plugin_name,
         )
+
+
+@operation(is_idempotent=False)
+def compose(
+    src: str | list[str],
+    project: str = "",
+    present: bool = True,
+    pull: str = "",
+    build: bool = False,
+    force_recreate: bool = False,
+    remove_orphans: bool = True,
+    remove_volumes: bool = False,
+    compose_command: str = "docker compose",
+):
+    """
+    Deploy a Docker Compose stack on the target.
+
+    + src: path (or list of paths) to compose file(s) already present on the target
+    + project: compose project name (maps to ``--project-name``; defaults to compose's own default)
+    + present: ``True`` runs ``up -d``, ``False`` runs ``down``
+    + pull: policy for ``up -d --pull`` (``""``, ``"always"``, ``"missing"``, ``"never"``)
+    + build: pass ``--build`` on ``up``
+    + force_recreate: pass ``--force-recreate`` on ``up``
+    + remove_orphans: pass ``--remove-orphans`` on ``up`` / ``down``
+    + remove_volumes: pass ``-v`` on ``down`` (only honored when ``present=False``)
+    + compose_command: compose binary to invoke; use ``"docker-compose"`` for v1
+
+    This operation is not idempotent from pyinfra's perspective: it always shells out
+    to compose. Docker itself skips services whose definition has not changed, so
+    re-runs are safe and cheap.
+
+    ``_env`` and ``_chdir`` are the standard pyinfra global operation kwargs and
+    work here without any special handling, which is useful for compose variable
+    interpolation.
+
+    **Examples:**
+
+    .. code:: python
+
+        from pyinfra.operations import docker, files
+
+        # Upload the compose file then bring the stack up
+        files.put(
+            name="Upload compose file",
+            src="files/docker-compose.yml",
+            dest="/srv/app/docker-compose.yml",
+        )
+        docker.compose(
+            name="Deploy app stack",
+            src="/srv/app/docker-compose.yml",
+            project="app",
+            _env={"DIR_STORAGE": "/srv/app/data"},
+        )
+
+        # Tear the stack down, including named volumes
+        docker.compose(
+            name="Remove app stack",
+            src="/srv/app/docker-compose.yml",
+            project="app",
+            present=False,
+            remove_volumes=True,
+        )
+    """
+    if not src:
+        raise OperationError("docker.compose requires at least one compose file via src")
+
+    if pull and pull not in ("always", "missing", "never"):
+        raise OperationError(
+            'docker.compose pull must be one of "", "always", "missing", "never"',
+        )
+
+    srcs = [src] if isinstance(src, str) else list(src)
+
+    command_bits: list = [compose_command]
+    if project:
+        command_bits.extend(["--project-name", QuoteString(project)])
+    for compose_file in srcs:
+        command_bits.extend(["-f", QuoteString(compose_file)])
+
+    if present:
+        command_bits.append("up -d")
+        if pull:
+            command_bits.extend(["--pull", pull])
+        if build:
+            command_bits.append("--build")
+        if force_recreate:
+            command_bits.append("--force-recreate")
+        if remove_orphans:
+            command_bits.append("--remove-orphans")
+    else:
+        command_bits.append("down")
+        if remove_volumes:
+            command_bits.append("-v")
+        if remove_orphans:
+            command_bits.append("--remove-orphans")
+
+    yield StringCommand(*command_bits)

--- a/tests/operations/docker.compose/compose_down.json
+++ b/tests/operations/docker.compose/compose_down.json
@@ -1,0 +1,9 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "present": false
+    },
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml down --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_down_with_volumes.json
+++ b/tests/operations/docker.compose/compose_down_with_volumes.json
@@ -1,0 +1,10 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "present": false,
+        "remove_volumes": true
+    },
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml down -v --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_basic.json
+++ b/tests/operations/docker.compose/compose_up_basic.json
@@ -1,0 +1,6 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml up -d --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_full_flags.json
+++ b/tests/operations/docker.compose/compose_up_full_flags.json
@@ -1,0 +1,11 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "build": true,
+        "force_recreate": true,
+        "remove_orphans": true
+    },
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml up -d --build --force-recreate --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_multi_file.json
+++ b/tests/operations/docker.compose/compose_up_multi_file.json
@@ -1,0 +1,6 @@
+{
+    "args": [["/srv/app/base.yml", "/srv/app/override.yml"]],
+    "commands": [
+        "docker compose -f /srv/app/base.yml -f /srv/app/override.yml up -d --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_with_project_and_pull.json
+++ b/tests/operations/docker.compose/compose_up_with_project_and_pull.json
@@ -1,0 +1,10 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "project": "app",
+        "pull": "always"
+    },
+    "commands": [
+        "docker compose --project-name app -f /srv/app/docker-compose.yml up -d --pull always --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_v1.json
+++ b/tests/operations/docker.compose/compose_v1.json
@@ -1,0 +1,9 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "compose_command": "docker-compose"
+    },
+    "commands": [
+        "docker-compose -f /srv/app/docker-compose.yml up -d --remove-orphans"
+    ]
+}


### PR DESCRIPTION
Closes #1276.

Adds `docker.compose` so a Docker Compose stack can be deployed as a single pyinfra operation, instead of falling back to `server.shell('docker-compose up -d', _chdir=..., _env=...)`.

## Summary

`docker.compose(src, project="", present=True, pull="", build=False, force_recreate=False, remove_orphans=True, remove_volumes=False, compose_command="docker compose")`

- `src` accepts a single path or a list of paths on the target (repeated `-f`).
- `project` maps to `--project-name`; omitted → compose default (directory name).
- `present=True` runs `up -d`, `present=False` runs `down`.
- `pull` / `build` / `force_recreate` / `remove_orphans` map 1:1 to the documented `docker compose up` flags.
- `remove_volumes` is only honored on `down` (adds `-v`).
- `compose_command` defaults to v2 (`docker compose`); set to `\"docker-compose\"` for the legacy v1 binary.
- `_env` and `_chdir` are the standard pyinfra global operation kwargs and work out of the box, which is what the issue author actually needed for compose variable interpolation.
- Validation: empty `src` → `OperationError`; `pull` must be `\"\"`, `\"always\"`, `\"missing\"`, or `\"never\"`.

### Why not `docker.stack`?

The original issue proposed `docker.stack(...)`. `docker stack` is the Docker Swarm command (deploys a compose file to a Swarm cluster), which is a different workflow. The single-host compose flow the issue actually describes is `docker compose` / `docker-compose`, so the operation is named `docker.compose`.

### Idempotency

Marked `is_idempotent=False`, following the `prune` precedent. `docker compose up -d` is internally idempotent on the Docker side (unchanged services are skipped, changed ones are recreated), so re-runs are safe. A follow-up PR can add a `DockerComposeProject` fact to do a config-hash comparison and make the operation pyinfra-idempotent, but that is intentionally out of scope here.

### Not in this PR

- `DockerComposeProject` fact for config-hash-based idempotency.
- Uploading the compose file from the controller (users combine `files.put` + `docker.compose`).
- Swarm (`docker stack deploy`).

## Tests

7 fixtures under `tests/operations/docker.compose/`:

- `compose_up_basic.json` — single src, default flags.
- `compose_up_multi_file.json` — list of srcs.
- `compose_up_with_project_and_pull.json` — `project`, `pull=\"always\"`.
- `compose_up_full_flags.json` — `build`, `force_recreate`, `remove_orphans`.
- `compose_down.json` — `present=False`.
- `compose_down_with_volumes.json` — `present=False`, `remove_volumes=True`.
- `compose_v1.json` — `compose_command=\"docker-compose\"` (v1 still works).


- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)