### PR TITLE
feat: enforce conventional commits standard for commit messages and PR titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
     Please provide a short description of the proposed change and here's a handy checklist of things
     to make PRs quicker to review and merge.
 
-    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
+    Note that we will not merge new connectors, but instead welcome PRs that link to third party
     connector packages.
 -->
 
@@ -13,3 +13,5 @@
 - [ ] Pull request includes documentation for any new/updated operations/facts
 - [ ] Tests pass (see `scripts/dev-test.sh`)
 - [ ] Type checking & code style passes (see `scripts/dev-lint.sh`)
+- [ ] Pull request title follows the 
+      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,33 @@
+name: Lint PR title
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  pr-lint:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@45b9ed7cf24087a2f7785bf55be97394ba87e1c2 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            ci
+            chore
+            docs
+            style
+            refactor
+            test
+          scopes: |
+            api
+            cli
+            operations(\.[A-Za-z0-9.\-]+)?
+            facts(\.[A-Za-z0-9.\-]+)?
+            connectors(\.[A-Za-z0-9.\-]+)?
+          requireScope: false

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@45b9ed7cf24087a2f7785bf55be97394ba87e1c2 # v6
         env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           types: |
             fix

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -48,7 +48,12 @@ scripts/dev-format.sh
 
 ### Commit Messages
 
-Please try to use consistent commit messages, look at the [recent history](https://github.com/pyinfra-dev/pyinfra/commits/) for examples. PRs that follow this will be rebased, PRs that do not will be squashed.
+Coommit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+standard. PRs that follow this will be rebased, PRs that do not will be squashed.
+
+The following scopes are allowed: `api`, `cli`, `operations`, `facts`, `connectors`. With the last 
+three an optional sub-scope can be added, ie `operations.docker` or `facts.apt`.
+
 
 ### Tests
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -48,7 +48,7 @@ scripts/dev-format.sh
 
 ### Commit Messages
 
-Coommit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+Commit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 standard. PRs that follow this will be rebased, PRs that do not will be squashed.
 
 The following scopes are allowed: `api`, `cli`, `operations`, `facts`, `connectors`. With the last 


### PR DESCRIPTION
PR titles default to commit message, which is linted to enforce Conventional Commits standard.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
