### PR TITLE
fix(facts.iptables): requires_command() error in when table specified

### DIFF
--- a/src/pyinfra/facts/iptables.py
+++ b/src/pyinfra/facts/iptables.py
@@ -92,7 +92,7 @@ class IptablesRules(FactBase):
     default = list
 
     @override
-    def requires_command(self) -> str:
+    def requires_command(self, *args, **kwargs) -> str:
         return "iptables-save"
 
     @override

--- a/src/pyinfra/facts/iptables.py
+++ b/src/pyinfra/facts/iptables.py
@@ -125,7 +125,7 @@ class Ip6tablesRules(IptablesRules):
     """
 
     @override
-    def requires_command(self) -> str:
+    def requires_command(self, *args, **kwargs) -> str:
         return "ip6tables-save"
 
     @override
@@ -147,7 +147,7 @@ class IptablesChains(FactBase):
     default = dict
 
     @override
-    def requires_command(self) -> str:
+    def requires_command(self, *args, **kwargs) -> str:
         return "iptables-save"
 
     @override


### PR DESCRIPTION
`command()` supports the `table` argument, but the same args are passed to `requires_command()`, which was throwing an error because it did not expect `table`.

This deploy:
```
iptables.rule(
    name="Masquerade traffic",
    table="nat",
    chain="POSTROUTING",
    source="10.0.0.0/24",
    out_interface="eth0",
    jump="MASQUERADE",
    _sudo=True,
)
```
Would result in this error:
```
TypeError: IptablesRules.requires_command() got an unexpected keyword argument 'table'
```

This change brings the fact in line with others by accepting args and kwargs.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
