### PR TITLE
feat(apt): add purge option to apt.packages (closes #1698)

### DIFF
--- a/src/pyinfra/operations/apt.py
+++ b/src/pyinfra/operations/apt.py
@@ -405,6 +405,7 @@ def packages(
     force=False,
     no_recommends=False,
     allow_downgrades=False,
+    purge=False,
     extra_install_args: str | None = None,
     extra_uninstall_args: str | None = None,
 ):
@@ -420,6 +421,8 @@ def packages(
     + force: whether to force package installs by passing `--force-yes` to apt
     + no_recommends: don't install recommended packages
     + allow_downgrades: allow downgrading packages with version (--allow-downgrades)
+    + purge: when removing packages (``present=False``) use ``apt purge`` so configuration files
+      are removed alongside the package
     + extra_install_args: additional arguments to the apt install command
     + extra_uninstall_args: additional arguments to the apt uninstall command
 
@@ -476,7 +479,7 @@ def packages(
 
     install_command = " ".join(install_command_args)
 
-    uninstall_command_args = ["remove"]
+    uninstall_command_args = ["purge" if purge else "remove"]
     if extra_uninstall_args:
         uninstall_command_args.append(extra_uninstall_args)
 

--- a/tests/operations/apt.packages/purge_packages.yaml
+++ b/tests/operations/apt.packages/purge_packages.yaml
@@ -1,0 +1,12 @@
+args:
+  - - git
+    - python-pip
+kwargs:
+  present: false
+  purge: true
+facts:
+  deb.DebPackages:
+    git: [""]
+    python-pip: [""]
+commands:
+  - 'DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" purge git python-pip'


### PR DESCRIPTION
Closes #1698.

## Summary

Adds a \`purge\` parameter to \`apt.packages\` so callers can remove packages and their config files without dropping to \`server.shell\`. When \`purge=True\` and \`present=False\`, the operation runs \`apt-get purge ...\` instead of \`apt-get remove ...\`.

\`\`\`python
apt.packages(
    name=\"Purge rsyslog (binary + config)\",
    packages=[\"rsyslog\"],
    present=False,
    purge=True,
)
\`\`\`

## Changes

- \`src/pyinfra/operations/apt.py\`: new \`purge=False\` kwarg; \`uninstall_command_args\` switches to \`["purge"]\` when set; docstring updated.
- \`tests/operations/apt.packages/purge_packages.yaml\`: YAML fixture covering \`purge=True\` against two installed packages.

## Verification

- \`uv run pytest tests/test_operations.py -k 'apt.packages' --disable-warnings\` -- 14 / 14 relevant fixtures pass (one pre-existing unrelated \`test_apt_packages_update_cached\` failure reproduces on \`3.x\` without this change).
- \`uv run ruff check src/pyinfra/operations/apt.py\` clean
- \`uv run ruff format --check\` clean
- \`uv run mypy src/pyinfra/operations/apt.py\` clean