### PR TITLE
fix(operations): handle output from the 'uutils' version of stat (eg. recent Ubuntu)

### DIFF
--- a/src/pyinfra/facts/files.py
+++ b/src/pyinfra/facts/files.py
@@ -67,6 +67,21 @@ CHAR_TO_PERMISSION = (
 )
 
 
+def _unquote_stat_name(name: str) -> str:
+    """
+    Strip the quoting `stat %N` (or `ls -ld`) wraps a path in:
+    'name' (GNU coreutils), `name' (older GNU/RHEL 6), or "name" (uutils-coreutils).
+    """
+    for opener, closer in (("'", "'"), ("`", "'"), ('"', '"')):
+        if (
+            len(name) >= len(opener) + len(closer)
+            and name.startswith(opener)
+            and name.endswith(closer)
+        ):
+            return name[len(opener) : -len(closer)]
+    return name
+
+
 def _parse_mode(mode: str) -> int:
     """
     Converts ls mode output (rwxrwxrwx) -> octal permission integer (755).
@@ -187,7 +202,7 @@ def _parse_ls_output(output: str) -> tuple[FileDict, str] | None:
     # Handle symbolic links
     if path_type == "link" and " -> " in path:
         filename, target = path.split(" -> ", 1)
-        data["link_target"] = target.strip("'").lstrip("`")
+        data["link_target"] = _unquote_stat_name(target)
 
     return data, path_type
 
@@ -270,7 +285,7 @@ class File(FactBase[Union[FileDict, Literal[False], None]]):
             if path_type == "link":
                 filename = match.group(8)
                 filename, target = filename.split(" -> ")
-                data["link_target"] = target.strip("'").lstrip("`")
+                data["link_target"] = _unquote_stat_name(target)
 
             return data
 

--- a/tests/facts/files.Link/valid_uutils.json
+++ b/tests/facts/files.Link/valid_uutils.json
@@ -1,0 +1,17 @@
+{
+    "arg": "/home/pyinfra/mylink",
+    "command": "! (test -e /home/pyinfra/mylink || test -L /home/pyinfra/mylink ) || ( stat -c 'user=%U group=%G mode=%A atime=%X mtime=%Y ctime=%Z size=%s %N' /home/pyinfra/mylink 2> /dev/null || stat -f 'user=%Su group=%Sg mode=%Sp atime=%a mtime=%m ctime=%c size=%z %N%SY' /home/pyinfra/mylink || ls -ld /home/pyinfra/mylink )",
+    "output": [
+        "user=pyinfra group=pyinfra mode=lrwxrwxrwx atime=1594804774 mtime=1594804770 ctime=0 size=8 \"/home/pyinfra/mylink\" -> \"file.txt\""
+    ],
+    "fact": {
+        "group": "pyinfra",
+        "user": "pyinfra",
+        "mode": 777,
+        "link_target": "file.txt",
+        "atime": "2020-07-15T09:19:34",
+        "mtime": "2020-07-15T09:19:30",
+        "ctime": "1970-01-01T00:00:00",
+        "size": 8
+    }
+}


### PR DESCRIPTION
<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

On systems with the "uutils" version of the "stat" utility (eg. recent Ubuntu), the output is quoted differently, which breaks file-stat checks and leads to unnecessary changes to files. This fixes that by recognizing different styles of quoting.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`) - modulo what seems to be a pre-existing failure in apt.packages.test_apt_packages_update_cached
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
