### PR TITLE
feat: Add `fetch_tags` flag to `git.repo`

### DIFF
--- a/src/pyinfra/operations/git.py
+++ b/src/pyinfra/operations/git.py
@@ -93,14 +93,16 @@ def repo(
     src: str,
     dest: str,
     branch: str | None = None,
-    pull=True,
-    rebase=False,
+    pull: bool = True,
+    rebase: bool = False,
     user: str | None = None,
     group: str | None = None,
-    ssh_keyscan=False,
-    update_submodules=False,
-    recursive_submodules=False,
+    ssh_keyscan: bool = False,
+    update_submodules: bool = False,
+    recursive_submodules: bool = False,
     depth: int | None = None,
+    *,
+    fetch_tags: bool = False,
 ):
     """
     Clone/pull git repositories.
@@ -116,6 +118,7 @@ def repo(
     + update_submodules: update any git submodules
     + recursive_submodules: update git submodules recursively
     + depth: create a shallow clone with a history truncated to the specified number of commits
+    + fetch_tags: Whether all tags should be fetched prior to attempting to check out the specified revision
 
     **Example:**
 
@@ -163,7 +166,12 @@ def repo(
         is_tag = False
         current_branch = host.get_fact(GitBranch, repo=dest)
         if branch is not None and current_branch != branch:
-            git_commands.append("fetch")  # fetch to ensure we have the branch locally
+            # fetch to ensure we have the branch/tag locally
+            if fetch_tags:
+                git_commands.append(StringCommand("fetch", "--tags"))
+            else:
+                git_commands.append(StringCommand("fetch"))
+
             git_commands.append(StringCommand("checkout", QuoteString(branch)))
         if branch and branch in (host.get_fact(GitTag, repo=dest) or []):
             git_commands.append(StringCommand("checkout", QuoteString(branch)))

--- a/tests/operations/git.repo/branch_pull.json
+++ b/tests/operations/git.repo/branch_pull.json
@@ -1,7 +1,8 @@
 {
     "args": ["myrepo", "/home/myrepo"],
     "kwargs": {
-        "branch": "mybranch"
+        "branch": "mybranch",
+        "fetch_tags": true
     },
     "facts": {
         "files.Directory": {
@@ -25,7 +26,7 @@
         }
     },
     "commands": [
-        "cd /home/myrepo && git fetch",
+        "cd /home/myrepo && git fetch --tags",
         "cd /home/myrepo && git checkout mybranch",
         "cd /home/myrepo && git pull"
     ],


### PR DESCRIPTION
In my use case, I have an existing git repository that I would like to update to a tag that does not yet exist in the local checkout. Right now this fails because `git fetch` does not pick up new tags, and the `GitTag` fact check fails to realize the new revision is a tag (since it doesn't exist). Using `git fetch --tags` makes sure that the tag is there before its existence is checked.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`) (
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
