### PR TITLE
facts.{yum,dnf,zypper}: add filename field to each repository entry

### DIFF
--- a/src/pyinfra/facts/dnf.py
+++ b/src/pyinfra/facts/dnf.py
@@ -4,8 +4,8 @@ from typing_extensions import override
 
 from pyinfra.api import FactBase
 
-from .util import make_cat_files_command
-from .util.packaging import parse_yum_repositories
+from .util import make_cat_files_command_with_markers
+from .util.packaging import REPO_FILENAME_MARKER, parse_yum_repositories
 
 
 class DnfRepositories(FactBase):
@@ -24,14 +24,16 @@ class DnfRepositories(FactBase):
                 "countme": "1",
                 "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9",
                 "metadata_expire": "86400",
-                "enabled_metadata": "1"
+                "enabled_metadata": "1",
+                "filename": "/etc/yum.repos.d/almalinux.repo"
             },
         ]
     """
 
     @override
     def command(self) -> str:
-        return make_cat_files_command(
+        return make_cat_files_command_with_markers(
+            REPO_FILENAME_MARKER,
             "/etc/dnf.conf",
             "/etc/dnf.repos.d/*.repo",
             "/etc/yum.repos.d/*.repo",

--- a/src/pyinfra/facts/util/__init__.py
+++ b/src/pyinfra/facts/util/__init__.py
@@ -15,3 +15,17 @@ def make_cat_files_command(*filenames: Iterable[str]) -> str:
         commands = ["({0})".format(command) for command in commands]
 
     return " && ".join(commands)
+
+
+def make_cat_files_command_with_markers(marker: str, *filenames: str) -> str:
+    """
+    Build a shell command that cats each file prefixed by a marker line naming the file.
+    Globs are expanded by the shell; missing files (including unexpanded globs) are skipped.
+    """
+
+    args = " ".join(filenames)
+    return (
+        "for f in {args}; do "
+        '[ -f "$f" ] && {{ printf "{marker} %s\\n" "$f"; cat "$f"; }}; '
+        "done || true"
+    ).format(args=args, marker=marker)

--- a/src/pyinfra/facts/util/packaging.py
+++ b/src/pyinfra/facts/util/packaging.py
@@ -20,13 +20,27 @@ def parse_packages(regex: str, output: Iterable[str]) -> PackageVersionDict:
     return packages
 
 
+REPO_FILENAME_MARKER = "#pyinfra-filename:"
+
+
 def _parse_yum_or_zypper_repositories(output):
     repos = []
 
     current_repo: dict[str, str] = {}
+    current_file: str | None = None
     for line in output:
         line = line.strip()
-        if not line or line.startswith("#"):
+        if not line:
+            continue
+
+        if line.startswith(REPO_FILENAME_MARKER):
+            if current_repo:
+                repos.append(current_repo)
+                current_repo = {}
+            current_file = line[len(REPO_FILENAME_MARKER) :].strip() or None
+            continue
+
+        if line.startswith("#"):
             continue
 
         if line.startswith("["):
@@ -36,6 +50,8 @@ def _parse_yum_or_zypper_repositories(output):
 
             current_repo["repoid"] = line[1:-1]
             current_repo["name"] = line[1:-1]
+            if current_file is not None:
+                current_repo["filename"] = current_file
 
         if current_repo and "=" in line:
             key, value = re.split(r"\s*=\s*", line, maxsplit=1)

--- a/src/pyinfra/facts/yum.py
+++ b/src/pyinfra/facts/yum.py
@@ -4,8 +4,8 @@ from typing_extensions import override
 
 from pyinfra.api import FactBase
 
-from .util import make_cat_files_command
-from .util.packaging import parse_yum_repositories
+from .util import make_cat_files_command_with_markers
+from .util.packaging import REPO_FILENAME_MARKER, parse_yum_repositories
 
 
 class YumRepositories(FactBase):
@@ -24,14 +24,16 @@ class YumRepositories(FactBase):
                 "countme": "1",
                 "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9",
                 "metadata_expire": "86400",
-                "enabled_metadata": "1"
+                "enabled_metadata": "1",
+                "filename": "/etc/yum.repos.d/almalinux.repo"
             },
         ]
     """
 
     @override
     def command(self) -> str:
-        return make_cat_files_command(
+        return make_cat_files_command_with_markers(
+            REPO_FILENAME_MARKER,
             "/etc/yum.conf",
             "/etc/yum.repos.d/*.repo",
         )

--- a/src/pyinfra/facts/zypper.py
+++ b/src/pyinfra/facts/zypper.py
@@ -4,8 +4,8 @@ from typing_extensions import override
 
 from pyinfra.api import FactBase
 
-from .util import make_cat_files_command
-from .util.packaging import parse_zypper_repositories
+from .util import make_cat_files_command_with_markers
+from .util.packaging import REPO_FILENAME_MARKER, parse_zypper_repositories
 
 
 class ZypperRepositories(FactBase):
@@ -20,14 +20,16 @@ class ZypperRepositories(FactBase):
                 "name": "Main Repository",
                 "enabled": "1",
                 "autorefresh": "1",
-                "baseurl": "http://download.opensuse.org/distribution/leap/$releasever/repo/oss/"
+                "baseurl": "http://download.opensuse.org/distribution/leap/$releasever/repo/oss/",
+                "filename": "/etc/zypp/repos.d/oss.repo"
             },
         ]
     """
 
     @override
     def command(self) -> str:
-        return make_cat_files_command(
+        return make_cat_files_command_with_markers(
+            REPO_FILENAME_MARKER,
             "/etc/zypp/repos.d/*.repo",
         )
 

--- a/tests/facts/dnf.DnfRepositories/repos-with-spaces.json
+++ b/tests/facts/dnf.DnfRepositories/repos-with-spaces.json
@@ -1,14 +1,16 @@
 {
-    "command": "(! test -f /etc/dnf.conf || cat /etc/dnf.conf) && (cat /etc/dnf.repos.d/*.repo || true) && (cat /etc/yum.repos.d/*.repo || true)",
+    "command": "for f in /etc/dnf.conf /etc/dnf.repos.d/*.repo /etc/yum.repos.d/*.repo; do [ -f \"$f\" ] && { printf \"#pyinfra-filename: %s\\n\" \"$f\"; cat \"$f\"; }; done || true",
     "requires_command": "dnf",
     "output": [
+        "#pyinfra-filename: /etc/yum.repos.d/rhel-atomic.repo",
         "[rhel-atomic-7-cdk-3.6-source-rpms]",
         "name = Red Hat Container Development Kit 3.6 /(Source RPMs)"
     ],
     "fact": [
         {
             "repoid": "rhel-atomic-7-cdk-3.6-source-rpms",
-            "name": "Red Hat Container Development Kit 3.6 /(Source RPMs)"
+            "name": "Red Hat Container Development Kit 3.6 /(Source RPMs)",
+            "filename": "/etc/yum.repos.d/rhel-atomic.repo"
         }
     ]
 }

--- a/tests/facts/dnf.DnfRepositories/repos.json
+++ b/tests/facts/dnf.DnfRepositories/repos.json
@@ -1,10 +1,12 @@
 {
-    "command": "(! test -f /etc/dnf.conf || cat /etc/dnf.conf) && (cat /etc/dnf.repos.d/*.repo || true) && (cat /etc/yum.repos.d/*.repo || true)",
+    "command": "for f in /etc/dnf.conf /etc/dnf.repos.d/*.repo /etc/yum.repos.d/*.repo; do [ -f \"$f\" ] && { printf \"#pyinfra-filename: %s\\n\" \"$f\"; cat \"$f\"; }; done || true",
     "requires_command": "dnf",
     "output": [
+        "#pyinfra-filename: /etc/yum.repos.d/somerepo.repo",
         "",
         "[somerepo]",
         "baseurl=abc",
+        "#pyinfra-filename: /etc/yum.repos.d/anotherrepo.repo",
         "",
         "[anotherrepo]"
     ],
@@ -12,11 +14,13 @@
         {
             "repoid": "somerepo",
             "name": "somerepo",
+            "filename": "/etc/yum.repos.d/somerepo.repo",
             "baseurl": "abc"
         },
         {
             "repoid": "anotherrepo",
-            "name": "anotherrepo"
+            "name": "anotherrepo",
+            "filename": "/etc/yum.repos.d/anotherrepo.repo"
         }
     ]
 }

--- a/tests/facts/yum.YumRepositories/repos.json
+++ b/tests/facts/yum.YumRepositories/repos.json
@@ -1,17 +1,18 @@
 {
-    "command": "(! test -f /etc/yum.conf || cat /etc/yum.conf) && (cat /etc/yum.repos.d/*.repo || true)",
+    "command": "for f in /etc/yum.conf /etc/yum.repos.d/*.repo; do [ -f \"$f\" ] && { printf \"#pyinfra-filename: %s\\n\" \"$f\"; cat \"$f\"; }; done || true",
     "requires_command": "yum",
     "output": [
+        "#pyinfra-filename: /etc/yum.repos.d/somerepo.repo",
         "# comment line",
         " # comment line with whitespaces",
         "[somerepo]",
         "baseurl=abc"
-
     ],
     "fact": [
         {
             "repoid": "somerepo",
             "name": "somerepo",
+            "filename": "/etc/yum.repos.d/somerepo.repo",
             "baseurl": "abc"
         }
     ]

--- a/tests/facts/zypper.ZypperRepositories/repos.json
+++ b/tests/facts/zypper.ZypperRepositories/repos.json
@@ -1,17 +1,18 @@
 {
-    "command": "cat /etc/zypp/repos.d/*.repo || true",
+    "command": "for f in /etc/zypp/repos.d/*.repo; do [ -f \"$f\" ] && { printf \"#pyinfra-filename: %s\\n\" \"$f\"; cat \"$f\"; }; done || true",
     "requires_command": "zypper",
     "output": [
+        "#pyinfra-filename: /etc/zypp/repos.d/somerepo.repo",
         "# comment line",
         " # comment line with whitespaces",
         "[somerepo]",
         "baseurl=abc"
-
     ],
     "fact": [
         {
             "repoid": "somerepo",
             "name": "somerepo",
+            "filename": "/etc/zypp/repos.d/somerepo.repo",
             "baseurl": "abc"
         }
     ]


### PR DESCRIPTION
Closes #1042.

## Problem

`YumRepositories`, `DnfRepositories`, and `ZypperRepositories` concatenate every `.repo` file via `cat`, so each parsed entry loses its source filename. That makes the inspect-then-clean-up pattern unworkable: `yum.repo(..., present=False)` needs the filename, but the fact never exposes it. The issue author ran into exactly this.

## Change

- New helper `make_cat_files_command_with_markers(marker, *filenames)` in `src/pyinfra/facts/util/__init__.py`. It uses a portable `for f in ...; do [ -f "$f" ] && { printf "MARKER %s\n" "$f"; cat "$f"; }; done || true` loop so missing files and unexpanded globs are skipped silently, and each file's contents are preceded by a single marker line naming the path.
- `_parse_yum_or_zypper_repositories` in `src/pyinfra/facts/util/packaging.py` now recognises the `#pyinfra-filename:` marker and attaches a `filename` key to every repo entry it emits. Non-marker comments keep their existing skip behaviour, so any user-written comments in `.repo` files remain ignored.
- `YumRepositories`, `DnfRepositories`, and `ZypperRepositories` switched to the new helper; docstrings updated to show the new `filename` field in the example output.
- Fact fixtures updated (including a second dnf case) to cover the new command string and assert the `filename` field.

The change is additive: existing repo dict keys keep their shape.

## Checklist

- [x] Pull request is based on the default branch (`3.x`)
- [x] Pull request includes tests for new behaviour (fact fixtures cover the filename marker for yum, dnf, and zypper, including the spaces-in-name case)
- [x] Documentation updated (fact docstrings show the new `filename` field)
- [x] Tests pass (`uv run pytest` - 1608 passed)
- [x] Type checking & code style passes (`uv run ruff check`, `uv run ruff format`, `uv run mypy`, `uv run python scripts/lint_arguments_sync.py`)