### PR TITLE
operations.files: add limit_rate to cap download bandwidth

### DIFF
--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -90,6 +90,7 @@ def download(
     headers: dict[str, str] | None = None,
     insecure=False,
     proxy: str | None = None,
+    limit_rate: str | None = None,
     temp_dir: str | Path | None = None,
     extra_curl_args: dict[str, str] | None = None,
     extra_wget_args: dict[str, str] | None = None,
@@ -111,6 +112,7 @@ def download(
     + headers: optional dictionary of headers to set for the HTTP request
     + insecure: disable SSL verification for the HTTP request
     + proxy: simple HTTP proxy through which we can download files, form `http://<yourproxy>:<port>`
+    + limit_rate: cap the download bandwidth, accepts the curl/wget format (e.g. ``1M``, ``500k``)
     + temp_dir: use this custom temporary directory during the download
     + extra_curl_args: optional dictionary with custom arguments for curl
     + extra_wget_args: optional dictionary with custom arguments for wget
@@ -197,6 +199,10 @@ def download(
         if insecure:
             curl_args.append("--insecure")
             wget_args.append("--no-check-certificate")
+
+        if limit_rate:
+            curl_args.append(StringCommand("--limit-rate", QuoteString(limit_rate)))
+            wget_args.append(StringCommand("--limit-rate", QuoteString(limit_rate)))
 
         if headers:
             for key, value in headers.items():

--- a/tests/operations/files.download/download_limit_rate_curl.json
+++ b/tests/operations/files.download/download_limit_rate_curl.json
@@ -1,0 +1,20 @@
+{
+    "args": ["http://myfile"],
+    "kwargs": {
+        "dest": "/home/myfile",
+        "limit_rate": "1M"
+    },
+    "facts": {
+        "server.Date": "datetime:2015-01-01T00:00:00",
+        "files.File": {
+            "path=/home/myfile": null
+        },
+        "server.Which": {
+            "command=curl": "yes"
+        }
+    },
+    "commands": [
+        "curl -sSLf --limit-rate 1M http://myfile -o _tempfile_",
+        "mv _tempfile_ /home/myfile"
+    ]
+}

--- a/tests/operations/files.download/download_limit_rate_wget.json
+++ b/tests/operations/files.download/download_limit_rate_wget.json
@@ -1,0 +1,21 @@
+{
+    "args": ["http://myfile"],
+    "kwargs": {
+        "dest": "/home/myfile",
+        "limit_rate": "500k"
+    },
+    "facts": {
+        "server.Date": "datetime:2015-01-01T00:00:00",
+        "files.File": {
+            "path=/home/myfile": null
+        },
+        "server.Which": {
+            "command=curl": null,
+            "command=wget": "yes"
+        }
+    },
+    "commands": [
+        "wget -q --limit-rate 500k http://myfile -O _tempfile_ || ( rm -f _tempfile_ ; exit 1 )",
+        "mv _tempfile_ /home/myfile"
+    ]
+}


### PR DESCRIPTION
## Summary

Adds a `limit_rate` parameter to `files.download` that forwards to the
`--limit-rate` flag on both `curl` and `wget`. This lets deploys cap
the download bandwidth of large artifacts, which is useful for:

- Avoiding SSH connection drops when saturating the uplink of the target host.
- Not starving neighbouring processes (databases, app servers) during a deploy.
- Respecting ISP / egress quotas on shared infrastructure.

Both tools accept the same value format (e.g. `1M`, `500k`), so the
parameter is a thin, symmetric wrapper.

## Usage

```python
from pyinfra.operations import files

files.download(
    name="Download large artifact",
    src="https://example.com/big.tar.gz",
    dest="/opt/big.tar.gz",
    limit_rate="2M",
)
```

## Changes

- New `limit_rate: str | None` parameter on `files.download`.
- Value is wrapped in `QuoteString` for safe shell escaping.
- Docstring updated (picked up by `scripts/generate_operations_docs.py`).
- Fixtures added for both code paths:
  - `tests/operations/files.download/download_limit_rate_curl.json`
  - `tests/operations/files.download/download_limit_rate_wget.json`

Closes #866

## Checklist

- [x] Pull request is based on the default branch (`3.x`)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (`uv run pytest`)
- [x] Type checking & code style passes (`uv run ruff check`, `uv run ruff format --diff`, `uv run mypy`, `uv run python scripts/lint_arguments_sync.py`)