### PR TITLE
feat: Add server.Uptime fact

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -107,6 +107,27 @@ class KernelVersion(FactBase):
         return "uname -r"
 
 
+class Uptime(FactBase[int]):
+    """
+    Returns the number of seconds the system has been up.
+    """
+
+    @override
+    def command(self) -> str:
+        self._kernel = host.get_fact(Kernel)
+        if self._kernel in ("Darwin", "FreeBSD"):
+            return "date +%s; sysctl -n kern.boottime | awk '{print $4}' | tr -d ','"
+
+        return "cut -d. -f1 /proc/uptime"
+
+    @override
+    def process(self, output: list[str]) -> int:
+        if self._kernel in ("Darwin", "FreeBSD"):
+            return int(output[0]) - int(output[1])
+
+        return int(output[0])
+
+
 # Deprecated/renamed -> Kernel
 class Os(FactBase[str]):
     """

--- a/tests/facts/server.Uptime/uptime_linux.json
+++ b/tests/facts/server.Uptime/uptime_linux.json
@@ -1,0 +1,8 @@
+{
+    "command": "cut -d. -f1 /proc/uptime",
+    "facts": {
+        "server.Kernel": "Linux"
+    },
+    "output": ["86400"],
+    "fact": 86400
+}

--- a/tests/facts/server.Uptime/uptime_macos.json
+++ b/tests/facts/server.Uptime/uptime_macos.json
@@ -1,0 +1,8 @@
+{
+    "command": "date +%s; sysctl -n kern.boottime | awk '{print $4}' | tr -d ','",
+    "facts": {
+        "server.Kernel": "Darwin"
+    },
+    "output": ["1746748800", "1746662400"],
+    "fact": 86400
+}


### PR DESCRIPTION
This PR adds the `server.Uptime` fact.

#1708 for reference.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
