### PR TITLE
chore: allow paramiko 5.0.0 to avoid CVE-2026-44405

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license-files = ["LICENSE.md"]
 requires-python = ">=3.10,<4.0"
 dependencies = [
     "gevent>=1.5",
-    "paramiko>=2.11,<5", # 2.11 (2022) adds Transport.open_channel(timeout=...) for ProxyJump timeout (#971)
+    "paramiko>=2.11,<6", # 2.11 (2022) adds Transport.open_channel(timeout=...) for ProxyJump timeout (#971)
     "click>2",
     "jinja2>3,<4",
     "python-dateutil>2,<3",
@@ -22,7 +22,7 @@ dependencies = [
     "packaging>=16.1",
     "pydantic>=2.11,<3",
     "typing-extensions; python_version < '3.11'", # Backport of typing for Unpack (added 3.11)
-    "types-paramiko>=2.7,<5",
+    "types-paramiko>=2.7,<6",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1323,11 +1323,11 @@ requires-dist = [
     { name = "gevent", specifier = ">=1.5" },
     { name = "jinja2", specifier = ">3,<4" },
     { name = "packaging", specifier = ">=16.1" },
-    { name = "paramiko", specifier = ">=2.11,<5" },
+    { name = "paramiko", specifier = ">=2.11,<6" },
     { name = "pydantic", specifier = ">=2.11,<3" },
     { name = "python-dateutil", specifier = ">2,<3" },
     { name = "typeguard", specifier = ">=4,<5" },
-    { name = "types-paramiko", specifier = ">=2.7,<5" },
+    { name = "types-paramiko", specifier = ">=2.7,<6" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 


### PR DESCRIPTION
Solves https://github.com/pyinfra-dev/pyinfra/issues/1742
- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
