### PR TITLE
fix(gpg.key): use _matches_keyid for full-fingerprint idempotency check

### DIFF
--- a/src/pyinfra/operations/gpg.py
+++ b/src/pyinfra/operations/gpg.py
@@ -341,11 +341,9 @@ def key(
                 # Check if all requested keys already exist
                 all_keys_exist = True
                 for kid in keyids_to_check:
-                    # Remove 0x prefix if present for comparison
                     clean_keyid = kid.replace("0x", "").replace("0X", "").upper()
                     key_exists = any(
-                        clean_keyid in existing_key_id.upper()
-                        or existing_key_id.upper().endswith(clean_keyid)
+                        _matches_keyid(existing_key_id, clean_keyid)
                         for existing_key_id in existing_keys.keys()
                     )
                     if not key_exists:

--- a/tests/operations/gpg.key/keyserver_idempotent_full_fingerprint_vs_long_id.json
+++ b/tests/operations/gpg.key/keyserver_idempotent_full_fingerprint_vs_long_id.json
@@ -1,0 +1,42 @@
+{
+    "args": [],
+    "kwargs": {
+        "keyserver": "hkps://keyserver.ubuntu.com",
+        "keyid": ["9DC858229FC7DD38854AE2D88D81803C0EBFCD88"],
+        "dest": "/etc/apt/keyrings/vendor.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": {
+                "mode": "755",
+                "user": "root",
+                "group": "root"
+            },
+            "path=_tempfile_": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/vendor.gpg": {
+                "mode": "644",
+                "user": "root",
+                "group": "root"
+            }
+        },
+        "gpg.GpgKeyrings": {
+            "directories=['/etc/apt/keyrings']": {
+                "/etc/apt/keyrings/vendor.gpg": {
+                    "format": "gpg",
+                    "keys": {
+                        "8D81803C0EBFCD88": {
+                            "length": 4096,
+                            "uid": "Test Key <test@example.com>"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "commands": [
+        "chmod 644 /etc/apt/keyrings/vendor.gpg"
+    ],
+    "noop_description": "GPG keys ['9DC858229FC7DD38854AE2D88D81803C0EBFCD88'] already exist in /etc/apt/keyrings/vendor.gpg"
+}

--- a/tests/operations/gpg.key/keyserver_idempotent_short_id_vs_long_id.json
+++ b/tests/operations/gpg.key/keyserver_idempotent_short_id_vs_long_id.json
@@ -1,0 +1,42 @@
+{
+    "args": [],
+    "kwargs": {
+        "keyserver": "hkps://keyserver.ubuntu.com",
+        "keyid": ["0x0EBFCD88"],
+        "dest": "/etc/apt/keyrings/vendor.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": {
+                "mode": "755",
+                "user": "root",
+                "group": "root"
+            },
+            "path=_tempfile_": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/vendor.gpg": {
+                "mode": "644",
+                "user": "root",
+                "group": "root"
+            }
+        },
+        "gpg.GpgKeyrings": {
+            "directories=['/etc/apt/keyrings']": {
+                "/etc/apt/keyrings/vendor.gpg": {
+                    "format": "gpg",
+                    "keys": {
+                        "8D81803C0EBFCD88": {
+                            "length": 4096,
+                            "uid": "Test Key <test@example.com>"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "commands": [
+        "chmod 644 /etc/apt/keyrings/vendor.gpg"
+    ],
+    "noop_description": "GPG keys ['0x0EBFCD88'] already exist in /etc/apt/keyrings/vendor.gpg"
+}

--- a/tests/operations/gpg.key/keyserver_single_idempotent_full_fingerprint.json
+++ b/tests/operations/gpg.key/keyserver_single_idempotent_full_fingerprint.json
@@ -1,0 +1,42 @@
+{
+    "args": [],
+    "kwargs": {
+        "keyserver": "hkps://keyserver.ubuntu.com",
+        "keyid": ["9DC858229FC7DD38854AE2D88D81803C0EBFCD88"],
+        "dest": "/etc/apt/keyrings/vendor.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": {
+                "mode": "755",
+                "user": "root",
+                "group": "root"
+            },
+            "path=_tempfile_": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/vendor.gpg": {
+                "mode": "644",
+                "user": "root",
+                "group": "root"
+            }
+        },
+        "gpg.GpgKeyrings": {
+            "directories=['/etc/apt/keyrings']": {
+                "/etc/apt/keyrings/vendor.gpg": {
+                    "format": "gpg",
+                    "keys": {
+                        "3C0EBFCD88": {
+                            "length": 4096,
+                            "uid": "Test Key <test@example.com>"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "commands": [
+        "chmod 644 /etc/apt/keyrings/vendor.gpg"
+    ],
+    "noop_description": "GPG keys ['9DC858229FC7DD38854AE2D88D81803C0EBFCD88'] already exist in /etc/apt/keyrings/vendor.gpg"
+}

--- a/tests/operations/gpg.key/local_file_idempotent_full_fingerprint_vs_long_id.json
+++ b/tests/operations/gpg.key/local_file_idempotent_full_fingerprint_vs_long_id.json
@@ -1,0 +1,41 @@
+{
+    "args": [],
+    "kwargs": {
+        "src": "/tmp/local-key.asc",
+        "keyid": ["9DC858229FC7DD38854AE2D88D81803C0EBFCD88"],
+        "dest": "/etc/apt/keyrings/vendor.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": {
+                "mode": "755",
+                "user": "root",
+                "group": "root"
+            }
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/vendor.gpg": {
+                "mode": "644",
+                "user": "root",
+                "group": "root"
+            }
+        },
+        "gpg.GpgKeyrings": {
+            "directories=['/etc/apt/keyrings']": {
+                "/etc/apt/keyrings/vendor.gpg": {
+                    "format": "gpg",
+                    "keys": {
+                        "8D81803C0EBFCD88": {
+                            "length": 4096,
+                            "uid": "Test Key <test@example.com>"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "commands": [
+        "chmod 644 /etc/apt/keyrings/vendor.gpg"
+    ],
+    "noop_description": "GPG keys ['9DC858229FC7DD38854AE2D88D81803C0EBFCD88'] already exist in /etc/apt/keyrings/vendor.gpg"
+}


### PR DESCRIPTION
When keyid is a full 40-char fingerprint, the previous inline comparison

    clean_keyid in existing_key_id.upper()

failed because `GpgKeyrings` returns short key IDs (8/16 chars) as dict keys — the fingerprint is never a substring of the short ID.

`_matches_keyid()` already handles all cases (short ID, long ID, full fingerprint) via endswith/startswith logic. Use it consistently with `_remove_key_from_keyrings` / `_remove_key_from_keyring`, which were already calling the helper.

### Behavior delta

The old `in` check additionally allowed a "middle substring" match (e.g. `clean_keyid` sitting inside an existing ID). In practice GPG IDs are always suffixes of the fingerprint, so no real keyring is affected, but the match is now strictly anchored (equality / `endswith` / `startswith` on either side).

### Test matrix added

`tests/operations/gpg.key/`:
- `keyserver_single_idempotent_full_fingerprint.json` — full 40-char fingerprint vs existing 10-char short ID (the bug being fixed)
- `keyserver_idempotent_full_fingerprint_vs_long_id.json` — full fingerprint vs existing 16-char long ID (different-length `endswith` case)
- `keyserver_idempotent_short_id_vs_long_id.json` — 8-char short keyid vs existing 16-char long ID (existing path, previously uncovered)
- `local_file_idempotent_full_fingerprint_vs_long_id.json` — same scenario via `src=` instead of `keyserver=` (shared idempotency path)

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
