### PR TITLE
fix(operations.docker.volume): use docker volume rm to delete volumes

### DIFF
--- a/src/pyinfra/operations/util/docker.py
+++ b/src/pyinfra/operations/util/docker.py
@@ -319,7 +319,7 @@ def _create_volume(**kwargs):
 
 
 def _remove_volume(**kwargs):
-    return f"docker image rm {kwargs['volume']}"
+    return f"docker volume rm {kwargs['volume']}"
 
 
 def _create_network(**kwargs):

--- a/tests/operations/docker.prune/prune_all_and_volumes.json
+++ b/tests/operations/docker.prune/prune_all_and_volumes.json
@@ -1,0 +1,9 @@
+{
+    "kwargs": {
+        "all": true,
+        "volumes": true
+    },
+    "commands": [
+        "docker system prune -a --volumes -f"
+    ]
+}

--- a/tests/operations/docker.prune/prune_default.json
+++ b/tests/operations/docker.prune/prune_default.json
@@ -1,0 +1,6 @@
+{
+    "kwargs": {},
+    "commands": [
+        "docker system prune -f"
+    ]
+}

--- a/tests/operations/docker.prune/prune_with_filter.json
+++ b/tests/operations/docker.prune/prune_with_filter.json
@@ -1,0 +1,8 @@
+{
+    "kwargs": {
+        "filter": "until=2160h"
+    },
+    "commands": [
+        "docker system prune --filter=until=2160h -f"
+    ]
+}

--- a/tests/operations/docker.volume/remove_volume.json
+++ b/tests/operations/docker.volume/remove_volume.json
@@ -1,0 +1,17 @@
+{
+    "kwargs": {
+        "volume": "nginx_volume",
+        "present": false
+    },
+    "facts": {
+        "docker.DockerVolume": {
+            "object_id=nginx_volume": {
+                "Name": "nginx_volume",
+                "Driver": "local"
+            }
+        }
+    },
+    "commands": [
+        "docker volume rm nginx_volume"
+    ]
+}


### PR DESCRIPTION
## Summary

- `docker.volume(present=False)` failed with `Error: No such image: <name>` because the remove path called `docker image rm` instead of `docker volume rm`.
- Add a `remove_volume` fixture so the path is exercised.
- Add fixtures for `docker.prune` (default, `all`/`volumes`, `filter`), which previously had no fixture directory at all.

Fixes #1738


## Requirements

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)