### PR TITLE
operations.git: don't pull when already up to date

### DIFF
--- a/src/pyinfra/facts/git.py
+++ b/src/pyinfra/facts/git.py
@@ -69,3 +69,48 @@ class GitTrackingBranch(GitFactBase):
         if m:
             return m.group(1)
         return None
+
+
+_SHA_RE = re.compile(r"[0-9a-f]{7,64}")
+
+
+class GitLocalCommit(GitFactBase):
+    """
+    Returns the SHA of the current ``HEAD`` of a local git repository, or ``None``
+    when the repository does not exist or the command fails.
+    """
+
+    @override
+    def command(self, repo) -> str:
+        return "! test -d {0} || (cd {0} && git rev-parse HEAD 2>/dev/null)".format(repo)
+
+    @override
+    def process(self, output):
+        if not output:
+            return None
+        line = list(output)[0].strip()
+        return line if _SHA_RE.fullmatch(line) else None
+
+
+class GitRemoteBranchCommit(GitFactBase):
+    """
+    Returns the SHA of the tip of ``branch`` on ``remote`` as reported by
+    ``git ls-remote``. Returns ``None`` when the remote is unreachable, the
+    branch does not exist on the remote, or the repository is missing.
+    """
+
+    @override
+    def command(self, repo, remote: str = "origin", branch: str | None = None) -> str:
+        ref = branch if branch else "HEAD"
+        return ("! test -d {0} || (cd {0} && git ls-remote {1} {2} 2>/dev/null | head -n1)").format(
+            repo, remote, ref
+        )
+
+    @override
+    def process(self, output):
+        if not output:
+            return None
+        parts = list(output)[0].strip().split("\t", 1)
+        if parts and _SHA_RE.fullmatch(parts[0]):
+            return parts[0]
+        return None

--- a/src/pyinfra/facts/git.py
+++ b/src/pyinfra/facts/git.py
@@ -71,24 +71,25 @@ class GitTrackingBranch(GitFactBase):
         return None
 
 
-_SHA_RE = re.compile(r"[0-9a-f]{7,64}")
+_SHA_RE = re.compile(r"[0-9a-f]{40}|[0-9a-f]{64}")
 
 
 class GitLocalCommit(GitFactBase):
     """
-    Returns the SHA of the current ``HEAD`` of a local git repository, or ``None``
-    when the repository does not exist or the command fails.
+    Returns the SHA of ``ref`` (defaults to ``HEAD``) in a local git repository,
+    or ``None`` when the repository does not exist, the ref is unknown, or the
+    command fails.
     """
 
     @override
-    def command(self, repo) -> str:
-        return "! test -d {0} || (cd {0} && git rev-parse HEAD 2>/dev/null)".format(repo)
+    def command(self, repo: str, ref: str = "HEAD") -> str:
+        return "! test -d {0} || (cd {0} && git rev-parse {1} 2>/dev/null)".format(repo, ref)
 
     @override
-    def process(self, output):
+    def process(self, output: list[str]):
         if not output:
             return None
-        line = list(output)[0].strip()
+        line = output[0].strip()
         return line if _SHA_RE.fullmatch(line) else None
 
 
@@ -100,17 +101,17 @@ class GitRemoteBranchCommit(GitFactBase):
     """
 
     @override
-    def command(self, repo, remote: str = "origin", branch: str | None = None) -> str:
+    def command(self, repo: str, remote: str = "origin", branch: str | None = None) -> str:
         ref = branch if branch else "HEAD"
         return ("! test -d {0} || (cd {0} && git ls-remote {1} {2} 2>/dev/null | head -n1)").format(
             repo, remote, ref
         )
 
     @override
-    def process(self, output):
+    def process(self, output: list[str]):
         if not output:
             return None
-        parts = list(output)[0].strip().split("\t", 1)
+        parts = output[0].strip().split("\t", 1)
         if parts and _SHA_RE.fullmatch(parts[0]):
             return parts[0]
         return None

--- a/src/pyinfra/operations/git.py
+++ b/src/pyinfra/operations/git.py
@@ -9,7 +9,14 @@ import re
 from pyinfra import host
 from pyinfra.api import OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.files import Directory, File
-from pyinfra.facts.git import GitBranch, GitConfig, GitTag, GitTrackingBranch
+from pyinfra.facts.git import (
+    GitBranch,
+    GitConfig,
+    GitLocalCommit,
+    GitRemoteBranchCommit,
+    GitTag,
+    GitTrackingBranch,
+)
 
 from . import files, ssh
 from .util.files import chown, unix_path_join
@@ -154,14 +161,36 @@ def repo(
     # Ensuring existing repo
     else:
         is_tag = False
-        if branch and host.get_fact(GitBranch, repo=dest) != branch:
+        current_branch = host.get_fact(GitBranch, repo=dest)
+        branch_switching = False
+        if branch is not None and current_branch != branch:
+            branch_switching = True
             git_commands.append("fetch")  # fetch to ensure we have the branch locally
             git_commands.append(StringCommand("checkout", QuoteString(branch)))
         if branch and branch in (host.get_fact(GitTag, repo=dest) or []):
             git_commands.append(StringCommand("checkout", QuoteString(branch)))
             is_tag = True
         if pull and not is_tag:
-            if rebase:
+            skip_pull = False
+            # If the branch hasn't changed and the local HEAD already matches the
+            # remote tip, a `git pull` would be a no-op. Skip it so pyinfra reports
+            # the operation unchanged rather than always "Success".
+            if not branch_switching:
+                effective_branch = branch or current_branch
+                if effective_branch:
+                    local_commit = host.get_fact(GitLocalCommit, repo=dest)
+                    remote_commit = host.get_fact(
+                        GitRemoteBranchCommit,
+                        repo=dest,
+                        branch=effective_branch,
+                    )
+                    if local_commit and remote_commit and local_commit == remote_commit:
+                        skip_pull = True
+            if skip_pull:
+                host.noop(
+                    "git repository {0} is already up to date".format(dest),
+                )
+            elif rebase:
                 git_commands.append("pull --rebase")
             else:
                 git_commands.append("pull")
@@ -389,31 +418,62 @@ def worktree(
         # pull the worktree only if it's already linked to a tracking branch or
         # if a remote branch is set
         elif host.get_fact(GitTrackingBranch, repo=worktree) or from_remote_branch:
-            pull_args: list[str | QuoteString] = [
-                "cd",
-                QuoteString(worktree),
-                "&&",
-                "git",
-                "pull",
-            ]
-
-            if rebase:
-                pull_args.append("--rebase")
-
-            if from_remote_branch:
-                if len(from_remote_branch) != 2 or type(from_remote_branch) not in (tuple, list):
-                    raise OperationError(
-                        "The remote branch must be a 2-tuple (remote, branch) such as "
-                        '("origin", "master")',
-                    )
-                pull_args.extend(
-                    [
-                        QuoteString(from_remote_branch[0]),
-                        QuoteString(from_remote_branch[1]),
-                    ]
+            if from_remote_branch and (
+                len(from_remote_branch) != 2 or type(from_remote_branch) not in (tuple, list)
+            ):
+                raise OperationError(
+                    "The remote branch must be a 2-tuple (remote, branch) such as "
+                    '("origin", "master")',
                 )
 
-            yield StringCommand(*pull_args)
+            # Determine the remote ref we would pull from, so we can short-circuit
+            # the pull when the worktree HEAD already matches the remote tip.
+            remote_name: str | None = None
+            remote_branch: str | None = None
+            if from_remote_branch:
+                remote_name, remote_branch = from_remote_branch[0], from_remote_branch[1]
+            else:
+                tracking = host.get_fact(GitTrackingBranch, repo=worktree)
+                if tracking and "/" in tracking:
+                    remote_name, remote_branch = tracking.split("/", 1)
+
+            skip_pull = False
+            if remote_name and remote_branch:
+                local_commit = host.get_fact(GitLocalCommit, repo=worktree)
+                remote_commit = host.get_fact(
+                    GitRemoteBranchCommit,
+                    repo=worktree,
+                    remote=remote_name,
+                    branch=remote_branch,
+                )
+                if local_commit and remote_commit and local_commit == remote_commit:
+                    skip_pull = True
+
+            if skip_pull:
+                host.noop(
+                    "git worktree {0} is already up to date".format(worktree),
+                )
+            else:
+                pull_args: list[str | QuoteString] = [
+                    "cd",
+                    QuoteString(worktree),
+                    "&&",
+                    "git",
+                    "pull",
+                ]
+
+                if rebase:
+                    pull_args.append("--rebase")
+
+                if from_remote_branch:
+                    pull_args.extend(
+                        [
+                            QuoteString(from_remote_branch[0]),
+                            QuoteString(from_remote_branch[1]),
+                        ]
+                    )
+
+                yield StringCommand(*pull_args)
 
 
 @operation()

--- a/src/pyinfra/operations/git.py
+++ b/src/pyinfra/operations/git.py
@@ -162,9 +162,7 @@ def repo(
     else:
         is_tag = False
         current_branch = host.get_fact(GitBranch, repo=dest)
-        branch_switching = False
         if branch is not None and current_branch != branch:
-            branch_switching = True
             git_commands.append("fetch")  # fetch to ensure we have the branch locally
             git_commands.append(StringCommand("checkout", QuoteString(branch)))
         if branch and branch in (host.get_fact(GitTag, repo=dest) or []):
@@ -172,20 +170,21 @@ def repo(
             is_tag = True
         if pull and not is_tag:
             skip_pull = False
-            # If the branch hasn't changed and the local HEAD already matches the
-            # remote tip, a `git pull` would be a no-op. Skip it so pyinfra reports
-            # the operation unchanged rather than always "Success".
-            if not branch_switching:
-                effective_branch = branch or current_branch
-                if effective_branch:
-                    local_commit = host.get_fact(GitLocalCommit, repo=dest)
-                    remote_commit = host.get_fact(
-                        GitRemoteBranchCommit,
-                        repo=dest,
-                        branch=effective_branch,
-                    )
-                    if local_commit and remote_commit and local_commit == remote_commit:
-                        skip_pull = True
+            # Skip `git pull` when the local branch tip already matches the
+            # remote tip, so pyinfra reports the operation unchanged rather
+            # than always "Success". This still applies when we switch branch:
+            # if the target branch already exists locally at the remote tip,
+            # the fetch+checkout leaves nothing for pull to do.
+            effective_branch = branch or current_branch
+            if effective_branch:
+                local_commit = host.get_fact(GitLocalCommit, repo=dest, ref=effective_branch)
+                remote_commit = host.get_fact(
+                    GitRemoteBranchCommit,
+                    repo=dest,
+                    branch=effective_branch,
+                )
+                if local_commit and remote_commit and local_commit == remote_commit:
+                    skip_pull = True
             if skip_pull:
                 host.noop(
                     "git repository {0} is already up to date".format(dest),

--- a/tests/facts/git.GitLocalCommit/branch_ref.json
+++ b/tests/facts/git.GitLocalCommit/branch_ref.json
@@ -1,0 +1,12 @@
+{
+    "arg": {
+        "repo": "myrepo",
+        "ref": "mybranch"
+    },
+    "command": "! test -d myrepo || (cd myrepo && git rev-parse mybranch 2>/dev/null)",
+    "requires_command": "git",
+    "output": [
+        "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
+    ],
+    "fact": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
+}

--- a/tests/facts/git.GitLocalCommit/head.json
+++ b/tests/facts/git.GitLocalCommit/head.json
@@ -1,0 +1,9 @@
+{
+    "arg": "myrepo",
+    "command": "! test -d myrepo || (cd myrepo && git rev-parse HEAD 2>/dev/null)",
+    "requires_command": "git",
+    "output": [
+        "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
+    ],
+    "fact": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
+}

--- a/tests/facts/git.GitLocalCommit/no_repo.json
+++ b/tests/facts/git.GitLocalCommit/no_repo.json
@@ -1,0 +1,7 @@
+{
+    "arg": "myrepo",
+    "command": "! test -d myrepo || (cd myrepo && git rev-parse HEAD 2>/dev/null)",
+    "requires_command": "git",
+    "output": [],
+    "fact": null
+}

--- a/tests/facts/git.GitRemoteBranchCommit/branch.json
+++ b/tests/facts/git.GitRemoteBranchCommit/branch.json
@@ -1,0 +1,12 @@
+{
+    "arg": {
+        "repo": "myrepo",
+        "branch": "main"
+    },
+    "command": "! test -d myrepo || (cd myrepo && git ls-remote origin main 2>/dev/null | head -n1)",
+    "requires_command": "git",
+    "output": [
+        "1a2b3c4d5e6f7890abcdef1234567890abcdef12\trefs/heads/main"
+    ],
+    "fact": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
+}

--- a/tests/facts/git.GitRemoteBranchCommit/unreachable.json
+++ b/tests/facts/git.GitRemoteBranchCommit/unreachable.json
@@ -1,0 +1,10 @@
+{
+    "arg": {
+        "repo": "myrepo",
+        "branch": "main"
+    },
+    "command": "! test -d myrepo || (cd myrepo && git ls-remote origin main 2>/dev/null | head -n1)",
+    "requires_command": "git",
+    "output": [],
+    "fact": null
+}

--- a/tests/operations/git.repo/branch_pull.json
+++ b/tests/operations/git.repo/branch_pull.json
@@ -16,6 +16,12 @@
         "git.GitTag": {
             "repo=/home/myrepo": [
             ]
+        },
+        "git.GitLocalCommit": {
+            "ref=mybranch, repo=/home/myrepo": null
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=mybranch, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         }
     },
     "commands": [

--- a/tests/operations/git.repo/branch_switch_up_to_date.json
+++ b/tests/operations/git.repo/branch_switch_up_to_date.json
@@ -1,7 +1,7 @@
 {
     "args": ["myrepo", "/home/myrepo"],
     "kwargs": {
-        "rebase": true
+        "branch": "mybranch"
     },
     "facts": {
         "files.Directory": {
@@ -13,16 +13,19 @@
         "git.GitBranch": {
             "repo=/home/myrepo": "master"
         },
+        "git.GitTag": {
+            "repo=/home/myrepo": [
+            ]
+        },
         "git.GitLocalCommit": {
-            "ref=master, repo=/home/myrepo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "ref=mybranch, repo=/home/myrepo": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
         },
         "git.GitRemoteBranchCommit": {
-            "branch=master, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            "branch=mybranch, remote=origin, repo=/home/myrepo": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
         }
     },
     "commands": [
-        "cd /home/myrepo && git pull --rebase"
-    ],
-    "idempotent": false,
-    "disable_idempotent_warning_reason": "git pull will always be executed"
+        "cd /home/myrepo && git fetch",
+        "cd /home/myrepo && git checkout mybranch"
+    ]
 }

--- a/tests/operations/git.repo/rebase.json
+++ b/tests/operations/git.repo/rebase.json
@@ -12,6 +12,12 @@
         },
         "git.GitBranch": {
             "repo=/home/myrepo": "master"
+        },
+        "git.GitLocalCommit": {
+            "repo=/home/myrepo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=master, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         }
     },
     "commands": [

--- a/tests/operations/git.repo/recursive_submodules.json
+++ b/tests/operations/git.repo/recursive_submodules.json
@@ -15,7 +15,7 @@
             "repo=/home/myrepo": "master"
         },
         "git.GitLocalCommit": {
-            "repo=/home/myrepo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "ref=master, repo=/home/myrepo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         },
         "git.GitRemoteBranchCommit": {
             "branch=master, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/operations/git.repo/recursive_submodules.json
+++ b/tests/operations/git.repo/recursive_submodules.json
@@ -13,6 +13,12 @@
         },
         "git.GitBranch": {
             "repo=/home/myrepo": "master"
+        },
+        "git.GitLocalCommit": {
+            "repo=/home/myrepo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=master, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         }
     },
     "commands": [

--- a/tests/operations/git.repo/up_to_date.json
+++ b/tests/operations/git.repo/up_to_date.json
@@ -11,7 +11,7 @@
             "repo=/home/myrepo": "master"
         },
         "git.GitLocalCommit": {
-            "repo=/home/myrepo": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
+            "ref=master, repo=/home/myrepo": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
         },
         "git.GitRemoteBranchCommit": {
             "branch=master, remote=origin, repo=/home/myrepo": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"

--- a/tests/operations/git.repo/up_to_date.json
+++ b/tests/operations/git.repo/up_to_date.json
@@ -1,0 +1,22 @@
+{
+    "args": ["myrepo", "/home/myrepo"],
+    "facts": {
+        "files.Directory": {
+            "path=/home/myrepo": {},
+            "path=/home/myrepo/.git": {
+                "mode": 0
+            }
+        },
+        "git.GitBranch": {
+            "repo=/home/myrepo": "master"
+        },
+        "git.GitLocalCommit": {
+            "repo=/home/myrepo": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=master, remote=origin, repo=/home/myrepo": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
+        }
+    },
+    "commands": [],
+    "noop_description": "git repository /home/myrepo is already up to date"
+}

--- a/tests/operations/git.repo/update_submodules.json
+++ b/tests/operations/git.repo/update_submodules.json
@@ -12,6 +12,12 @@
         },
         "git.GitBranch": {
             "repo=/home/myrepo": "master"
+        },
+        "git.GitLocalCommit": {
+            "repo=/home/myrepo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=master, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         }
     },
     "commands": [

--- a/tests/operations/git.repo/update_submodules.json
+++ b/tests/operations/git.repo/update_submodules.json
@@ -14,7 +14,7 @@
             "repo=/home/myrepo": "master"
         },
         "git.GitLocalCommit": {
-            "repo=/home/myrepo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "ref=master, repo=/home/myrepo": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         },
         "git.GitRemoteBranchCommit": {
             "branch=master, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/operations/git.worktree/pull.json
+++ b/tests/operations/git.worktree/pull.json
@@ -10,7 +10,7 @@
             "repo=/home/myworktree": "origin/master"
         },
         "git.GitLocalCommit": {
-            "repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "ref=HEAD, repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         },
         "git.GitRemoteBranchCommit": {
             "branch=master, remote=origin, repo=/home/myworktree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/operations/git.worktree/pull_from_remote_branch.json
+++ b/tests/operations/git.worktree/pull_from_remote_branch.json
@@ -11,6 +11,12 @@
         },
         "git.GitTrackingBranch" : {
             "repo=/home/myworktree": null
+        },
+        "git.GitLocalCommit": {
+            "repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=master, remote=origin, repo=/home/myworktree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         }
     },
     "commands": [

--- a/tests/operations/git.worktree/pull_from_remote_branch.json
+++ b/tests/operations/git.worktree/pull_from_remote_branch.json
@@ -13,7 +13,7 @@
             "repo=/home/myworktree": null
         },
         "git.GitLocalCommit": {
-            "repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "ref=HEAD, repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         },
         "git.GitRemoteBranchCommit": {
             "branch=master, remote=origin, repo=/home/myworktree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/operations/git.worktree/pull_rebase from_remote_branch.json
+++ b/tests/operations/git.worktree/pull_rebase from_remote_branch.json
@@ -12,6 +12,12 @@
         },
         "git.GitTrackingBranch" : {
             "repo=/home/myworktree": null
+        },
+        "git.GitLocalCommit": {
+            "repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=master, remote=origin, repo=/home/myworktree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         }
     },
     "commands": [

--- a/tests/operations/git.worktree/pull_rebase from_remote_branch.json
+++ b/tests/operations/git.worktree/pull_rebase from_remote_branch.json
@@ -14,7 +14,7 @@
             "repo=/home/myworktree": null
         },
         "git.GitLocalCommit": {
-            "repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "ref=HEAD, repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         },
         "git.GitRemoteBranchCommit": {
             "branch=master, remote=origin, repo=/home/myworktree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/operations/git.worktree/pull_rebase.json
+++ b/tests/operations/git.worktree/pull_rebase.json
@@ -13,7 +13,7 @@
             "repo=/home/myworktree": "origin/master"
         },
         "git.GitLocalCommit": {
-            "repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "ref=HEAD, repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         },
         "git.GitRemoteBranchCommit": {
             "branch=master, remote=origin, repo=/home/myworktree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/operations/git.worktree/pull_rebase.json
+++ b/tests/operations/git.worktree/pull_rebase.json
@@ -11,6 +11,12 @@
         },
         "git.GitTrackingBranch" : {
             "repo=/home/myworktree": "origin/master"
+        },
+        "git.GitLocalCommit": {
+            "repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=master, remote=origin, repo=/home/myworktree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         }
     },
     "commands": [

--- a/tests/operations/git.worktree/pull_remote_needs_quotes.json
+++ b/tests/operations/git.worktree/pull_remote_needs_quotes.json
@@ -11,6 +11,12 @@
         },
         "git.GitTrackingBranch": {
             "repo=/home/my worktree; whoami": null
+        },
+        "git.GitLocalCommit": {
+            "repo=/home/my worktree; whoami": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=master; rm -rf /, remote=origin; evil, repo=/home/my worktree; whoami": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         }
     },
     "commands": [

--- a/tests/operations/git.worktree/pull_remote_needs_quotes.json
+++ b/tests/operations/git.worktree/pull_remote_needs_quotes.json
@@ -13,7 +13,7 @@
             "repo=/home/my worktree; whoami": null
         },
         "git.GitLocalCommit": {
-            "repo=/home/my worktree; whoami": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "ref=HEAD, repo=/home/my worktree; whoami": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         },
         "git.GitRemoteBranchCommit": {
             "branch=master; rm -rf /, remote=origin; evil, repo=/home/my worktree; whoami": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/operations/git.worktree/up_to_date.json
+++ b/tests/operations/git.worktree/up_to_date.json
@@ -10,15 +10,12 @@
             "repo=/home/myworktree": "origin/master"
         },
         "git.GitLocalCommit": {
-            "repo=/home/myworktree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "repo=/home/myworktree": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
         },
         "git.GitRemoteBranchCommit": {
-            "branch=master, remote=origin, repo=/home/myworktree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            "branch=master, remote=origin, repo=/home/myworktree": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
         }
     },
-    "commands": [
-        "cd /home/myworktree && git pull"
-    ],
-    "idempotent": false,
-    "disable_idempotent_warning_reason": "git pull is always executed"
+    "commands": [],
+    "noop_description": "git worktree /home/myworktree is already up to date"
 }

--- a/tests/operations/git.worktree/up_to_date.json
+++ b/tests/operations/git.worktree/up_to_date.json
@@ -10,7 +10,7 @@
             "repo=/home/myworktree": "origin/master"
         },
         "git.GitLocalCommit": {
-            "repo=/home/myworktree": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
+            "ref=HEAD, repo=/home/myworktree": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
         },
         "git.GitRemoteBranchCommit": {
             "branch=master, remote=origin, repo=/home/myworktree": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"


### PR DESCRIPTION
Fixes #994.

`git.repo` and `git.worktree` always yielded `git pull`, so pyinfra reported the operation as changed even when git replied "Already up to date". Compare local `HEAD` to the remote branch tip via two new facts (`GitLocalCommit`, `GitRemoteBranchCommit`) and skip the pull when they match.

- [x] Pull request is based on the default branch (`3.x`)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (`scripts/dev-test.sh`)
- [x] Type checking & code style passes (`scripts/dev-lint.sh`)