### PR TITLE
feat(connectors.ssh): auto-load OpenSSH user certificates from ssh_config

### DIFF
--- a/src/pyinfra/connectors/ssh_util.py
+++ b/src/pyinfra/connectors/ssh_util.py
@@ -64,48 +64,81 @@ def _load_private_key_file(filename: str, key_filename: str, key_password: str):
     raise exception
 
 
-def get_private_key(state: "State", key_filename: str, key_password: str) -> PKey:
-    if key_filename in state.private_keys:
-        return state.private_keys[key_filename]
+def _resolve_key_paths(key_filename: str, cwd: str | None = None) -> list[str]:
+    candidates = [path.expanduser(key_filename)]
+    if cwd:
+        candidates.append(path.join(cwd, path.expanduser(key_filename)))
+    return candidates
 
-    ssh_key_filenames = [
-        # Global from executed directory
-        path.expanduser(key_filename),
-    ]
 
-    if state.cwd:
-        # Relative to the CWD
-        path.join(state.cwd, key_filename)
+def load_key_with_certificate(
+    key_filename: str,
+    key_password: str | None = None,
+    certificate_filename: str | None = None,
+    cwd: str | None = None,
+) -> PKey:
+    """
+    Load a paramiko ``PKey`` from disk and attach an OpenSSH certificate when one
+    is available. Has no dependency on pyinfra state so it can be reused both
+    from the CLI key path (via :func:`get_private_key`) and from the ssh_config
+    path in :mod:`pyinfra.connectors.sshuserclient`.
 
-    key = None
+    + key_filename: path to the private key (``~`` is expanded).
+    + key_password: passphrase if the key is encrypted, otherwise empty.
+    + certificate_filename: explicit certificate path (eg. from an ssh_config
+      ``CertificateFile`` directive). When unset, the adjacent
+      ``<key>-cert.pub`` is used if present, falling back to ``<key>.pub``.
+    + cwd: optional working directory used to resolve relative key paths.
+    """
+
+    resolved_path: str | None = None
+    key: PKey | None = None
     key_file_exists = False
 
-    for filename in ssh_key_filenames:
-        if not path.isfile(filename):
+    for candidate in _resolve_key_paths(key_filename, cwd):
+        if not path.isfile(candidate):
             continue
-
         key_file_exists = True
-
         try:
-            key = _load_private_key_file(filename, key_filename, key_password)
+            key = _load_private_key_file(candidate, key_filename, key_password or "")
+            resolved_path = candidate
             break
         except SSHException:
             pass
 
-    # No break, so no key found
-    if not key:
+    if key is None or resolved_path is None:
         if not key_file_exists:
             raise PyinfraError(f"No such private key file: {key_filename}")
         raise PyinfraError(f"Invalid private key file: {key_filename}")
 
-    # Load any certificate, names from OpenSSH:
+    # OpenSSH certificate name (eg. ``id_ed25519-cert.pub``):
     # https://github.com/openssh/openssh-portable/blob/049297de975b92adcc2db77e3fb7046c0e3c695d/ssh-keygen.c#L2453  # noqa: E501
-    for certificate_filename in (
-        f"{key_filename}-cert.pub",
-        f"{key_filename}.pub",
-    ):
-        if path.isfile(certificate_filename):
-            key.load_certificate(certificate_filename)
+    # Anchor the implicit search on the path the key actually loaded from so
+    # ``~/...`` and other relative inputs resolve consistently. ``<key>.pub``
+    # is intentionally skipped: it is the bare public key, not a certificate,
+    # and ``load_certificate`` overwrites any previously-attached cert with a
+    # non-cert public blob.
+    if certificate_filename is not None:
+        expanded_cert = path.expanduser(certificate_filename)
+        if path.isfile(expanded_cert):
+            key.load_certificate(expanded_cert)
+    else:
+        implicit_cert = f"{resolved_path}-cert.pub"
+        if path.isfile(implicit_cert):
+            key.load_certificate(implicit_cert)
+
+    return key
+
+
+def get_private_key(state: "State", key_filename: str, key_password: str) -> PKey:
+    if key_filename in state.private_keys:
+        return state.private_keys[key_filename]
+
+    key = load_key_with_certificate(
+        key_filename=key_filename,
+        key_password=key_password,
+        cwd=state.cwd,
+    )
 
     state.private_keys[key_filename] = key
     return key

--- a/src/pyinfra/connectors/sshuserclient/client.py
+++ b/src/pyinfra/connectors/sshuserclient/client.py
@@ -19,7 +19,9 @@ from paramiko.hostkeys import HostKeyEntry
 from typing_extensions import override
 
 from pyinfra import logger
+from pyinfra.api.exceptions import PyinfraError
 from pyinfra.api.util import memoize
+from pyinfra.connectors.ssh_util import load_key_with_certificate
 
 from .config import SSHConfig
 
@@ -90,6 +92,41 @@ class WarningPolicy(MissingHostKeyPolicy):
     @override
     def missing_host_key(self, client, hostname, key):
         logger.warning("No host key for %s found in known_hosts", hostname)
+
+
+def _attach_identity_with_certificate(cfg: dict, host_config: dict) -> None:
+    """
+    Replace ``cfg["key_filename"]`` with a pre-built ``pkey`` when an ssh_config
+    ``IdentityFile`` exists on disk. Honours ``CertificateFile`` directives and
+    falls back to the implicit ``<key>-cert.pub`` lookup so OpenSSH-style CA
+    auth works without explicit pyinfra ``ssh_key`` configuration (issue #1569).
+    Silent fall-through when no identity exists keeps the legacy paramiko
+    ``key_filename`` flow for missing or otherwise unloadable files.
+    """
+
+    identity_files = host_config.get("identityfile") or []
+    if isinstance(identity_files, str):
+        identity_files = [identity_files]
+
+    certificate_files = host_config.get("certificatefile") or []
+    if isinstance(certificate_files, str):
+        certificate_files = [certificate_files]
+    certificate_filename = certificate_files[0] if certificate_files else None
+
+    for identity_file in identity_files:
+        expanded = path.expanduser(identity_file)
+        if not path.isfile(expanded):
+            continue
+        try:
+            cfg["pkey"] = load_key_with_certificate(
+                key_filename=identity_file,
+                certificate_filename=certificate_filename,
+            )
+        except (PyinfraError, SSHException, OSError) as e:
+            logger.debug("Could not load identity %s with certificate: %s", identity_file, e)
+            continue
+        cfg.pop("key_filename", None)
+        return
 
 
 def get_missing_host_key_policy(policy):
@@ -279,6 +316,7 @@ class SSHClient(ParamikoClient):
 
         if "identityfile" in host_config:
             cfg["key_filename"] = host_config["identityfile"]
+            _attach_identity_with_certificate(cfg, host_config)
 
         if "port" in host_config:
             cfg["port"] = int(host_config["port"])

--- a/tests/test_connectors/conftest.py
+++ b/tests/test_connectors/conftest.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def ssh_ca_keypair(tmp_path_factory) -> dict[str, Path]:
+    if shutil.which("ssh-keygen") is None:
+        pytest.skip("ssh-keygen not available on PATH")
+
+    ssh_dir = tmp_path_factory.mktemp("ssh")
+    ca_key = ssh_dir / "ca"
+    user_key = ssh_dir / "user_ed25519"
+    user_cert = ssh_dir / "user_ed25519-cert.pub"
+
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(ca_key), "-C", "test-ca"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(user_key), "-C", "test-user"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "ssh-keygen",
+            "-s",
+            str(ca_key),
+            "-I",
+            "test-user",
+            "-n",
+            "testuser",
+            "-V",
+            "+1h",
+            str(user_key) + ".pub",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    assert user_cert.is_file(), "ssh-keygen did not produce the expected certificate"
+
+    return {
+        "ca_key": ca_key,
+        "user_key": user_key,
+        "user_cert": user_cert,
+        "ssh_dir": ssh_dir,
+    }

--- a/tests/test_connectors/test_ssh.py
+++ b/tests/test_connectors/test_ssh.py
@@ -92,7 +92,7 @@ class TestSSHConnector(TestCase):
             # Check the key was created properly
             fake_key_open.assert_called_with(filename="testkey")
             # Check the certificate file was then loaded
-            fake_key.load_certificate.assert_called_with("testkey.pub")
+            fake_key.load_certificate.assert_called_with("testkey-cert.pub")
 
             # And check the Paramiko SSH call was correct
             self.fake_connect_mock.assert_called_with(
@@ -239,7 +239,7 @@ class TestSSHConnector(TestCase):
             # Check the key was created properly
             fake_key_open.assert_called_with(filename="testkey", password="testpass")
             # Check the certificate file was then loaded
-            fake_key.load_certificate.assert_called_with("testkey.pub")
+            fake_key.load_certificate.assert_called_with("testkey-cert.pub")
 
     def test_connect_with_rsa_ssh_key_password_from_prompt(self):
         state = State(make_inventory(hosts=(("somehost", {"ssh_key": "testkey"}),)), Config())
@@ -270,7 +270,7 @@ class TestSSHConnector(TestCase):
             # Check the key was created properly
             fake_key_open.assert_called_with(filename="testkey", password="testpass")
             # Check the certificate file was then loaded
-            fake_key.load_certificate.assert_called_with("testkey.pub")
+            fake_key.load_certificate.assert_called_with("testkey-cert.pub")
 
     def test_connect_with_rsa_ssh_key_missing_password(self):
         state = State(make_inventory(hosts=(("somehost", {"ssh_key": "testkey"}),)), Config())

--- a/tests/test_connectors/test_ssh_util.py
+++ b/tests/test_connectors/test_ssh_util.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from pyinfra.connectors.ssh_util import get_private_key, load_key_with_certificate
+
+CERT_KEY_TYPE = "ssh-ed25519-cert-v01@openssh.com"
+
+
+def test_load_key_with_certificate_attaches_adjacent_cert(ssh_ca_keypair):
+    key = load_key_with_certificate(str(ssh_ca_keypair["user_key"]))
+
+    assert key.public_blob is not None
+    assert key.public_blob.key_type == CERT_KEY_TYPE
+
+
+def test_load_key_with_certificate_honours_explicit_cert(ssh_ca_keypair, tmp_path):
+    other_cert = tmp_path / "elsewhere-cert.pub"
+    other_cert.write_bytes(ssh_ca_keypair["user_cert"].read_bytes())
+
+    key = load_key_with_certificate(
+        str(ssh_ca_keypair["user_key"]),
+        certificate_filename=str(other_cert),
+    )
+
+    assert key.public_blob is not None
+    assert key.public_blob.key_type == CERT_KEY_TYPE
+
+
+def test_load_key_with_certificate_no_cert_returns_bare_key(ssh_ca_keypair, tmp_path):
+    # Same private key copied to a directory without an adjacent -cert.pub.
+    bare = tmp_path / "bare_ed25519"
+    bare.write_bytes(ssh_ca_keypair["user_key"].read_bytes())
+
+    key = load_key_with_certificate(str(bare))
+
+    assert key.public_blob is None
+
+
+def test_get_private_key_expands_tilde_for_cert(ssh_ca_keypair, monkeypatch):
+    # Regression: get_private_key used the unexpanded key_filename when looking
+    # for the adjacent cert, silently dropping certs for ~-prefixed paths.
+    monkeypatch.setenv("HOME", str(ssh_ca_keypair["ssh_dir"]))
+
+    state = mock.MagicMock(cwd=None, private_keys={})
+
+    key = get_private_key(
+        state,
+        key_filename="~/" + ssh_ca_keypair["user_key"].name,
+        key_password="",
+    )
+
+    assert key.public_blob is not None
+    assert key.public_blob.key_type == CERT_KEY_TYPE
+
+
+def test_load_key_with_certificate_missing_key_raises(tmp_path):
+    with pytest.raises(Exception):
+        load_key_with_certificate(str(tmp_path / "nope"))

--- a/tests/test_connectors/test_ssh_util.py
+++ b/tests/test_connectors/test_ssh_util.py
@@ -42,7 +42,10 @@ def test_load_key_with_certificate_no_cert_returns_bare_key(ssh_ca_keypair, tmp_
 def test_get_private_key_expands_tilde_for_cert(ssh_ca_keypair, monkeypatch):
     # Regression: get_private_key used the unexpanded key_filename when looking
     # for the adjacent cert, silently dropping certs for ~-prefixed paths.
-    monkeypatch.setenv("HOME", str(ssh_ca_keypair["ssh_dir"]))
+    home = str(ssh_ca_keypair["ssh_dir"])
+    monkeypatch.setenv("HOME", home)
+    # On Windows os.path.expanduser reads USERPROFILE, not HOME.
+    monkeypatch.setenv("USERPROFILE", home)
 
     state = mock.MagicMock(cwd=None, private_keys={})
 

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -2,10 +2,13 @@ from base64 import b64decode
 from unittest import TestCase
 from unittest.mock import mock_open, patch
 
+import pytest
 from paramiko import PKey, ProxyCommand, SSHException
 
 from pyinfra.connectors.sshuserclient import SSHClient
 from pyinfra.connectors.sshuserclient.client import AskPolicy, get_ssh_config
+
+CERT_KEY_TYPE = "ssh-ed25519-cert-v01@openssh.com"
 
 SSH_CONFIG_DATA = """
 # Comment
@@ -458,3 +461,86 @@ class TestSSHUserConfig(TestCase):
             # Ensure we wrote the correct content
             correct_output = f"{example_hostname} {example_keytype} {example_key}\n"
             assert write_call_args[0][0] == correct_output
+
+
+@pytest.fixture
+def _clear_ssh_config_cache():
+    get_ssh_config.cache = {}
+    yield
+    get_ssh_config.cache = {}
+
+
+def _write_ssh_config(config_path, host, **directives):
+    body = [f"Host {host}"]
+    for key, value in directives.items():
+        body.append(f"    {key} {value}")
+    config_path.write_text("\n".join(body) + "\n")
+
+
+def test_parse_config_loads_cert_for_identityfile(
+    ssh_ca_keypair, tmp_path, _clear_ssh_config_cache
+):
+    # ssh_config IdentityFile points at a key with an adjacent -cert.pub; the
+    # cert must be attached and key_filename must be dropped so paramiko uses
+    # the pkey we built.
+    config_path = tmp_path / "ssh_config"
+    _write_ssh_config(
+        config_path,
+        host="myhost",
+        IdentityFile=str(ssh_ca_keypair["user_key"]),
+    )
+
+    client = SSHClient()
+    _, cfg, *_ = client.parse_config("myhost", ssh_config_file=str(config_path))
+
+    assert "key_filename" not in cfg
+    assert isinstance(cfg["pkey"], PKey)
+    assert cfg["pkey"].public_blob is not None
+    assert cfg["pkey"].public_blob.key_type == CERT_KEY_TYPE
+
+
+def test_parse_config_honours_certificatefile_directive(
+    ssh_ca_keypair, tmp_path, _clear_ssh_config_cache
+):
+    # CertificateFile in ssh_config overrides the implicit <key>-cert.pub
+    # lookup. We copy the real cert to a different path and reference it.
+    other_cert = tmp_path / "other-cert.pub"
+    other_cert.write_bytes(ssh_ca_keypair["user_cert"].read_bytes())
+
+    # Use a bare copy of the key so the implicit lookup would NOT find a cert.
+    bare_key = tmp_path / "bare_ed25519"
+    bare_key.write_bytes(ssh_ca_keypair["user_key"].read_bytes())
+
+    config_path = tmp_path / "ssh_config"
+    _write_ssh_config(
+        config_path,
+        host="myhost",
+        IdentityFile=str(bare_key),
+        CertificateFile=str(other_cert),
+    )
+
+    client = SSHClient()
+    _, cfg, *_ = client.parse_config("myhost", ssh_config_file=str(config_path))
+
+    assert "key_filename" not in cfg
+    assert cfg["pkey"].public_blob is not None
+    assert cfg["pkey"].public_blob.key_type == CERT_KEY_TYPE
+
+
+def test_parse_config_keeps_key_filename_when_no_real_identityfile(
+    tmp_path, _clear_ssh_config_cache
+):
+    # IdentityFile that doesn't exist on disk must not crash: fall back to the
+    # legacy key_filename path and let paramiko handle it.
+    config_path = tmp_path / "ssh_config"
+    _write_ssh_config(
+        config_path,
+        host="myhost",
+        IdentityFile=str(tmp_path / "does-not-exist"),
+    )
+
+    client = SSHClient()
+    _, cfg, *_ = client.parse_config("myhost", ssh_config_file=str(config_path))
+
+    assert "pkey" not in cfg
+    assert cfg["key_filename"] == [str(tmp_path / "does-not-exist")]


### PR DESCRIPTION
## Summary

Make OpenSSH CA-signed user certificates work without the inventory-level workaround documented in #1569. When `~/.ssh/config` supplies `IdentityFile` (and optionally `CertificateFile`), pyinfra now pre-resolves the private key, attaches the certificate via `paramiko.PKey.load_certificate`, and passes the key as `pkey` instead of relying on paramiko's `key_filename` flow (which cannot attach an OpenSSH cert on its own).

Other fixes folded into the same change because they sit on the cert-loading path:

- `get_private_key` failed to find the adjacent `-cert.pub` for `~`-prefixed `ssh_key` values; the implicit lookup is now anchored on the resolved key path.
- The implicit lookup also tried `<key>.pub` after `<key>-cert.pub`. `<key>.pub` is the bare public key, not a certificate, and `load_certificate` happily overwrites any previously-attached cert with a non-cert public blob. Dropped.

The cert-attaching logic now lives in a state-free helper, `load_key_with_certificate(key_filename, key_password=None, certificate_filename=None, cwd=None)`. `get_private_key` keeps the existing per-state caching by wrapping it; sshuserclient calls it directly so no pyinfra state is leaked into the paramiko-extension layer.

Closes #1569

## Test plan

- [x] New session-scoped pytest fixture in `tests/test_connectors/conftest.py` that uses `ssh-keygen` to generate a CA, a user ed25519 key, and a CA-signed `-cert.pub`. Skips automatically if `ssh-keygen` is missing.
- [x] New `tests/test_connectors/test_ssh_util.py` covers: adjacent cert attaches, explicit `certificate_filename` honoured, key with no cert returns the bare key, `~`-prefixed `ssh_key` regression, missing key raises.
- [x] New tests in `tests/test_connectors/test_sshuserclient.py` covering ssh_config `IdentityFile` + adjacent cert, ssh_config `CertificateFile` overriding the implicit path, and the legacy fall-through when `IdentityFile` does not exist on disk.
- [x] Three existing mocked assertions in `tests/test_connectors/test_ssh.py` updated to expect `testkey-cert.pub` rather than the dropped `testkey.pub` fallback.
- [x] `uv run pytest tests/test_connectors/` — 187 passed.
- [x] `scripts/dev-lint.sh` — clean (ruff, ruff format, mypy, arguments sync).

## Requirements

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts (no public-API surface added; behaviour matches OpenSSH semantics for `IdentityFile` and `CertificateFile`)
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
