### PR TITLE
fix(operations.server): normalize sysctl value for comparison

### DIFF
--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -506,7 +506,14 @@ def sysctl(
 
     string_value = " ".join(["{0}".format(v) for v in value]) if isinstance(value, list) else value
 
-    value = [try_int(v) for v in value] if isinstance(value, list) else try_int(value)
+    if isinstance(value, list):
+        value = [try_int(v) for v in value]
+        if len(value) == 1:
+            value = value[0]
+    elif isinstance(value, str) and len(value.split()) > 1:
+        value = [try_int(v) for v in value.split()]
+    else:
+        value = try_int(value)
 
     existing_sysctls = host.get_fact(Sysctl, keys=[key])
     existing_value = existing_sysctls.get(key)

--- a/tests/facts/server.Sysctl/sysctl_port_range.json
+++ b/tests/facts/server.Sysctl/sysctl_port_range.json
@@ -1,0 +1,13 @@
+{
+    "command": "sysctl -a 2>/dev/null || true",
+    "output": [
+        "net.ipv4.ip_local_port_range = 1024	65535",
+        "net.ipv4.ip_local_reserved_ports = ",
+        "kern.hostname: example"
+    ],
+    "fact": {
+        "net.ipv4.ip_local_port_range": [1024, 65535],
+        "net.ipv4.ip_local_reserved_ports": "",
+        "kern.hostname": "example"
+    }
+}

--- a/tests/operations/server.sysctl/set_noop_space_separated_list.json
+++ b/tests/operations/server.sysctl/set_noop_space_separated_list.json
@@ -1,0 +1,12 @@
+{
+    "args": ["net.ipv4.ip_local_port_range", [1024, 65535]],
+    "facts": {
+        "server.Sysctl": {
+            "keys=['net.ipv4.ip_local_port_range']": {
+                "net.ipv4.ip_local_port_range": [1024, 65535]
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "sysctl net.ipv4.ip_local_port_range is set to 1024 65535"
+}

--- a/tests/operations/server.sysctl/set_noop_space_separated_string.json
+++ b/tests/operations/server.sysctl/set_noop_space_separated_string.json
@@ -1,0 +1,12 @@
+{
+    "args": ["net.ipv4.ip_local_port_range", "1024 65535"],
+    "facts": {
+        "server.Sysctl": {
+            "keys=['net.ipv4.ip_local_port_range']": {
+                "net.ipv4.ip_local_port_range": [1024, 65535]
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "sysctl net.ipv4.ip_local_port_range is set to 1024 65535"
+}


### PR DESCRIPTION
A space-separated string value (e.g. "1024 65535") was compared against the fact's parsed list (e.g. [1024, 65535]), so the operation always re-ran. Normalize string values containing whitespace into a list of ints, and collapse single-element lists to the bare value, so the comparison matches the fact shape.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
