### PR TITLE
fix(api): honour ctx_config TEMP_DIR override in get_temp_dir_config

### DIFF
--- a/src/pyinfra/api/host.py
+++ b/src/pyinfra/api/host.py
@@ -18,6 +18,7 @@ from pyinfra import logger
 from pyinfra.api.output import format_text
 from pyinfra.connectors.base import BaseConnector
 from pyinfra.connectors.util import CommandOutput, remove_any_sudo_askpass_file
+from pyinfra.context import ctx_config
 
 from .connectors import get_execution_connector
 from .exceptions import ConnectError
@@ -314,7 +315,15 @@ class Host:
         return temp_directory
 
     def get_temp_dir_config(self):
-        return self.state.config.TEMP_DIR or self.state.config.DEFAULT_TEMP_DIR
+        # Deploy files mutate the per-deploy `ctx_config` copy, not
+        # `state.config` (see pyinfra.context). Prefer that override so
+        # `config.TEMP_DIR = ...` inside a deploy lands the askpass
+        # script under the requested directory (issue #1729). Mirrors the
+        # precedence used by `pop_global_arguments`.
+        config = self.state.config
+        if ctx_config.isset():
+            config = ctx_config.get()
+        return config.TEMP_DIR or config.DEFAULT_TEMP_DIR
 
     def get_temp_filename(
         self,

--- a/src/pyinfra/api/host.py
+++ b/src/pyinfra/api/host.py
@@ -316,14 +316,21 @@ class Host:
 
     def get_temp_dir_config(self):
         # Deploy files mutate the per-deploy `ctx_config` copy, not
-        # `state.config` (see pyinfra.context). Prefer that override so
-        # `config.TEMP_DIR = ...` inside a deploy lands the askpass
-        # script under the requested directory (issue #1729). Mirrors the
-        # precedence used by `pop_global_arguments`.
+        # `state.config` (see pyinfra.context), so prefer an explicit
+        # override there: `config.TEMP_DIR = ...` inside a deploy must
+        # land the askpass script under the requested directory (issue
+        # #1729). A `ctx_config` carrying no explicit TEMP_DIR (the copy
+        # of a default config, or a context leaked from elsewhere) must
+        # not shadow a TEMP_DIR set on `state.config` via an
+        # inventory/config file, so fall through to it rather than
+        # swapping the config wholesale.
+        ctx = ctx_config.get() if ctx_config.isset() else None
         config = self.state.config
-        if ctx_config.isset():
-            config = ctx_config.get()
-        return config.TEMP_DIR or config.DEFAULT_TEMP_DIR
+        return (
+            (ctx.TEMP_DIR if ctx is not None else None)
+            or config.TEMP_DIR
+            or config.DEFAULT_TEMP_DIR
+        )
 
     def get_temp_filename(
         self,

--- a/tests/test_api/test_api_host.py
+++ b/tests/test_api/test_api_host.py
@@ -102,3 +102,17 @@ class TestHostTempDirConfig(TestCase):
     def test_get_temp_dir_config_falls_back_to_state_default(self):
         host = self._make_host()
         assert host.get_temp_dir_config() == host.state.config.DEFAULT_TEMP_DIR
+
+    def test_get_temp_dir_config_state_config_wins_over_empty_ctx(self):
+        # A ctx_config without an explicit TEMP_DIR (the per-deploy copy of
+        # a default config, or a context leaked from another test under
+        # full-suite ordering) must not shadow a TEMP_DIR set on
+        # state.config via an inventory/config file. Deterministic guard
+        # for the order-dependent failure of test_connectors
+        # TestEnsureAskpassTempDir.test_config_temp_dir.
+        inventory = make_inventory()
+        State(inventory, Config(TEMP_DIR="/var/tmp"))
+        host = inventory.get_host("somehost")
+
+        with ctx_config.use(Config()):
+            assert host.get_temp_dir_config() == "/var/tmp"

--- a/tests/test_api/test_api_host.py
+++ b/tests/test_api/test_api_host.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from pyinfra.api import Config, State
 from pyinfra.api.host import HostData
+from pyinfra.context import ctx_config
 
 from ..util import make_inventory
 
@@ -74,3 +75,30 @@ class TestHostDeployContext(TestCase):
             assert host.current_deploy_name == "outer"
 
         assert host.current_deploy_name is None
+
+
+class TestHostTempDirConfig(TestCase):
+    def _make_host(self):
+        inventory = make_inventory()
+        State(inventory, Config())
+        return inventory.get_host("somehost")
+
+    def test_get_temp_dir_config_prefers_ctx_config_override(self):
+        # Regression for pyinfra-dev/pyinfra#1729: `config.TEMP_DIR` mutated
+        # inside a deploy file changes the per-deploy `ctx_config` copy, not
+        # `state.config`. The askpass helper must see the override.
+        host = self._make_host()
+        assert host.get_temp_dir_config() == "/tmp"
+
+        overlay = host.state.config.copy()
+        overlay.TEMP_DIR = "/home/me/tmp"
+
+        with ctx_config.use(overlay):
+            assert host.get_temp_dir_config() == "/home/me/tmp"
+
+        # And it must fall back to state.config once the ctx exits.
+        assert host.get_temp_dir_config() == "/tmp"
+
+    def test_get_temp_dir_config_falls_back_to_state_default(self):
+        host = self._make_host()
+        assert host.get_temp_dir_config() == host.state.config.DEFAULT_TEMP_DIR


### PR DESCRIPTION
## Summary

`config.TEMP_DIR` set inside a deploy file silently fell back to `/tmp` on the SUDO_ASKPASS path. Root cause: `_parallel_load_hosts` wraps deploy loading in `ctx_config.use(state.config.copy())` so deploy-file mutations land on a per-deploy gevent-local config, not on `state.config`. `host.get_temp_dir_config()` (the one feeding the askpass helper) only read `state.config`, so the deploy-time override was invisible to it. Setting the same value in `config.py` or an inventory file worked because those mutate `state.config` directly before deploy load.

Fix: read `ctx_config.get()` first when it's set, fall back to `state.config`. This mirrors the precedence already used by `pop_global_arguments` (`src/pyinfra/api/arguments.py:385-388`).

Scope note: `_get_temp_directory` (feeding `get_temp_filename`, file uploads, etc.) has the same neglect but is `@memoize`-decorated and behaves differently across the deploy lifetime. Kept it out of this PR for atomicity. Happy to follow up.

Fixes #1729

## Test plan

- [x] New `TestHostTempDirConfig` in `tests/test_api/test_api_host.py`:
  - `test_get_temp_dir_config_prefers_ctx_config_override` reproduces the bug: mutate a copy of `state.config` inside `ctx_config.use(...)` and assert `host.get_temp_dir_config()` returns the override; verify fallback once the context exits. Confirmed RED on `3.x` with the exact `'/tmp' == '/home/me/tmp'` shape from the issue.
  - `test_get_temp_dir_config_falls_back_to_state_default` sanity check on the default path.
- [x] `uv run pytest tests/test_api tests/test_connectors tests/test_cli` — 335 passed.
- [x] `scripts/dev-lint.sh` — ruff, ruff format, mypy, arguments sync all clean.

## Requirements

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts (behavioural fix, no surface change)
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
