### PR TITLE
fix(cli): add --use-sudo-login option

### DIFF
--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -129,6 +129,12 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     default=False,
     help="Whether to use a password with sudo.",
 )
+@click.option(
+    "--use-sudo-login",
+    is_flag=True,
+    default=False,
+    help="Use a login shell when sudo-ing.",
+)
 @click.option("--su-user", help="Which user to su to.")
 @click.option(
     "--dzdo",
@@ -300,6 +306,7 @@ def _main(
     sudo: bool,
     sudo_user: str,
     use_sudo_password: bool,
+    use_sudo_login: bool,
     su_user: str,
     dzdo: bool,
     dzdo_user: str,
@@ -350,6 +357,7 @@ def _main(
         sudo,
         sudo_user,
         use_sudo_password,
+        use_sudo_login,
         same_sudo_password,
         su_user,
         dzdo,
@@ -598,6 +606,7 @@ def _set_config(
     sudo,
     sudo_user,
     use_sudo_password,
+    use_sudo_login,
     same_sudo_password,
     su_user,
     dzdo,
@@ -626,6 +635,9 @@ def _set_config(
 
     if use_sudo_password:
         config.USE_SUDO_PASSWORD = use_sudo_password
+
+    if use_sudo_login:
+        config.USE_SUDO_LOGIN = True
 
     if same_sudo_password:
         config.SUDO_PASSWORD = getpass("sudo password: ")

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -175,6 +175,7 @@ class TestDirectMainExecution(PatchSSHTestCase):
                 sudo=False,
                 sudo_user=None,
                 use_sudo_password=False,
+                use_sudo_login=False,
                 su_user=None,
                 dzdo=False,
                 dzdo_user=None,


### PR DESCRIPTION
Closes #1639

`_use_sudo_login` can be set via `config.py` but was missing a CLI flag, unlike other sudo options (`--sudo`, `--sudo-user`, `--use-sudo-password`).

Adds `--use-sudo-login` flag to the CLI, following the same pattern as existing sudo options.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [ ] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
