### PR TITLE
fix(cli): keep trying module candidates when attribute is missing

### DIFF
--- a/src/pyinfra_cli/util.py
+++ b/src/pyinfra_cli/util.py
@@ -167,7 +167,7 @@ def try_import_module_attribute(path, prefix=None, raise_for_none=True):
     if prefix:
         possible_modules.append(f"{prefix}.{mod_path}")
 
-    module = None
+    any_module_found = False
 
     for possible in possible_modules:
         try:
@@ -182,23 +182,26 @@ def try_import_module_attribute(path, prefix=None, raise_for_none=True):
             # referenced above the find_spec call.
             logger.warning(f"Exception raised during inventory search on: {possible}: {e}")
             continue
-        else:
-            if spec is not None:
-                module = import_module(possible)
-                break
 
-    if module is None:
-        if raise_for_none:
-            raise CliError(f"No such module: {possible_modules[0]}")
+        if spec is None:
+            continue
+
+        any_module_found = True
+        candidate = import_module(possible)
+        # A bare module name may shadow a prefixed pyinfra fact/operation (eg. an
+        # installed `pip` package vs. `pyinfra.facts.pip`); keep trying remaining
+        # candidates when the attribute is missing rather than short-circuiting.
+        attr = getattr(candidate, attr_name, None)
+        if attr is not None:
+            return attr
+
+    if not raise_for_none:
         return
 
-    attr = getattr(module, attr_name, None)
-    if attr is None:
-        if raise_for_none:
-            raise CliError(f"No such attribute in module {possible_modules[0]}: {attr_name}")
-        return
+    if not any_module_found:
+        raise CliError(f"No such module: {possible_modules[0]}")
 
-    return attr
+    raise CliError(f"No such attribute in module {possible_modules[0]}: {attr_name}")
 
 
 def _parallel_load_hosts(state: State, callback: Callable, name: str):

--- a/tests/test_cli/test_cli_util.py
+++ b/tests/test_cli/test_cli_util.py
@@ -9,7 +9,7 @@ import pytest
 from pyinfra.operations import server
 from pyinfra_cli.commands import get_func_and_args
 from pyinfra_cli.exceptions import CliError
-from pyinfra_cli.util import json_encode
+from pyinfra_cli.util import json_encode, try_import_module_attribute
 
 
 class TestCliUtil(TestCase):
@@ -83,3 +83,22 @@ def test_user_op(user_sys_path):
     import test_ops
 
     assert res == (test_ops.dummy_op, (["arg1", "arg2"], {}))
+
+
+def test_try_import_module_attribute_falls_through_when_attr_missing(monkeypatch, tmp_path):
+    # Regression for pyinfra-dev/pyinfra#1747: when a top-level module that
+    # collides with a pyinfra fact/operation is importable but lacks the
+    # requested attribute, the bare candidate must not short-circuit the
+    # prefixed candidate.
+    stub_pip = tmp_path / "pip"
+    stub_pip.mkdir()
+    (stub_pip / "__init__.py").write_text("")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, "pip", raising=False)
+
+    from pyinfra.facts.pip import Pip3Packages
+
+    result = try_import_module_attribute("pip.Pip3Packages", prefix="pyinfra.facts")
+
+    assert result is Pip3Packages


### PR DESCRIPTION
## Summary

`try_import_module_attribute` short-circuited at the first module whose `find_spec` resolved, even when that module did not expose the requested attribute. When the installed `pip` package was importable in the same environment (eg. any `uv venv --seed` setup), looking up `pip.Pip3Packages` therefore imported the real `pip` and raised without ever trying `pyinfra.facts.pip`.

This change iterates every candidate and returns the first whose `getattr` succeeds. The "no such module" vs. "no such attribute" error messages keep their current contract.

Fixes #1747

## Test plan

- [x] Added `test_try_import_module_attribute_falls_through_when_attr_missing` in `tests/test_cli/test_cli_util.py`. It drops an empty `pip` stub at the front of `sys.path` and asserts `try_import_module_attribute("pip.Pip3Packages", prefix="pyinfra.facts") is Pip3Packages`. Confirmed it fails on `3.x` with the exact symptom from the issue.
- [x] `uv run pytest tests/test_cli/` (49 passed, including the existing `test_setup_no_module` / `test_setup_no_op` coverage of both error messages)
- [x] `scripts/dev-lint.sh` (ruff, ruff format, mypy, arguments sync)

## Requirements

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
