### PR TITLE
operations.docker: add compose, login/logout, and build operations

### DIFF
--- a/src/pyinfra/facts/docker.py
+++ b/src/pyinfra/facts/docker.py
@@ -149,3 +149,27 @@ class DockerPlugin(DockerSingleMixin):
     """
 
     docker_type = "plugin"
+
+
+class DockerAuths(FactBase):
+    """
+    Returns the list of registry servers the current user is authenticated
+    against, read from ``${DOCKER_CONFIG:-$HOME/.docker}/config.json``.
+
+    Returns an empty list if no config file exists or no auths are stored.
+    """
+
+    @override
+    def command(self) -> str:
+        return (
+            'config="${DOCKER_CONFIG:-$HOME/.docker}/config.json"; '
+            '[ -r "$config" ] && cat "$config" || echo "{}"'
+        )
+
+    @override
+    def process(self, output):
+        try:
+            data = json.loads("".join(output))
+        except json.JSONDecodeError:
+            return []
+        return list(data.get("auths", {}).keys())

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -509,9 +509,9 @@ def plugin(
 @operation(is_idempotent=False)
 def compose(
     src: str | list[str],
-    project: str = "",
+    project: str | None = None,
     present: bool = True,
-    pull: str = "",
+    pull: str | None = None,
     build: bool = False,
     force_recreate: bool = False,
     remove_orphans: bool = True,
@@ -524,7 +524,7 @@ def compose(
     + src: path (or list of paths) to compose file(s) already present on the target
     + project: compose project name (maps to ``--project-name``; defaults to compose's own default)
     + present: ``True`` runs ``up -d``, ``False`` runs ``down``
-    + pull: policy for ``up -d --pull`` (``""``, ``"always"``, ``"missing"``, ``"never"``)
+    + pull: policy for ``up -d --pull`` (``None``, ``"always"``, ``"missing"``, ``"never"``)
     + build: pass ``--build`` on ``up``
     + force_recreate: pass ``--force-recreate`` on ``up``
     + remove_orphans: pass ``--remove-orphans`` on ``up`` / ``down``
@@ -570,9 +570,9 @@ def compose(
     if not src:
         raise OperationError("docker.compose requires at least one compose file via src")
 
-    if pull and pull not in ("always", "missing", "never"):
+    if pull is not None and pull not in ("always", "missing", "never"):
         raise OperationError(
-            'docker.compose pull must be one of "", "always", "missing", "never"',
+            'docker.compose pull must be one of None, "always", "missing", "never"',
         )
 
     srcs = [src] if isinstance(src, str) else list(src)

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -235,6 +235,118 @@ def image(image: str, present: bool = True, force: bool = False):
 
 
 @operation()
+def build(
+    path: str,
+    tags: str | list[str] | None = None,
+    dockerfile: str | None = None,
+    build_args: dict[str, str] | None = None,
+    labels: dict[str, str] | None = None,
+    target: str | None = None,
+    platform: str | None = None,
+    network: str | None = None,
+    cache_from: str | list[str] | None = None,
+    secrets: list[str] | None = None,
+    pull: bool = False,
+    no_cache: bool = False,
+    force: bool = False,
+    builder: str = "docker build",
+):
+    """
+    Build a Docker image from a context directory or URL.
+
+    + path: build context (local directory or git/http URL)
+    + tags: tag or list of tags to apply to the built image (maps to ``-t``)
+    + dockerfile: path to the Dockerfile (maps to ``-f``; relative to the context)
+    + build_args: ``--build-arg`` values as a mapping
+    + labels: ``--label`` values as a mapping
+    + target: ``--target`` stage for multi-stage Dockerfiles
+    + platform: ``--platform`` (e.g. ``linux/amd64``)
+    + network: ``--network`` (e.g. ``host``)
+    + cache_from: image or list of images for ``--cache-from``
+    + secrets: list of raw ``--secret`` specs (e.g. ``id=mysecret,src=/run/secret``)
+    + pull: pass ``--pull`` to always fetch newer base images
+    + no_cache: pass ``--no-cache``
+    + force: rebuild even if all provided tags already exist locally
+    + builder: builder command to invoke; use ``"docker buildx build"`` for BuildKit
+
+    Idempotency is tag-based: when ``tags`` is provided and ``force`` is false, the
+    operation no-ops if every tag already exists on the target. Without ``tags``
+    the build always runs (Docker's own layer cache still applies).
+
+    **Examples:**
+
+    .. code:: python
+
+        from pyinfra.operations import docker
+
+        # Build and tag a local context
+        docker.build(
+            name="Build app image",
+            path="/srv/app",
+            tags=["app:1.0", "app:latest"],
+            build_args={"VERSION": "1.0"},
+            pull=True,
+        )
+
+        # BuildKit cross-platform build from a custom Dockerfile
+        docker.build(
+            name="Build multi-arch app",
+            path="/srv/app",
+            tags="registry.io/app:arm64",
+            dockerfile="docker/Dockerfile.prod",
+            platform="linux/arm64",
+            builder="docker buildx build",
+        )
+    """
+    if not path:
+        raise OperationError("docker.build requires a context path")
+
+    tag_list: list[str] = (
+        [tags] if isinstance(tags, str) else list(tags) if tags is not None else []
+    )
+    cache_from_list: list[str] = (
+        [cache_from]
+        if isinstance(cache_from, str)
+        else list(cache_from)
+        if cache_from is not None
+        else []
+    )
+
+    if tag_list and not force:
+        missing = [tag for tag in tag_list if not host.get_fact(DockerImage, object_id=tag)]
+        if not missing:
+            host.noop("Image(s) {0} already exist!".format(", ".join(tag_list)))
+            return
+
+    command_bits: list = [builder]
+    for tag in tag_list:
+        command_bits.extend(["-t", QuoteString(tag)])
+    if dockerfile:
+        command_bits.extend(["-f", QuoteString(dockerfile)])
+    for key, value in (build_args or {}).items():
+        command_bits.extend(["--build-arg", QuoteString("{0}={1}".format(key, value))])
+    for key, value in (labels or {}).items():
+        command_bits.extend(["--label", QuoteString("{0}={1}".format(key, value))])
+    if target:
+        command_bits.extend(["--target", QuoteString(target)])
+    if platform:
+        command_bits.extend(["--platform", QuoteString(platform)])
+    if network:
+        command_bits.extend(["--network", QuoteString(network)])
+    for cache in cache_from_list:
+        command_bits.extend(["--cache-from", QuoteString(cache)])
+    for secret in secrets or []:
+        command_bits.extend(["--secret", QuoteString(secret)])
+    if pull:
+        command_bits.append("--pull")
+    if no_cache:
+        command_bits.append("--no-cache")
+    command_bits.append(QuoteString(path))
+
+    yield StringCommand(*command_bits)
+
+
+@operation()
 def volume(volume: str, driver: str = "", labels: list[str] | None = None, present: bool = True):
     """
     Manage Docker volumes

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -11,12 +11,15 @@ from shlex import quote as shlex_quote
 from pyinfra import host
 from pyinfra.api import MaskString, OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.docker import (
+    DockerAuths,
     DockerContainer,
     DockerImage,
     DockerNetwork,
     DockerPlugin,
     DockerVolume,
 )
+
+DOCKER_HUB_SERVER = "https://index.docker.io/v1/"
 
 from .util.docker import ContainerSpec, handle_docker, parse_image_reference
 
@@ -508,11 +511,12 @@ def plugin(
         )
 
 
-@operation(is_idempotent=False)
+@operation()
 def login(
     username: str,
     password: str,
     server: str = "",
+    force: bool = False,
 ):
     """
     Log in to a Docker registry.
@@ -520,14 +524,15 @@ def login(
     + username: username to authenticate with
     + password: password to authenticate with
     + server: registry server to log in to (defaults to Docker Hub)
+    + force: log in even if ``~/.docker/config.json`` already has an entry for the server
+
+    Idempotency is checked against the ``auths`` section of
+    ``${DOCKER_CONFIG:-$HOME/.docker}/config.json``: if the server is already
+    present, the operation is a no-op. Use ``force=True`` to re-run ``docker
+    login`` (e.g. after rotating credentials).
 
     The password is piped to ``docker login --password-stdin`` so it is not
     exposed on the command line, and is masked in pyinfra's command log.
-
-    This operation is not idempotent: ``docker login`` is run every time,
-    because the on-disk credential store can be delegated to an external
-    helper (``credsStore``), so pyinfra cannot reliably detect an existing
-    session.
 
     **Examples:**
 
@@ -555,6 +560,14 @@ def login(
     if not password:
         raise OperationError("docker.login requires a password")
 
+    target_server = server or DOCKER_HUB_SERVER
+
+    if not force:
+        existing_auths = host.get_fact(DockerAuths)
+        if target_server in existing_auths:
+            host.noop(f"Already logged in to Docker registry {target_server}")
+            return
+
     command_bits: list = [
         "printf '%s'",
         MaskString(shlex_quote(password)),
@@ -562,6 +575,45 @@ def login(
         QuoteString(username),
         "--password-stdin",
     ]
+    if server:
+        command_bits.append(QuoteString(server))
+
+    yield StringCommand(*command_bits)
+
+
+@operation()
+def logout(server: str = ""):
+    """
+    Log out of a Docker registry.
+
+    + server: registry server to log out of (defaults to Docker Hub)
+
+    No-ops when the server is not present in
+    ``${DOCKER_CONFIG:-$HOME/.docker}/config.json``.
+
+    **Examples:**
+
+    .. code:: python
+
+        from pyinfra.operations import docker
+
+        # Log out of a private registry
+        docker.logout(
+            name="Log out of private registry",
+            server="myregistry.io:5000",
+        )
+
+        # Log out of Docker Hub
+        docker.logout(name="Log out of Docker Hub")
+    """
+    target_server = server or DOCKER_HUB_SERVER
+
+    existing_auths = host.get_fact(DockerAuths)
+    if target_server not in existing_auths:
+        host.noop(f"Not logged in to Docker registry {target_server}")
+        return
+
+    command_bits: list = ["docker logout"]
     if server:
         command_bits.append(QuoteString(server))
 

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -7,7 +7,7 @@ as inventory directly.
 from __future__ import annotations
 
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.docker import (
     DockerContainer,
     DockerImage,
@@ -504,3 +504,100 @@ def plugin(
             command="remove",
             plugin=plugin_name,
         )
+
+
+@operation(is_idempotent=False)
+def compose(
+    src: str | list[str],
+    project: str = "",
+    present: bool = True,
+    pull: str = "",
+    build: bool = False,
+    force_recreate: bool = False,
+    remove_orphans: bool = True,
+    remove_volumes: bool = False,
+    compose_command: str = "docker compose",
+):
+    """
+    Deploy a Docker Compose stack on the target.
+
+    + src: path (or list of paths) to compose file(s) already present on the target
+    + project: compose project name (maps to ``--project-name``; defaults to compose's own default)
+    + present: ``True`` runs ``up -d``, ``False`` runs ``down``
+    + pull: policy for ``up -d --pull`` (``""``, ``"always"``, ``"missing"``, ``"never"``)
+    + build: pass ``--build`` on ``up``
+    + force_recreate: pass ``--force-recreate`` on ``up``
+    + remove_orphans: pass ``--remove-orphans`` on ``up`` / ``down``
+    + remove_volumes: pass ``-v`` on ``down`` (only honored when ``present=False``)
+    + compose_command: compose binary to invoke; use ``"docker-compose"`` for v1
+
+    This operation is not idempotent from pyinfra's perspective: it always shells out
+    to compose. Docker itself skips services whose definition has not changed, so
+    re-runs are safe and cheap.
+
+    ``_env`` and ``_chdir`` are the standard pyinfra global operation kwargs and
+    work here without any special handling, which is useful for compose variable
+    interpolation.
+
+    **Examples:**
+
+    .. code:: python
+
+        from pyinfra.operations import docker, files
+
+        # Upload the compose file then bring the stack up
+        files.put(
+            name="Upload compose file",
+            src="files/docker-compose.yml",
+            dest="/srv/app/docker-compose.yml",
+        )
+        docker.compose(
+            name="Deploy app stack",
+            src="/srv/app/docker-compose.yml",
+            project="app",
+            _env={"DIR_STORAGE": "/srv/app/data"},
+        )
+
+        # Tear the stack down, including named volumes
+        docker.compose(
+            name="Remove app stack",
+            src="/srv/app/docker-compose.yml",
+            project="app",
+            present=False,
+            remove_volumes=True,
+        )
+    """
+    if not src:
+        raise OperationError("docker.compose requires at least one compose file via src")
+
+    if pull and pull not in ("always", "missing", "never"):
+        raise OperationError(
+            'docker.compose pull must be one of "", "always", "missing", "never"',
+        )
+
+    srcs = [src] if isinstance(src, str) else list(src)
+
+    command_bits: list = [compose_command]
+    if project:
+        command_bits.extend(["--project-name", QuoteString(project)])
+    for compose_file in srcs:
+        command_bits.extend(["-f", QuoteString(compose_file)])
+
+    if present:
+        command_bits.append("up -d")
+        if pull:
+            command_bits.extend(["--pull", pull])
+        if build:
+            command_bits.append("--build")
+        if force_recreate:
+            command_bits.append("--force-recreate")
+        if remove_orphans:
+            command_bits.append("--remove-orphans")
+    else:
+        command_bits.append("down")
+        if remove_volumes:
+            command_bits.append("-v")
+        if remove_orphans:
+            command_bits.append("--remove-orphans")
+
+    yield StringCommand(*command_bits)

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -515,7 +515,7 @@ def plugin(
 def login(
     username: str,
     password: str,
-    server: str = "",
+    server: str | None = None,
     force: bool = False,
 ):
     """
@@ -582,7 +582,7 @@ def login(
 
 
 @operation()
-def logout(server: str = ""):
+def logout(server: str | None = None):
     """
     Log out of a Docker registry.
 

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -6,8 +6,10 @@ as inventory directly.
 
 from __future__ import annotations
 
+from shlex import quote as shlex_quote
+
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import MaskString, OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.docker import (
     DockerContainer,
     DockerImage,
@@ -504,3 +506,63 @@ def plugin(
             command="remove",
             plugin=plugin_name,
         )
+
+
+@operation(is_idempotent=False)
+def login(
+    username: str,
+    password: str,
+    server: str = "",
+):
+    """
+    Log in to a Docker registry.
+
+    + username: username to authenticate with
+    + password: password to authenticate with
+    + server: registry server to log in to (defaults to Docker Hub)
+
+    The password is piped to ``docker login --password-stdin`` so it is not
+    exposed on the command line, and is masked in pyinfra's command log.
+
+    This operation is not idempotent: ``docker login`` is run every time,
+    because the on-disk credential store can be delegated to an external
+    helper (``credsStore``), so pyinfra cannot reliably detect an existing
+    session.
+
+    **Examples:**
+
+    .. code:: python
+
+        from pyinfra.operations import docker
+
+        # Log in to a private registry
+        docker.login(
+            name="Log in to private registry",
+            server="myregistry.io:5000",
+            username="ci",
+            password="s3cret",
+        )
+
+        # Log in to Docker Hub
+        docker.login(
+            name="Log in to Docker Hub",
+            username="ci",
+            password="s3cret",
+        )
+    """
+    if not username:
+        raise OperationError("docker.login requires a username")
+    if not password:
+        raise OperationError("docker.login requires a password")
+
+    command_bits: list = [
+        "printf '%s'",
+        MaskString(shlex_quote(password)),
+        "| docker login --username",
+        QuoteString(username),
+        "--password-stdin",
+    ]
+    if server:
+        command_bits.append(QuoteString(server))
+
+    yield StringCommand(*command_bits)

--- a/tests/facts/docker.DockerAuths/malformed_config.json
+++ b/tests/facts/docker.DockerAuths/malformed_config.json
@@ -1,0 +1,5 @@
+{
+    "command": "config=\"${DOCKER_CONFIG:-$HOME/.docker}/config.json\"; [ -r \"$config\" ] && cat \"$config\" || echo \"{}\"",
+    "output": ["not json at all"],
+    "fact": []
+}

--- a/tests/facts/docker.DockerAuths/no_config_file.json
+++ b/tests/facts/docker.DockerAuths/no_config_file.json
@@ -1,0 +1,5 @@
+{
+    "command": "config=\"${DOCKER_CONFIG:-$HOME/.docker}/config.json\"; [ -r \"$config\" ] && cat \"$config\" || echo \"{}\"",
+    "output": ["{}"],
+    "fact": []
+}

--- a/tests/facts/docker.DockerAuths/with_auths.json
+++ b/tests/facts/docker.DockerAuths/with_auths.json
@@ -1,0 +1,7 @@
+{
+    "command": "config=\"${DOCKER_CONFIG:-$HOME/.docker}/config.json\"; [ -r \"$config\" ] && cat \"$config\" || echo \"{}\"",
+    "output": [
+        "{\"auths\": {\"https://index.docker.io/v1/\": {\"auth\": \"xxx\"}, \"myregistry.io:5000\": {\"auth\": \"yyy\"}}}"
+    ],
+    "fact": ["https://index.docker.io/v1/", "myregistry.io:5000"]
+}

--- a/tests/operations/docker.build/build_basic.json
+++ b/tests/operations/docker.build/build_basic.json
@@ -1,0 +1,8 @@
+{
+    "kwargs": {
+        "path": "/srv/app"
+    },
+    "commands": [
+        "docker build /srv/app"
+    ]
+}

--- a/tests/operations/docker.build/build_cache_from_and_secrets.json
+++ b/tests/operations/docker.build/build_cache_from_and_secrets.json
@@ -1,0 +1,17 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": "app:1.0",
+        "network": "host",
+        "cache_from": ["app:builder", "app:latest"],
+        "secrets": ["id=npmrc,src=/root/.npmrc"]
+    },
+    "facts": {
+        "docker.DockerImage": {
+            "object_id=app:1.0": []
+        }
+    },
+    "commands": [
+        "docker build -t app:1.0 --network host --cache-from app:builder --cache-from app:latest --secret id=npmrc,src=/root/.npmrc /srv/app"
+    ]
+}

--- a/tests/operations/docker.build/build_custom_dockerfile.json
+++ b/tests/operations/docker.build/build_custom_dockerfile.json
@@ -1,0 +1,15 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": "app:prod",
+        "dockerfile": "docker/Dockerfile.prod"
+    },
+    "facts": {
+        "docker.DockerImage": {
+            "object_id=app:prod": []
+        }
+    },
+    "commands": [
+        "docker build -t app:prod -f docker/Dockerfile.prod /srv/app"
+    ]
+}

--- a/tests/operations/docker.build/build_force_rebuild.json
+++ b/tests/operations/docker.build/build_force_rebuild.json
@@ -1,0 +1,10 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": "app:1.0",
+        "force": true
+    },
+    "commands": [
+        "docker build -t app:1.0 /srv/app"
+    ]
+}

--- a/tests/operations/docker.build/build_missing_path_error.json
+++ b/tests/operations/docker.build/build_missing_path_error.json
@@ -1,0 +1,9 @@
+{
+    "kwargs": {
+        "path": ""
+    },
+    "exception": {
+        "name": "OperationError",
+        "message": "docker.build requires a context path"
+    }
+}

--- a/tests/operations/docker.build/build_multi_tag_all_exist.json
+++ b/tests/operations/docker.build/build_multi_tag_all_exist.json
@@ -1,0 +1,18 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": ["app:1.0", "app:latest"]
+    },
+    "facts": {
+        "docker.DockerImage": {
+            "object_id=app:1.0": [
+                {"Id": "sha256:abcd1234", "RepoTags": ["app:1.0"]}
+            ],
+            "object_id=app:latest": [
+                {"Id": "sha256:abcd1234", "RepoTags": ["app:latest"]}
+            ]
+        }
+    },
+    "commands": [],
+    "noop_description": "Image(s) app:1.0, app:latest already exist!"
+}

--- a/tests/operations/docker.build/build_multi_tag_partial.json
+++ b/tests/operations/docker.build/build_multi_tag_partial.json
@@ -1,0 +1,17 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": ["app:1.0", "app:latest"]
+    },
+    "facts": {
+        "docker.DockerImage": {
+            "object_id=app:1.0": [
+                {"Id": "sha256:abcd1234", "RepoTags": ["app:1.0"]}
+            ],
+            "object_id=app:latest": []
+        }
+    },
+    "commands": [
+        "docker build -t app:1.0 -t app:latest /srv/app"
+    ]
+}

--- a/tests/operations/docker.build/build_single_tag_exists_noop.json
+++ b/tests/operations/docker.build/build_single_tag_exists_noop.json
@@ -1,0 +1,18 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": "app:1.0"
+    },
+    "facts": {
+        "docker.DockerImage": {
+            "object_id=app:1.0": [
+                {
+                    "Id": "sha256:abcd1234",
+                    "RepoTags": ["app:1.0"]
+                }
+            ]
+        }
+    },
+    "commands": [],
+    "noop_description": "Image(s) app:1.0 already exist!"
+}

--- a/tests/operations/docker.build/build_single_tag_new.json
+++ b/tests/operations/docker.build/build_single_tag_new.json
@@ -1,0 +1,14 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": "app:1.0"
+    },
+    "facts": {
+        "docker.DockerImage": {
+            "object_id=app:1.0": []
+        }
+    },
+    "commands": [
+        "docker build -t app:1.0 /srv/app"
+    ]
+}

--- a/tests/operations/docker.build/build_target_platform_pull_nocache.json
+++ b/tests/operations/docker.build/build_target_platform_pull_nocache.json
@@ -1,0 +1,18 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": "app:1.0",
+        "target": "runtime",
+        "platform": "linux/amd64",
+        "pull": true,
+        "no_cache": true
+    },
+    "facts": {
+        "docker.DockerImage": {
+            "object_id=app:1.0": []
+        }
+    },
+    "commands": [
+        "docker build -t app:1.0 --target runtime --platform linux/amd64 --pull --no-cache /srv/app"
+    ]
+}

--- a/tests/operations/docker.build/build_with_build_args_and_labels.json
+++ b/tests/operations/docker.build/build_with_build_args_and_labels.json
@@ -1,0 +1,16 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": "app:1.0",
+        "build_args": {"VERSION": "1.0", "COMMIT": "abc123"},
+        "labels": {"org.opencontainers.image.source": "https://example.com/app"}
+    },
+    "facts": {
+        "docker.DockerImage": {
+            "object_id=app:1.0": []
+        }
+    },
+    "commands": [
+        "docker build -t app:1.0 --build-arg VERSION=1.0 --build-arg COMMIT=abc123 --label org.opencontainers.image.source=https://example.com/app /srv/app"
+    ]
+}

--- a/tests/operations/docker.build/build_with_buildx.json
+++ b/tests/operations/docker.build/build_with_buildx.json
@@ -1,0 +1,16 @@
+{
+    "kwargs": {
+        "path": "/srv/app",
+        "tags": "registry.io/app:arm64",
+        "platform": "linux/arm64",
+        "builder": "docker buildx build"
+    },
+    "facts": {
+        "docker.DockerImage": {
+            "object_id=registry.io/app:arm64": []
+        }
+    },
+    "commands": [
+        "docker buildx build -t registry.io/app:arm64 --platform linux/arm64 /srv/app"
+    ]
+}

--- a/tests/operations/docker.compose/compose_down.json
+++ b/tests/operations/docker.compose/compose_down.json
@@ -1,0 +1,9 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "present": false
+    },
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml down --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_down_with_volumes.json
+++ b/tests/operations/docker.compose/compose_down_with_volumes.json
@@ -1,0 +1,10 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "present": false,
+        "remove_volumes": true
+    },
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml down -v --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_basic.json
+++ b/tests/operations/docker.compose/compose_up_basic.json
@@ -1,0 +1,6 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml up -d --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_full_flags.json
+++ b/tests/operations/docker.compose/compose_up_full_flags.json
@@ -1,0 +1,11 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "build": true,
+        "force_recreate": true,
+        "remove_orphans": true
+    },
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml up -d --build --force-recreate --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_multi_file.json
+++ b/tests/operations/docker.compose/compose_up_multi_file.json
@@ -1,0 +1,6 @@
+{
+    "args": [["/srv/app/base.yml", "/srv/app/override.yml"]],
+    "commands": [
+        "docker compose -f /srv/app/base.yml -f /srv/app/override.yml up -d --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_with_project_and_pull.json
+++ b/tests/operations/docker.compose/compose_up_with_project_and_pull.json
@@ -1,0 +1,10 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "project": "app",
+        "pull": "always"
+    },
+    "commands": [
+        "docker compose --project-name app -f /srv/app/docker-compose.yml up -d --pull always --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_v1.json
+++ b/tests/operations/docker.compose/compose_v1.json
@@ -1,0 +1,9 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "compose_command": "docker-compose"
+    },
+    "commands": [
+        "docker-compose -f /srv/app/docker-compose.yml up -d --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.login/login_force_reauth.json
+++ b/tests/operations/docker.login/login_force_reauth.json
@@ -1,0 +1,14 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "newpw",
+        "server": "myregistry.io:5000",
+        "force": true
+    },
+    "commands": [
+        {
+            "raw": "printf '%s' newpw | docker login --username ci --password-stdin myregistry.io:5000",
+            "masked": "printf '%s' *** | docker login --username ci --password-stdin myregistry.io:5000"
+        }
+    ]
+}

--- a/tests/operations/docker.login/login_noop_docker_hub_when_already_authenticated.json
+++ b/tests/operations/docker.login/login_noop_docker_hub_when_already_authenticated.json
@@ -1,0 +1,11 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s3cret"
+    },
+    "facts": {
+        "docker.DockerAuths": ["https://index.docker.io/v1/"]
+    },
+    "commands": [],
+    "noop_description": "Already logged in to Docker registry https://index.docker.io/v1/"
+}

--- a/tests/operations/docker.login/login_noop_when_already_authenticated.json
+++ b/tests/operations/docker.login/login_noop_when_already_authenticated.json
@@ -1,0 +1,12 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s3cret",
+        "server": "myregistry.io:5000"
+    },
+    "facts": {
+        "docker.DockerAuths": ["myregistry.io:5000"]
+    },
+    "commands": [],
+    "noop_description": "Already logged in to Docker registry myregistry.io:5000"
+}

--- a/tests/operations/docker.login/login_to_docker_hub.json
+++ b/tests/operations/docker.login/login_to_docker_hub.json
@@ -1,0 +1,12 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s3cret"
+    },
+    "commands": [
+        {
+            "raw": "printf '%s' s3cret | docker login --username ci --password-stdin",
+            "masked": "printf '%s' *** | docker login --username ci --password-stdin"
+        }
+    ]
+}

--- a/tests/operations/docker.login/login_to_docker_hub.json
+++ b/tests/operations/docker.login/login_to_docker_hub.json
@@ -3,6 +3,9 @@
         "username": "ci",
         "password": "s3cret"
     },
+    "facts": {
+        "docker.DockerAuths": []
+    },
     "commands": [
         {
             "raw": "printf '%s' s3cret | docker login --username ci --password-stdin",

--- a/tests/operations/docker.login/login_to_private_registry.json
+++ b/tests/operations/docker.login/login_to_private_registry.json
@@ -1,0 +1,13 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s3cret",
+        "server": "myregistry.io:5000"
+    },
+    "commands": [
+        {
+            "raw": "printf '%s' s3cret | docker login --username ci --password-stdin myregistry.io:5000",
+            "masked": "printf '%s' *** | docker login --username ci --password-stdin myregistry.io:5000"
+        }
+    ]
+}

--- a/tests/operations/docker.login/login_to_private_registry.json
+++ b/tests/operations/docker.login/login_to_private_registry.json
@@ -4,6 +4,9 @@
         "password": "s3cret",
         "server": "myregistry.io:5000"
     },
+    "facts": {
+        "docker.DockerAuths": []
+    },
     "commands": [
         {
             "raw": "printf '%s' s3cret | docker login --username ci --password-stdin myregistry.io:5000",

--- a/tests/operations/docker.login/login_with_special_chars_password.json
+++ b/tests/operations/docker.login/login_with_special_chars_password.json
@@ -1,0 +1,13 @@
+{
+    "kwargs": {
+        "username": "ci",
+        "password": "s!%^&$",
+        "server": "myregistry.io:5000"
+    },
+    "commands": [
+        {
+            "raw": "printf '%s' 's!%^&$' | docker login --username ci --password-stdin myregistry.io:5000",
+            "masked": "printf '%s' *** | docker login --username ci --password-stdin myregistry.io:5000"
+        }
+    ]
+}

--- a/tests/operations/docker.login/login_with_special_chars_password.json
+++ b/tests/operations/docker.login/login_with_special_chars_password.json
@@ -4,6 +4,9 @@
         "password": "s!%^&$",
         "server": "myregistry.io:5000"
     },
+    "facts": {
+        "docker.DockerAuths": []
+    },
     "commands": [
         {
             "raw": "printf '%s' 's!%^&$' | docker login --username ci --password-stdin myregistry.io:5000",

--- a/tests/operations/docker.logout/logout_from_docker_hub.json
+++ b/tests/operations/docker.logout/logout_from_docker_hub.json
@@ -1,0 +1,8 @@
+{
+    "facts": {
+        "docker.DockerAuths": ["https://index.docker.io/v1/"]
+    },
+    "commands": [
+        "docker logout"
+    ]
+}

--- a/tests/operations/docker.logout/logout_from_private_registry.json
+++ b/tests/operations/docker.logout/logout_from_private_registry.json
@@ -1,0 +1,11 @@
+{
+    "kwargs": {
+        "server": "myregistry.io:5000"
+    },
+    "facts": {
+        "docker.DockerAuths": ["myregistry.io:5000"]
+    },
+    "commands": [
+        "docker logout myregistry.io:5000"
+    ]
+}

--- a/tests/operations/docker.logout/logout_noop_when_not_authenticated.json
+++ b/tests/operations/docker.logout/logout_noop_when_not_authenticated.json
@@ -1,0 +1,10 @@
+{
+    "kwargs": {
+        "server": "myregistry.io:5000"
+    },
+    "facts": {
+        "docker.DockerAuths": []
+    },
+    "commands": [],
+    "noop_description": "Not logged in to Docker registry myregistry.io:5000"
+}


### PR DESCRIPTION
## Summary

- Adds three new docker operations in one place, since they share design (flag assembly, `DockerImage`/`DockerAuths`-based idempotency) and it's easier to review together.
- `docker.compose`: run `docker compose up -d` / `down` against an on-host compose file, with support for `--project-name`, `--pull`, `--build`, `--force-recreate`, `--remove-orphans`, and `-v`. Not idempotent from pyinfra's side; Docker's own layer/state handling keeps re-runs cheap.
- `docker.login` / `docker.logout`: idempotent registry auth. Checks `${DOCKER_CONFIG:-~/.docker}/config.json` via a new `DockerAuths` fact; `login` pipes the password to `--password-stdin` and masks it in logs.
- `docker.build`: wraps `docker build` (or `docker buildx build` via `builder=`). Supports `tags`, `dockerfile`, `build_args`, `labels`, `target`, `platform`, `network`, `cache_from`, `secrets`, `pull`, `no_cache`, and tag-based idempotency (no-op when every declared tag already exists locally, unless `force=True`).

Supersedes #1674 and #1673.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)