### PR TITLE
fix(operations.server): handle OpenBSD useradd properly

### DIFF
--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -996,9 +996,8 @@ def user(
 
         if create_home:
             args.append("-m")
-        elif os_type != "FreeBSD":
-            if os_type != "OpenBSD":
-                args.append("-M")
+        elif os_type not in ("FreeBSD", "OpenBSD"):
+            args.append("-M")
 
         if password and os_type != "FreeBSD":
             args.extend(["-p", QuoteString(password)])

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -996,8 +996,9 @@ def user(
 
         if create_home:
             args.append("-m")
-        elif os_type not in {"FreeBSD", "OpenBSD"}:
-            args.append("-M")
+        elif os_type != "FreeBSD":
+            if os_type != "OpenBSD":
+                args.append("-M")
 
         if password and os_type != "FreeBSD":
             args.extend(["-p", QuoteString(password)])

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -996,7 +996,7 @@ def user(
 
         if create_home:
             args.append("-m")
-        elif os_type != "FreeBSD":
+        elif os_type not in {"FreeBSD", "OpenBSD"}:
             args.append("-M")
 
         if password and os_type != "FreeBSD":

--- a/tests/operations/server.user/add_create_home_skeleton_openbsd.json
+++ b/tests/operations/server.user/add_create_home_skeleton_openbsd.json
@@ -1,0 +1,20 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "home": "homedir",
+        "create_home": true,
+        "ensure_home": true
+    },
+    "facts": {
+        "server.Os": "OpenBSD",
+        "server.Users": {},
+        "server.Groups": {},
+        "server.Which": {
+            "command=useradd": "/usr/sbin/useradd"
+        },
+        "files.Directory": {
+            "path=homedir": null
+        }
+    },
+    "commands": ["useradd -d homedir -m someuser", "mkdir -p homedir", "chown someuser:someuser homedir"]
+}

--- a/tests/operations/server.user/add_no_create_home_skeleton_openbsd.json
+++ b/tests/operations/server.user/add_no_create_home_skeleton_openbsd.json
@@ -1,0 +1,20 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "home": "homedir",
+        "create_home": false,
+        "ensure_home": true
+    },
+    "facts": {
+        "server.Os": "OpenBSD",
+        "server.Users": {},
+        "server.Groups": {},
+        "server.Which": {
+            "command=useradd": "/usr/sbin/useradd"
+        },
+        "files.Directory": {
+            "path=homedir": null
+        }
+    },
+    "commands": ["useradd -d homedir someuser", "mkdir -p homedir", "chown someuser:someuser homedir"]
+}


### PR DESCRIPTION
calling the `server.user` operation with `create_home=False` causes `useradd` to exit on OpenBSD as the binary does not support the `-M` flag. According to the manual page, the home directory is not created unless `-m` flag is present; no funky stuff like `/etc/login.defs` as far as I can tell. See https://man.openbsd.org/useradd and #1004

- [x] Pull request is based on the default branch (`3.x` at this time)
- [ ] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [ ] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

