### PR TITLE
scripts/generate_facts_docs: add canonical-name label for re-exported facts

### DIFF
--- a/scripts/generate_facts_docs.py
+++ b/scripts/generate_facts_docs.py
@@ -104,6 +104,13 @@ def build_facts_docs():
                     )
 
             lines.append(".. _facts:{0}.{1}:".format(module_name, name))
+            # Modules that re-export classes under an alias (e.g. facts/zfs.py
+            # exposes both ZfsDatasets and Datasets pointing at the same class)
+            # end up keyed by whichever name getmembers sees first. Emit the
+            # canonical class name as an extra label so cross-refs from the
+            # operations docs resolve regardless of import style.
+            if cls.__name__ != name:
+                lines.append(".. _facts:{0}.{1}:".format(module_name, cls.__name__))
             lines.append("")
 
             title = ":code:`{0}.{1}`".format(module_name, name)


### PR DESCRIPTION
Fixes:

```
docs/operations/zfs.rst:8: WARNING: undefined label: 'facts:zfs.zfsdatasets' [ref.ref]
```

`facts/zfs.py` re-exports each class under a short alias (`Datasets = ZfsDatasets`, etc.). `remove_dups()` keeps the alphabetically-first name (the alias), so the fact doc only labels `facts:zfs.Datasets`, but the operation doc references `facts:zfs.ZfsDatasets` because `operations/zfs.py` imports the canonical name.

This commit emits the class's canonical `__name__` as an extra label when it differs from the alias picked by `remove_dups`. Both forms resolve; modules without aliases are unaffected; existing URLs stay valid.

## Checklist

- [x] Based on `3.x`
- [x] `sphinx-build` is now warning-free
- [x] `uv run pytest`, `ruff check`, `ruff format` pass