### PR TITLE
fix: extra linting rules (#1721) broke the build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,8 @@ jobs:
     strategy:
       matrix:
         os: [macos-26, macos-15, macos-14, windows-2025, windows-2022, ubuntu-24.04, ubuntu-22.04]
-        # Test every OS vs. Python 3.14, and only one for 3.1[012]
+        # Test every OS vs. the default Python version (the newest stable release), and only one for
+        # supported Python versions below that
         python-version: ["3.14"]
         include:
           - os: ubuntu-24.04
@@ -106,7 +107,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - run: uv sync --group test --no-default-groups --python=${{ matrix.python-version }}
@@ -124,7 +125,7 @@ jobs:
         run: git fetch --tags origin
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Install


### PR DESCRIPTION
I didn't notice docs are built in 2 separate Github workflows and only fixed one. This PR fixes the second.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
