### PR TITLE
operations.server: dispatch BSD rc.d before sysvinit in server.service

### DIFF
--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -572,12 +572,15 @@ def service(
     elif host.get_fact(Which, command="sv"):
         service_operation = runit.service
 
-    # NOTE: important that we are not Linux here because /etc/rc.d will exist but checking it's
-    # contents may trigger things (like a reboot: https://github.com/Fizzadar/pyinfra/issues/819).
-    # Must also run before the sysvinit check: BSDs ship `service` in base (distinct from the
-    # Linux sysvinit wrapper), so matching on Which command="service" first would misroute FreeBSD
+    # NOTE: must run before the sysvinit check: BSDs ship `service` in base (distinct from the
+    # Linux sysvinit wrapper), so matching on Which command="service" first would misroute BSD
     # hosts to sysvinit. See https://github.com/pyinfra-dev/pyinfra/issues/1496.
-    elif host.get_fact(Os) != "Linux" and bool(host.get_fact(Directory, path="/etc/rc.d")):
+    # The OS list is explicit (rather than "not Linux") so other /etc/rc.d-having systems are not
+    # accidentally routed through bsdinit; see https://github.com/Fizzadar/pyinfra/issues/819 for
+    # the original motivation to exclude Linux here.
+    elif host.get_fact(Os) in ("FreeBSD", "OpenBSD", "NetBSD", "DragonFly") and bool(
+        host.get_fact(Directory, path="/etc/rc.d")
+    ):
         service_operation = bsdinit.service
 
     elif (

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -572,17 +572,20 @@ def service(
     elif host.get_fact(Which, command="sv"):
         service_operation = runit.service
 
+    # NOTE: important that we are not Linux here because /etc/rc.d will exist but checking it's
+    # contents may trigger things (like a reboot: https://github.com/Fizzadar/pyinfra/issues/819).
+    # Must also run before the sysvinit check: BSDs ship `service` in base (distinct from the
+    # Linux sysvinit wrapper), so matching on Which command="service" first would misroute FreeBSD
+    # hosts to sysvinit. See https://github.com/pyinfra-dev/pyinfra/issues/1496.
+    elif host.get_fact(Os) != "Linux" and bool(host.get_fact(Directory, path="/etc/rc.d")):
+        service_operation = bsdinit.service
+
     elif (
         host.get_fact(Which, command="service")
         or host.get_fact(Link, path="/etc/init.d")
         or host.get_fact(Directory, path="/etc/init.d")
     ):
         service_operation = sysvinit.service
-
-    # NOTE: important that we are not Linux here because /etc/rc.d will exist but checking it's
-    # contents may trigger things (like a reboot: https://github.com/Fizzadar/pyinfra/issues/819)
-    elif host.get_fact(Os) != "Linux" and bool(host.get_fact(Directory, path="/etc/rc.d")):
-        service_operation = bsdinit.service
 
     else:
         raise OperationError(

--- a/tests/operations/server.service/start_initd_service.json
+++ b/tests/operations/server.service/start_initd_service.json
@@ -1,6 +1,7 @@
 {
     "args": ["nginx"],
     "facts": {
+        "server.Os": "Linux",
         "sysvinit.InitdStatus": {
             "nginx": false
         },

--- a/tests/operations/server.service/start_rcd_freebsd_with_service_command.json
+++ b/tests/operations/server.service/start_rcd_freebsd_with_service_command.json
@@ -1,8 +1,8 @@
 {
     "args": ["nginx"],
     "facts": {
-        "server.Os": "Linux",
-        "sysvinit.InitdStatus": {
+        "server.Os": "FreeBSD",
+        "bsdinit.RcdStatus": {
             "nginx": false
         },
         "server.Which": {
@@ -10,17 +10,17 @@
             "command=initctl": false,
             "command=rc-service": false,
             "command=sv": false,
-            "command=service": false
+            "command=service": "/usr/sbin/service"
         },
         "files.Directory": {
-            "path=/etc/init.d": true,
-            "path=/etc/rc.d": false
+            "path=/etc/init.d": false,
+            "path=/etc/rc.d": true
         },
         "files.Link": {
-            "path=/etc/init.d": true
+            "path=/etc/init.d": false
         }
     },
     "commands": [
-        "/etc/init.d/nginx start"
+        "test -e /etc/rc.d/nginx && /etc/rc.d/nginx start || /usr/local/etc/rc.d/nginx start"
     ]
 }

--- a/tests/operations/server.service/start_rcd_netbsd.json
+++ b/tests/operations/server.service/start_rcd_netbsd.json
@@ -1,0 +1,26 @@
+{
+    "args": ["nginx"],
+    "facts": {
+        "server.Os": "NetBSD",
+        "bsdinit.RcdStatus": {
+            "nginx": false
+        },
+        "server.Which": {
+            "command=systemctl": false,
+            "command=initctl": false,
+            "command=rc-service": false,
+            "command=sv": false,
+            "command=service": "/usr/sbin/service"
+        },
+        "files.Directory": {
+            "path=/etc/init.d": false,
+            "path=/etc/rc.d": true
+        },
+        "files.Link": {
+            "path=/etc/init.d": false
+        }
+    },
+    "commands": [
+        "test -e /etc/rc.d/nginx && /etc/rc.d/nginx start || /usr/local/etc/rc.d/nginx start"
+    ]
+}


### PR DESCRIPTION
Closes #1496.

## Problem

On FreeBSD 14 (and any other BSD that ships `service(8)` in base), `server.service` runs `/etc/init.d/<name>` instead of the actual BSD rc script, failing with `sh: /etc/init.d/mysql-server: not found`.

The init-system detection in `src/pyinfra/operations/server.py` checked `Which command="service"` before the bsdinit branch. FreeBSD, NetBSD, and DragonFly all have `/usr/sbin/service`, so they matched that branch and were routed to `sysvinit.service`, even though their service scripts live in `/etc/rc.d` and `/usr/local/etc/rc.d`. OpenBSD does not ship `service`, so it was dispatched correctly by the fallback check, but only incidentally.

## Change

- Moved the bsdinit branch above the sysvinit branch so it wins for BSD hosts before the `service`/`/etc/init.d` heuristics run.
- Replaced the previous `Os != "Linux"` guard with an explicit list: `Os in ("FreeBSD", "OpenBSD", "NetBSD", "DragonFly")`. This keeps the original intent of excluding Linux (`/etc/rc.d` exists on some distros and inspecting it can have side effects, see #819) while also not accidentally routing other non-Linux hosts that happen to expose `/etc/rc.d` through `bsdinit.service`.
- Updated the inline comment to point to this issue and the rationale.

The change is behaviour-preserving for Linux (flow still lands on sysvinit when nothing earlier matched) and for OpenBSD (still dispatches to `bsdinit.service`, which already special-cases its `check` status command at `src/pyinfra/operations/bsdinit.py:37`).

## Tests

- `tests/operations/server.service/start_rcd_freebsd_with_service_command.json`: regression fixture for the reported scenario (FreeBSD, `service` present, `/etc/rc.d` present). Asserts the BSD command is emitted.
- `tests/operations/server.service/start_rcd_netbsd.json`: same shape with `server.Os: NetBSD` to lock in the explicit BSD list (NetBSD was previously covered by the `!= Linux` guard; this pins it).
- `start_initd.json` and `start_initd_service.json`: added `server.Os: Linux` because the BSD branch now runs before them and the test harness fails on missing facts.

## Checklist

- [x] Pull request is based on the default branch (`3.x`)
- [x] Tests for the updated behaviour (fixtures for FreeBSD + NetBSD regression, existing sysvinit/BSD/systemd fixtures still pass)
- [x] Docs: inline comment in `server.service` updated with rationale and issue link; no user-facing doc changes required
- [x] Tests pass (`uv run pytest` - 1610 passed)
- [x] Type checking & code style passes (`uv run ruff check`, `uv run ruff format`, `uv run mypy`, `uv run python scripts/lint_arguments_sync.py`)