### PR TITLE
fix(facts): add semicolons to TmpDir shell script for sh -c compatibility

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -65,13 +65,13 @@ class TmpDir(FactBase):
     def command(self):
         return """
 if [ -n "$TMPDIR" ] && [ -d "$TMPDIR" ] && [ -w "$TMPDIR" ]; then
-    echo "$TMPDIR"
+    echo "$TMPDIR";
 elif [ -n "$TMP" ] && [ -d "$TMP" ] && [ -w "$TMP" ]; then
-    echo "$TMP"
+    echo "$TMP";
 elif [ -n "$TEMP" ] && [ -d "$TEMP" ] && [ -w "$TEMP" ]; then
-    echo "$TEMP"
+    echo "$TEMP";
 else
-    echo ""
+    echo "";
 fi
         """.strip()
 

--- a/tests/facts/server.TmpDir/default_fallback.json
+++ b/tests/facts/server.TmpDir/default_fallback.json
@@ -1,5 +1,5 @@
 {
-    "command": "if [ -n \"$TMPDIR\" ] && [ -d \"$TMPDIR\" ] && [ -w \"$TMPDIR\" ]; then\n    echo \"$TMPDIR\"\nelif [ -n \"$TMP\" ] && [ -d \"$TMP\" ] && [ -w \"$TMP\" ]; then\n    echo \"$TMP\"\nelif [ -n \"$TEMP\" ] && [ -d \"$TEMP\" ] && [ -w \"$TEMP\" ]; then\n    echo \"$TEMP\"\nelse\n    echo \"\"\nfi",
+    "command": "if [ -n \"$TMPDIR\" ] && [ -d \"$TMPDIR\" ] && [ -w \"$TMPDIR\" ]; then\n    echo \"$TMPDIR\";\nelif [ -n \"$TMP\" ] && [ -d \"$TMP\" ] && [ -w \"$TMP\" ]; then\n    echo \"$TMP\";\nelif [ -n \"$TEMP\" ] && [ -d \"$TEMP\" ] && [ -w \"$TEMP\" ]; then\n    echo \"$TEMP\";\nelse\n    echo \"\";\nfi",
     "output": ["/tmp"],
     "fact": "/tmp"
 }

--- a/tests/facts/server.TmpDir/temp_set.json
+++ b/tests/facts/server.TmpDir/temp_set.json
@@ -1,5 +1,5 @@
 {
-    "command": "if [ -n \"$TMPDIR\" ] && [ -d \"$TMPDIR\" ] && [ -w \"$TMPDIR\" ]; then\n    echo \"$TMPDIR\"\nelif [ -n \"$TMP\" ] && [ -d \"$TMP\" ] && [ -w \"$TMP\" ]; then\n    echo \"$TMP\"\nelif [ -n \"$TEMP\" ] && [ -d \"$TEMP\" ] && [ -w \"$TEMP\" ]; then\n    echo \"$TEMP\"\nelse\n    echo \"\"\nfi",
+    "command": "if [ -n \"$TMPDIR\" ] && [ -d \"$TMPDIR\" ] && [ -w \"$TMPDIR\" ]; then\n    echo \"$TMPDIR\";\nelif [ -n \"$TMP\" ] && [ -d \"$TMP\" ] && [ -w \"$TMP\" ]; then\n    echo \"$TMP\";\nelif [ -n \"$TEMP\" ] && [ -d \"$TEMP\" ] && [ -w \"$TEMP\" ]; then\n    echo \"$TEMP\";\nelse\n    echo \"\";\nfi",
     "output": ["/temp"],
     "fact": "/temp"
 }

--- a/tests/facts/server.TmpDir/tmp_set.json
+++ b/tests/facts/server.TmpDir/tmp_set.json
@@ -1,5 +1,5 @@
 {
-    "command": "if [ -n \"$TMPDIR\" ] && [ -d \"$TMPDIR\" ] && [ -w \"$TMPDIR\" ]; then\n    echo \"$TMPDIR\"\nelif [ -n \"$TMP\" ] && [ -d \"$TMP\" ] && [ -w \"$TMP\" ]; then\n    echo \"$TMP\"\nelif [ -n \"$TEMP\" ] && [ -d \"$TEMP\" ] && [ -w \"$TEMP\" ]; then\n    echo \"$TEMP\"\nelse\n    echo \"\"\nfi",
+    "command": "if [ -n \"$TMPDIR\" ] && [ -d \"$TMPDIR\" ] && [ -w \"$TMPDIR\" ]; then\n    echo \"$TMPDIR\";\nelif [ -n \"$TMP\" ] && [ -d \"$TMP\" ] && [ -w \"$TMP\" ]; then\n    echo \"$TMP\";\nelif [ -n \"$TEMP\" ] && [ -d \"$TEMP\" ] && [ -w \"$TEMP\" ]; then\n    echo \"$TEMP\";\nelse\n    echo \"\";\nfi",
     "output": ["/usr/tmp"],
     "fact": "/usr/tmp"
 }

--- a/tests/facts/server.TmpDir/tmpdir_set.json
+++ b/tests/facts/server.TmpDir/tmpdir_set.json
@@ -1,5 +1,5 @@
 {
-    "command": "if [ -n \"$TMPDIR\" ] && [ -d \"$TMPDIR\" ] && [ -w \"$TMPDIR\" ]; then\n    echo \"$TMPDIR\"\nelif [ -n \"$TMP\" ] && [ -d \"$TMP\" ] && [ -w \"$TMP\" ]; then\n    echo \"$TMP\"\nelif [ -n \"$TEMP\" ] && [ -d \"$TEMP\" ] && [ -w \"$TEMP\" ]; then\n    echo \"$TEMP\"\nelse\n    echo \"\"\nfi",
+    "command": "if [ -n \"$TMPDIR\" ] && [ -d \"$TMPDIR\" ] && [ -w \"$TMPDIR\" ]; then\n    echo \"$TMPDIR\";\nelif [ -n \"$TMP\" ] && [ -d \"$TMP\" ] && [ -w \"$TMP\" ]; then\n    echo \"$TMP\";\nelif [ -n \"$TEMP\" ] && [ -d \"$TEMP\" ] && [ -w \"$TEMP\" ]; then\n    echo \"$TEMP\";\nelse\n    echo \"\";\nfi",
     "output": ["/var/tmp"],
     "fact": "/var/tmp"
 }


### PR DESCRIPTION
Fixes #1699

## Problem

The `TmpDir` fact's shell script fails when executed via `sh -c` under sudo with login shell (`sudo -H -n -i sh -c '...'`), producing:

```
sh: 1: Syntax error: "then" unexpected (expecting "fi")
```

This breaks `files.sync` operations when using SSH connector with `_sudo: True` and `_use_sudo_login: True`.

## Root Cause

The shell script in `TmpDir.command()` uses multi-line `if/elif/else` blocks with `echo` statements. When passed to `sh -c`, some shells (particularly under sudo login shell) don't properly treat newlines as statement separators, causing the syntax error.

## Changes

- **File**: `src/pyinfra/facts/server.py`
  - Added semicolons after each `echo` statement in `TmpDir.command()` to ensure proper statement termination:
    - `echo "$TMPDIR"` → `echo "$TMPDIR";`
    - `echo "$TMP"` → `echo "$TMP";`
    - `echo "$TEMP"` → `echo "$TEMP";`
    - `echo ""` → `echo "";`

- **Files**: `tests/facts/server.TmpDir/*.json` (4 files)
  - Updated command fixtures to match the new script output

## Testing

All 4 TmpDir fact tests pass:
```
tests/test_facts.py::server.TmpDir::test_server.TmpDir_default_fallback PASSED
tests/test_facts.py::server.TmpDir::test_server.TmpDir_temp_set PASSED
tests/test_facts.py::server.TmpDir::test_server.TmpDir_tmp_set PASSED
tests/test_facts.py::server.TmpDir::test_server.TmpDir_tmpdir_set PASSED
```