### PR TITLE
operations.files.download: reconcile mode/user/group on existing files

### DIFF
--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -80,7 +80,7 @@ def download(
     dest: str,
     user: str | None = None,
     group: str | None = None,
-    mode: str | None = None,
+    mode: int | str | None = None,
     cache_time: int | None = None,
     force=False,
     sha384sum: str | None = None,
@@ -129,6 +129,7 @@ def download(
         )
     """
 
+    mode = ensure_mode_int(mode)
     info = host.get_fact(File, path=dest)
 
     # Destination is a directory?
@@ -279,7 +280,22 @@ def download(
                 QuoteString("MD5 did not match!"),
             )
     else:
-        host.noop("file {0} has already been downloaded".format(dest))
+        # No re-download needed, but still reconcile ownership + mode against the
+        # existing file so a changed mode/user/group argument takes effect
+        # without forcing a re-download. See issue #1200.
+        assert info is not None  # narrowed: download=True covers info is None
+        changed = False
+
+        if (user and info["user"] != user) or (group and info["group"] != group):
+            yield file_utils.chown(dest, user, group)
+            changed = True
+
+        if mode and info["mode"] != mode:
+            yield file_utils.chmod(dest, mode)
+            changed = True
+
+        if not changed:
+            host.noop("file {0} has already been downloaded".format(dest))
 
 
 @operation()

--- a/tests/operations/files.download/existing_file_mode_match.json
+++ b/tests/operations/files.download/existing_file_mode_match.json
@@ -1,0 +1,19 @@
+{
+    "args": ["http://myfile"],
+    "kwargs": {
+        "dest": "/home/myfile",
+        "mode": "777"
+    },
+    "facts": {
+        "server.Date": "datetime:2015-01-01T00:00:00",
+        "files.File": {
+            "path=/home/myfile": {
+                "mode": 777,
+                "user": "root",
+                "group": "root"
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "file /home/myfile has already been downloaded"
+}

--- a/tests/operations/files.download/existing_file_mode_mismatch.json
+++ b/tests/operations/files.download/existing_file_mode_mismatch.json
@@ -1,0 +1,20 @@
+{
+    "args": ["http://myfile"],
+    "kwargs": {
+        "dest": "/home/myfile",
+        "mode": "777"
+    },
+    "facts": {
+        "server.Date": "datetime:2015-01-01T00:00:00",
+        "files.File": {
+            "path=/home/myfile": {
+                "mode": 644,
+                "user": "root",
+                "group": "root"
+            }
+        }
+    },
+    "commands": [
+        "chmod 777 /home/myfile"
+    ]
+}

--- a/tests/operations/files.download/existing_file_owner_mismatch.json
+++ b/tests/operations/files.download/existing_file_owner_mismatch.json
@@ -1,0 +1,21 @@
+{
+    "args": ["http://myfile"],
+    "kwargs": {
+        "dest": "/home/myfile",
+        "user": "newuser",
+        "group": "newgroup"
+    },
+    "facts": {
+        "server.Date": "datetime:2015-01-01T00:00:00",
+        "files.File": {
+            "path=/home/myfile": {
+                "mode": 644,
+                "user": "root",
+                "group": "root"
+            }
+        }
+    },
+    "commands": [
+        "chown newuser:newgroup /home/myfile"
+    ]
+}


### PR DESCRIPTION
download() short-circuits to a noop whenever the destination exists (and cache_time / checksums don't say otherwise), so changing the mode, user or group argument had no effect unless you manually deleted the target first. Compare the requested mode/owner against the File fact and emit chmod/chown when they differ; only noop when the file and its metadata both match.

Widen the mode parameter's type to int | str | None to match files.file() and let ensure_mode_int() reassignment type-check cleanly. Closes #1200.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
