### PR TITLE
operations.docker: add compose operation

### DIFF
--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -672,7 +672,7 @@ def logout(server: str | None = None):
 
 @operation(is_idempotent=False)
 def compose(
-    src: str,
+    project_directory: str,
     files: str | list[str] | None = None,
     project_name: str | None = None,
     present: bool = True,
@@ -686,15 +686,15 @@ def compose(
     """
     Deploy a Docker Compose stack on the target.
 
-    + src: project directory on the target (maps to ``--project-directory``).
-      Compose discovers ``compose.yaml`` / ``compose.yml`` /
-      ``docker-compose.yaml`` / ``docker-compose.yml`` inside this directory by
-      default.
+    + project_directory: project directory on the target (maps to
+      ``--project-directory``). Compose discovers ``compose.yaml`` /
+      ``compose.yml`` / ``docker-compose.yaml`` / ``docker-compose.yml`` inside
+      this directory by default.
     + files: optional path or list of paths to specific compose file(s) on the
       target (maps to ``-f``); use this to override the default discovery or to
       layer overrides.
     + project_name: compose project name (maps to ``--project-name``; defaults
-      to compose's own default — typically the basename of ``src``)
+      to compose's own default — typically the basename of ``project_directory``)
     + present: ``True`` runs ``up -d``, ``False`` runs ``down``
     + pull: policy for ``up -d --pull`` (``None``, ``"always"``, ``"missing"``, ``"never"``)
     + build: pass ``--build`` on ``up``
@@ -718,7 +718,8 @@ def compose(
         from pyinfra.operations import docker, files
 
         # Upload the compose file then bring the stack up using compose's
-        # default discovery (looks for compose.yaml/docker-compose.yml in src)
+        # default discovery (looks for compose.yaml / docker-compose.yml in
+        # the project directory)
         files.put(
             name="Upload compose file",
             src="files/docker-compose.yml",
@@ -726,7 +727,7 @@ def compose(
         )
         docker.compose(
             name="Deploy app stack",
-            src="/srv/app",
+            project_directory="/srv/app",
             project_name="app",
             _env={"DIR_STORAGE": "/srv/app/data"},
         )
@@ -734,21 +735,21 @@ def compose(
         # Layer a base compose file with an override
         docker.compose(
             name="Deploy app stack with override",
-            src="/srv/app",
+            project_directory="/srv/app",
             files=["docker-compose.yml", "docker-compose.prod.yml"],
         )
 
         # Tear the stack down, including named volumes
         docker.compose(
             name="Remove app stack",
-            src="/srv/app",
+            project_directory="/srv/app",
             project_name="app",
             present=False,
             remove_volumes=True,
         )
     """
-    if not src:
-        raise OperationError("docker.compose requires a project directory via src")
+    if not project_directory:
+        raise OperationError("docker.compose requires a project_directory")
 
     if pull is not None and pull not in ("always", "missing", "never"):
         raise OperationError(
@@ -760,7 +761,7 @@ def compose(
     )
 
     command_bits: list[str | QuoteString] = [compose_command]
-    command_bits.extend(["--project-directory", QuoteString(src)])
+    command_bits.extend(["--project-directory", QuoteString(project_directory)])
     if project_name:
         command_bits.extend(["--project-name", QuoteString(project_name)])
     for compose_file in file_list:

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -558,7 +558,8 @@ def plugin(
 
 @operation(is_idempotent=False)
 def compose(
-    src: str | list[str],
+    src: str,
+    files: str | list[str] | None = None,
     project: str | None = None,
     present: bool = True,
     pull: str | None = None,
@@ -571,8 +572,15 @@ def compose(
     """
     Deploy a Docker Compose stack on the target.
 
-    + src: path (or list of paths) to compose file(s) already present on the target
-    + project: compose project name (maps to ``--project-name``; defaults to compose's own default)
+    + src: project directory on the target (maps to ``--project-directory``).
+      Compose discovers ``compose.yaml`` / ``compose.yml`` /
+      ``docker-compose.yaml`` / ``docker-compose.yml`` inside this directory by
+      default.
+    + files: optional path or list of paths to specific compose file(s) on the
+      target (maps to ``-f``); use this to override the default discovery or to
+      layer overrides.
+    + project: compose project name (maps to ``--project-name``; defaults to
+      compose's own default — typically the basename of ``src``)
     + present: ``True`` runs ``up -d``, ``False`` runs ``down``
     + pull: policy for ``up -d --pull`` (``None``, ``"always"``, ``"missing"``, ``"never"``)
     + build: pass ``--build`` on ``up``
@@ -595,7 +603,8 @@ def compose(
 
         from pyinfra.operations import docker, files
 
-        # Upload the compose file then bring the stack up
+        # Upload the compose file then bring the stack up using compose's
+        # default discovery (looks for compose.yaml/docker-compose.yml in src)
         files.put(
             name="Upload compose file",
             src="files/docker-compose.yml",
@@ -603,34 +612,44 @@ def compose(
         )
         docker.compose(
             name="Deploy app stack",
-            src="/srv/app/docker-compose.yml",
+            src="/srv/app",
             project="app",
             _env={"DIR_STORAGE": "/srv/app/data"},
+        )
+
+        # Layer a base compose file with an override
+        docker.compose(
+            name="Deploy app stack with override",
+            src="/srv/app",
+            files=["docker-compose.yml", "docker-compose.prod.yml"],
         )
 
         # Tear the stack down, including named volumes
         docker.compose(
             name="Remove app stack",
-            src="/srv/app/docker-compose.yml",
+            src="/srv/app",
             project="app",
             present=False,
             remove_volumes=True,
         )
     """
     if not src:
-        raise OperationError("docker.compose requires at least one compose file via src")
+        raise OperationError("docker.compose requires a project directory via src")
 
     if pull is not None and pull not in ("always", "missing", "never"):
         raise OperationError(
             'docker.compose pull must be one of None, "always", "missing", "never"',
         )
 
-    srcs = [src] if isinstance(src, str) else list(src)
+    file_list: list[str] = (
+        [files] if isinstance(files, str) else list(files) if files is not None else []
+    )
 
-    command_bits: list = [compose_command]
+    command_bits: list[str | QuoteString] = [compose_command]
+    command_bits.extend(["--project-directory", QuoteString(src)])
     if project:
         command_bits.extend(["--project-name", QuoteString(project)])
-    for compose_file in srcs:
+    for compose_file in file_list:
         command_bits.extend(["-f", QuoteString(compose_file)])
 
     if present:

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -548,9 +548,9 @@ def plugin(
 @operation(is_idempotent=False)
 def compose(
     src: str | list[str],
-    project: str = "",
+    project: str | None = None,
     present: bool = True,
-    pull: str = "",
+    pull: str | None = None,
     build: bool = False,
     force_recreate: bool = False,
     remove_orphans: bool = True,
@@ -563,7 +563,7 @@ def compose(
     + src: path (or list of paths) to compose file(s) already present on the target
     + project: compose project name (maps to ``--project-name``; defaults to compose's own default)
     + present: ``True`` runs ``up -d``, ``False`` runs ``down``
-    + pull: policy for ``up -d --pull`` (``""``, ``"always"``, ``"missing"``, ``"never"``)
+    + pull: policy for ``up -d --pull`` (``None``, ``"always"``, ``"missing"``, ``"never"``)
     + build: pass ``--build`` on ``up``
     + force_recreate: pass ``--force-recreate`` on ``up``
     + remove_orphans: pass ``--remove-orphans`` on ``up`` / ``down``
@@ -609,9 +609,9 @@ def compose(
     if not src:
         raise OperationError("docker.compose requires at least one compose file via src")
 
-    if pull and pull not in ("always", "missing", "never"):
+    if pull is not None and pull not in ("always", "missing", "never"):
         raise OperationError(
-            'docker.compose pull must be one of "", "always", "missing", "never"',
+            'docker.compose pull must be one of None, "always", "missing", "never"',
         )
 
     srcs = [src] if isinstance(src, str) else list(src)

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -7,7 +7,7 @@ as inventory directly.
 from __future__ import annotations
 
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.docker import (
     DockerContainer,
     DockerImage,
@@ -543,3 +543,100 @@ def plugin(
             command="remove",
             plugin=plugin_name,
         )
+
+
+@operation(is_idempotent=False)
+def compose(
+    src: str | list[str],
+    project: str = "",
+    present: bool = True,
+    pull: str = "",
+    build: bool = False,
+    force_recreate: bool = False,
+    remove_orphans: bool = True,
+    remove_volumes: bool = False,
+    compose_command: str = "docker compose",
+):
+    """
+    Deploy a Docker Compose stack on the target.
+
+    + src: path (or list of paths) to compose file(s) already present on the target
+    + project: compose project name (maps to ``--project-name``; defaults to compose's own default)
+    + present: ``True`` runs ``up -d``, ``False`` runs ``down``
+    + pull: policy for ``up -d --pull`` (``""``, ``"always"``, ``"missing"``, ``"never"``)
+    + build: pass ``--build`` on ``up``
+    + force_recreate: pass ``--force-recreate`` on ``up``
+    + remove_orphans: pass ``--remove-orphans`` on ``up`` / ``down``
+    + remove_volumes: pass ``-v`` on ``down`` (only honored when ``present=False``)
+    + compose_command: compose binary to invoke; use ``"docker-compose"`` for v1
+
+    This operation is not idempotent from pyinfra's perspective: it always shells out
+    to compose. Docker itself skips services whose definition has not changed, so
+    re-runs are safe and cheap.
+
+    ``_env`` and ``_chdir`` are the standard pyinfra global operation kwargs and
+    work here without any special handling, which is useful for compose variable
+    interpolation.
+
+    **Examples:**
+
+    .. code:: python
+
+        from pyinfra.operations import docker, files
+
+        # Upload the compose file then bring the stack up
+        files.put(
+            name="Upload compose file",
+            src="files/docker-compose.yml",
+            dest="/srv/app/docker-compose.yml",
+        )
+        docker.compose(
+            name="Deploy app stack",
+            src="/srv/app/docker-compose.yml",
+            project="app",
+            _env={"DIR_STORAGE": "/srv/app/data"},
+        )
+
+        # Tear the stack down, including named volumes
+        docker.compose(
+            name="Remove app stack",
+            src="/srv/app/docker-compose.yml",
+            project="app",
+            present=False,
+            remove_volumes=True,
+        )
+    """
+    if not src:
+        raise OperationError("docker.compose requires at least one compose file via src")
+
+    if pull and pull not in ("always", "missing", "never"):
+        raise OperationError(
+            'docker.compose pull must be one of "", "always", "missing", "never"',
+        )
+
+    srcs = [src] if isinstance(src, str) else list(src)
+
+    command_bits: list = [compose_command]
+    if project:
+        command_bits.extend(["--project-name", QuoteString(project)])
+    for compose_file in srcs:
+        command_bits.extend(["-f", QuoteString(compose_file)])
+
+    if present:
+        command_bits.append("up -d")
+        if pull:
+            command_bits.extend(["--pull", pull])
+        if build:
+            command_bits.append("--build")
+        if force_recreate:
+            command_bits.append("--force-recreate")
+        if remove_orphans:
+            command_bits.append("--remove-orphans")
+    else:
+        command_bits.append("down")
+        if remove_volumes:
+            command_bits.append("-v")
+        if remove_orphans:
+            command_bits.append("--remove-orphans")
+
+    yield StringCommand(*command_bits)

--- a/tests/operations/docker.compose/compose_down.json
+++ b/tests/operations/docker.compose/compose_down.json
@@ -1,9 +1,9 @@
 {
-    "args": ["/srv/app/docker-compose.yml"],
+    "args": ["/srv/app"],
     "kwargs": {
         "present": false
     },
     "commands": [
-        "docker compose -f /srv/app/docker-compose.yml down --remove-orphans"
+        "docker compose --project-directory /srv/app down --remove-orphans"
     ]
 }

--- a/tests/operations/docker.compose/compose_down.json
+++ b/tests/operations/docker.compose/compose_down.json
@@ -1,0 +1,9 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "present": false
+    },
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml down --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_down_with_volumes.json
+++ b/tests/operations/docker.compose/compose_down_with_volumes.json
@@ -1,10 +1,10 @@
 {
-    "args": ["/srv/app/docker-compose.yml"],
+    "args": ["/srv/app"],
     "kwargs": {
         "present": false,
         "remove_volumes": true
     },
     "commands": [
-        "docker compose -f /srv/app/docker-compose.yml down -v --remove-orphans"
+        "docker compose --project-directory /srv/app down -v --remove-orphans"
     ]
 }

--- a/tests/operations/docker.compose/compose_down_with_volumes.json
+++ b/tests/operations/docker.compose/compose_down_with_volumes.json
@@ -1,0 +1,10 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "present": false,
+        "remove_volumes": true
+    },
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml down -v --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_basic.json
+++ b/tests/operations/docker.compose/compose_up_basic.json
@@ -1,6 +1,6 @@
 {
-    "args": ["/srv/app/docker-compose.yml"],
+    "args": ["/srv/app"],
     "commands": [
-        "docker compose -f /srv/app/docker-compose.yml up -d --remove-orphans"
+        "docker compose --project-directory /srv/app up -d --remove-orphans"
     ]
 }

--- a/tests/operations/docker.compose/compose_up_basic.json
+++ b/tests/operations/docker.compose/compose_up_basic.json
@@ -1,0 +1,6 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml up -d --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_full_flags.json
+++ b/tests/operations/docker.compose/compose_up_full_flags.json
@@ -1,11 +1,11 @@
 {
-    "args": ["/srv/app/docker-compose.yml"],
+    "args": ["/srv/app"],
     "kwargs": {
         "build": true,
         "force_recreate": true,
         "remove_orphans": true
     },
     "commands": [
-        "docker compose -f /srv/app/docker-compose.yml up -d --build --force-recreate --remove-orphans"
+        "docker compose --project-directory /srv/app up -d --build --force-recreate --remove-orphans"
     ]
 }

--- a/tests/operations/docker.compose/compose_up_full_flags.json
+++ b/tests/operations/docker.compose/compose_up_full_flags.json
@@ -1,0 +1,11 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "build": true,
+        "force_recreate": true,
+        "remove_orphans": true
+    },
+    "commands": [
+        "docker compose -f /srv/app/docker-compose.yml up -d --build --force-recreate --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_multi_file.json
+++ b/tests/operations/docker.compose/compose_up_multi_file.json
@@ -1,0 +1,6 @@
+{
+    "args": [["/srv/app/base.yml", "/srv/app/override.yml"]],
+    "commands": [
+        "docker compose -f /srv/app/base.yml -f /srv/app/override.yml up -d --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_multi_file.json
+++ b/tests/operations/docker.compose/compose_up_multi_file.json
@@ -1,6 +1,9 @@
 {
-    "args": [["/srv/app/base.yml", "/srv/app/override.yml"]],
+    "args": ["/srv/app"],
+    "kwargs": {
+        "files": ["docker-compose.yml", "docker-compose.prod.yml"]
+    },
     "commands": [
-        "docker compose -f /srv/app/base.yml -f /srv/app/override.yml up -d --remove-orphans"
+        "docker compose --project-directory /srv/app -f docker-compose.yml -f docker-compose.prod.yml up -d --remove-orphans"
     ]
 }

--- a/tests/operations/docker.compose/compose_up_single_file.json
+++ b/tests/operations/docker.compose/compose_up_single_file.json
@@ -1,0 +1,9 @@
+{
+    "args": ["/srv/app"],
+    "kwargs": {
+        "files": "docker-compose.yml"
+    },
+    "commands": [
+        "docker compose --project-directory /srv/app -f docker-compose.yml up -d --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_with_project_and_pull.json
+++ b/tests/operations/docker.compose/compose_up_with_project_and_pull.json
@@ -1,10 +1,10 @@
 {
-    "args": ["/srv/app/docker-compose.yml"],
+    "args": ["/srv/app"],
     "kwargs": {
         "project": "app",
         "pull": "always"
     },
     "commands": [
-        "docker compose --project-name app -f /srv/app/docker-compose.yml up -d --pull always --remove-orphans"
+        "docker compose --project-directory /srv/app --project-name app up -d --pull always --remove-orphans"
     ]
 }

--- a/tests/operations/docker.compose/compose_up_with_project_and_pull.json
+++ b/tests/operations/docker.compose/compose_up_with_project_and_pull.json
@@ -1,0 +1,10 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "project": "app",
+        "pull": "always"
+    },
+    "commands": [
+        "docker compose --project-name app -f /srv/app/docker-compose.yml up -d --pull always --remove-orphans"
+    ]
+}

--- a/tests/operations/docker.compose/compose_up_with_project_and_pull.json
+++ b/tests/operations/docker.compose/compose_up_with_project_and_pull.json
@@ -1,7 +1,7 @@
 {
     "args": ["/srv/app"],
     "kwargs": {
-        "project": "app",
+        "project_name": "app",
         "pull": "always"
     },
     "commands": [

--- a/tests/operations/docker.compose/compose_v1.json
+++ b/tests/operations/docker.compose/compose_v1.json
@@ -1,9 +1,9 @@
 {
-    "args": ["/srv/app/docker-compose.yml"],
+    "args": ["/srv/app"],
     "kwargs": {
         "compose_command": "docker-compose"
     },
     "commands": [
-        "docker-compose -f /srv/app/docker-compose.yml up -d --remove-orphans"
+        "docker-compose --project-directory /srv/app up -d --remove-orphans"
     ]
 }

--- a/tests/operations/docker.compose/compose_v1.json
+++ b/tests/operations/docker.compose/compose_v1.json
@@ -1,0 +1,9 @@
+{
+    "args": ["/srv/app/docker-compose.yml"],
+    "kwargs": {
+        "compose_command": "docker-compose"
+    },
+    "commands": [
+        "docker-compose -f /srv/app/docker-compose.yml up -d --remove-orphans"
+    ]
+}


### PR DESCRIPTION
## Summary

- Adds `docker.compose` to run `docker compose up -d` / `down` against an on-host compose file.
- Supports `--project-name`, `--pull`, `--build`, `--force-recreate`, `--remove-orphans`, and `-v`.
- Not idempotent from pyinfra's side; Docker's own layer/state handling keeps re-runs cheap.

Split out from #1675 (which supersedes #1674 and #1673).

## Test plan

- [x] Pull request is based on the default branch (`3.x`)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (`scripts/dev-test.sh`)
- [x] Type checking & code style passes (`scripts/dev-lint.sh`)
