### PR TITLE
fix(PR template): typo fix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
     Please provide a short description of the proposed change and here's a handy checklist of things
     to make PRs quicker to review and merge.
 
-    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
+    Note that we will not merge new connectors, but instead welcome PRs that link to third party
     connector packages.
 -->
 


### PR DESCRIPTION
I noticed this while working on #1714 😅 

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
