### PR TITLE
facts.crontab: match full crontab(5) env var syntax

### DIFF
--- a/src/pyinfra/facts/crontab.py
+++ b/src/pyinfra/facts/crontab.py
@@ -102,7 +102,21 @@ class CrontabFile:
         return self.commands
 
 
-_crontab_env_re = re.compile(r"^\s*([A-Z_]+)=(.*)$")
+# crontab(5) env line: ``name = value`` with optional spaces around ``=``. The
+# name may be a bare identifier or placed in matching single/double quotes; the
+# value runs to end-of-line (the caller handles any quoting in the value).
+_crontab_env_re = re.compile(
+    r"""
+    ^\s*
+    (?:
+        "[^"]*"                         # "quoted name"
+      | '[^']*'                         # 'quoted name'
+      | [A-Za-z_][A-Za-z0-9_]*          # bare identifier
+    )
+    \s*=
+    """,
+    re.VERBOSE,
+)
 
 
 class Crontab(FactBase[CrontabFile]):

--- a/tests/facts/crontab.Crontab/env_variables.json
+++ b/tests/facts/crontab.Crontab/env_variables.json
@@ -1,0 +1,34 @@
+{
+    "command": "crontab -l || true",
+    "requires_command": "crontab",
+    "output": [
+        "MAILTO=me@example.com",
+        "CRON_TZ=Europe/Amsterdam",
+        "@reboot echo rebooted",
+        "0 0 * * * apt update"
+    ],
+    "fact": [
+        {
+            "env": "MAILTO=me@example.com",
+            "comments": []
+        },
+        {
+            "env": "CRON_TZ=Europe/Amsterdam",
+            "comments": []
+        },
+        {
+            "command": "echo rebooted",
+            "special_time": "@reboot",
+            "comments": []
+        },
+        {
+            "command": "apt update",
+            "minute": 0,
+            "hour": 0,
+            "month": "*",
+            "day_of_month": "*",
+            "day_of_week": "*",
+            "comments": []
+        }
+    ]
+}

--- a/tests/facts/crontab.Crontab/env_variables_spaced_and_lowercase.json
+++ b/tests/facts/crontab.Crontab/env_variables_spaced_and_lowercase.json
@@ -1,0 +1,33 @@
+{
+    "command": "crontab -l || true",
+    "requires_command": "crontab",
+    "output": [
+        "MAILTO = me@example.com",
+        "cron_tz = Europe/Amsterdam",
+        "SHELL=/bin/bash",
+        "0 * * * * echo hi"
+    ],
+    "fact": [
+        {
+            "env": "MAILTO = me@example.com",
+            "comments": []
+        },
+        {
+            "env": "cron_tz = Europe/Amsterdam",
+            "comments": []
+        },
+        {
+            "env": "SHELL=/bin/bash",
+            "comments": []
+        },
+        {
+            "command": "echo hi",
+            "minute": 0,
+            "hour": "*",
+            "month": "*",
+            "day_of_month": "*",
+            "day_of_week": "*",
+            "comments": []
+        }
+    ]
+}


### PR DESCRIPTION
Closes #979.

## Problem

`server.Crontab` crashes when the crontab contains an environment variable declaration whose form doesn't exactly match `[A-Z_]+=value`:

```
$ pyinfra server fact server.Crontab
...
facts/crontab.py: line.split(None, 5)
ValueError: not enough values to unpack (expected 6, got 1)
```

The original fix in #1193 added `_crontab_env_re = r"^\s*([A-Z_]+)=(.*)$"`, which handles `MAILTO=me@example.com` but not valid crontab(5) forms that appear in the wild:

- `MAILTO = me@example.com` (spaces around `=`, explicitly allowed by `man 5 crontab`)
- `cron_tz = Europe/Amsterdam` (lowercase names)
- `"name with spaces"=value` (quoted names, allowed by the spec)

Any of these falls through to the 5-field split and crashes with the same `ValueError`.

## Fix

Relax `_crontab_env_re` to match the `man 5 crontab` spec: any-case identifier OR matching-quoted name, with optional whitespace around `=`. The regex now only needs to recognise the line as an env declaration; the full raw line is still stored in the `env` field so `CrontabFile.format_item()` preserves the original text on round-trip.

## Test plan

- [x] Two new fact fixtures under `tests/facts/crontab.Crontab/`:
  - `env_variables.json` covers the exact repro from #979 (`MAILTO=...`, `CRON_TZ=...`, mixed with `@reboot` and a standard cron line).
  - `env_variables_spaced_and_lowercase.json` covers spaced-around-`=` and lowercase-name forms that used to crash.
- [x] `uv run pytest` (1569 passed)
- [x] `uv run ruff check` / `ruff format --diff` / `mypy` / `lint_arguments_sync.py` clean

---

- [x] Pull request is based on the default branch (\`3.x\` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts (behavior fix, no public API change)
- [x] Tests pass (see \`scripts/dev-test.sh\`)
- [x] Type checking & code style passes (see \`scripts/dev-lint.sh\`)