### PR TITLE
fix: limit-aware inventory creation

### DIFF
--- a/src/pyinfra/api/inventory.py
+++ b/src/pyinfra/api/inventory.py
@@ -31,6 +31,7 @@ class Inventory:
     Args:
         names_data: tuple of ``(names, data)``
         override_data: dictionary of data overrides
+        limit: Iterable, restrict host data loading by name and group name
         ssh_*: deprecated, use ``override_data.ssh_*``
         winrm_*: deprecated, use ``override_data.winrm_*``
         **groups: map of group name -> ``(names, data)``
@@ -43,7 +44,7 @@ class Inventory:
     def empty():
         return Inventory(([], {}))
 
-    def __init__(self, names_data, override_data=None, **groups):
+    def __init__(self, names_data, override_data=None, limit=None, **groups):
         # Setup basics
         self.groups = defaultdict(list)  # lists of Host objects
         self.host_data: dict[str, dict] = defaultdict(dict)  # dict of name -> data
@@ -56,14 +57,16 @@ class Inventory:
         self.data = data
 
         # Create the actual host instances and groups
-        self.make_hosts_and_groups(names, groups)
+        self.make_hosts_and_groups(names, groups, limit=limit)
 
-    def make_hosts_and_groups(self, names, groups) -> None:
+    def make_hosts_and_groups(self, names, groups, limit=None) -> None:
         all_connectors = get_all_connectors()
         execution_connectors = get_execution_connectors()
 
+        # Map name -> group name -> data (before merging)
+        name_to_group_data: dict[str, dict[str, dict]] = defaultdict(dict)
         # Map name -> data
-        name_to_data: dict[str, dict] = defaultdict(dict)
+        name_to_merged_data: dict[str, dict] = defaultdict(dict)
         # Map name -> group names
         name_to_group_names = defaultdict(list)
 
@@ -71,21 +74,41 @@ class Inventory:
             # Assign group data
             self.group_data[group_name] = group_data
 
-            # For any hosts in the group, assign mappings
+            # Store per-group host data without merging so that limit
+            # filtering can be applied later in the host_data build step.
             for name, data in extract_name_data(group_names):
-                name_to_data[name].update(data)
+                name_to_group_data[name][group_name] = data
                 name_to_group_names[name].append(group_name)
 
+        # Merge per-group/per-host data, respecting limit so that hosts
+        # only get data from the limited groups/hosts.
+        if limit is None:
+            # If there is no limit, merge all data
+            for name, _ in extract_name_data(names):
+                for group_name in groups.keys():
+                    name_to_merged_data[name].update(name_to_group_data[name].get(group_name, {}))
+        else:
+            for limiter in limit:
+                # If the limiter matches a group name, try to merge data from that group
+                if limiter in groups.keys():
+                    for name, _ in extract_name_data(names):
+                        name_to_merged_data[name].update(name_to_group_data[name].get(limiter, {}))
+                else:
+                    # Else, try to merge data from all groups containing a host named `limiter`
+                    for group_data in name_to_group_data.get(limiter, {}).values():
+                        name_to_merged_data[limiter].update(group_data)
+
         # Build all/top-level host data - *before* we expand any inventory
-        # connectors.
+        # connectors. Top-level (all) data is merged last so it can override
+        # group-level data.
         for name, data in extract_name_data(names):
-            name_to_data[name].update(data)
+            name_to_merged_data[name].update(data)
 
         # Now, use the above to fill self.host_data and populate names_connectors
         names_connectors = []
 
         for name, _ in extract_name_data(names):
-            host_data = name_to_data[name]
+            host_data = name_to_merged_data[name]
 
             # Default to executing commands with the ssh connector
             connector_cls = execution_connectors["ssh"]

--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -393,6 +393,7 @@ def _main(
         cwd=state.cwd,
         override_data=override_data,
         group_data_directories=group_data,
+        limit=limit,
     )
     ctx_inventory.set(inventory)
 

--- a/src/pyinfra_cli/inventory.py
+++ b/src/pyinfra_cli/inventory.py
@@ -176,6 +176,7 @@ def make_inventory(
     override_data=None,
     cwd: str | None = None,
     group_data_directories=None,
+    limit=None,
 ):
     # (Un)fortunately the CLI is pretty flexible for inventory inputs; we support inventory files, a
     # single hostname, list of hosts, connectors, and python module.function or module:function
@@ -204,7 +205,9 @@ def make_inventory(
 
     if is_path_or_host_list_or_connector:
         # The inventory is either an inventory file or a (list of) hosts
-        return make_inventory_from_files(inventory, override_data, cwd, group_data_directories)
+        return make_inventory_from_files(
+            inventory, override_data, cwd, group_data_directories, limit=limit
+        )
     elif inventory_func is None:
         logger.warning(
             f"{inventory} is neither an inventory file, a (list of) hosts or connectors "
@@ -299,6 +302,7 @@ def make_inventory_from_files(
     override_data=None,
     cwd: str | None = None,
     group_data_directories=None,
+    limit=None,
 ):
     """
     Builds a ``pyinfra.api.Inventory`` from the filesystem. If the file does not exist
@@ -360,7 +364,7 @@ def make_inventory_from_files(
         name: group if isinstance(group, tuple) else (group, {})
         for name, group in groups.items()
     }
-    fake_inventory = Inventory((all_hosts, all_data), **fake_groups)
+    fake_inventory = Inventory((all_hosts, all_data), limit=limit, **fake_groups)
 
     possible_group_data_folders = []
     if cwd:
@@ -399,4 +403,9 @@ def make_inventory_from_files(
     for name, data in group_data.items():
         groups[name] = ([], data)
 
-    return Inventory(groups.pop("all"), override_data=override_data, **groups)
+    return Inventory(
+        groups.pop("all"),
+        override_data=override_data,
+        limit=limit,
+        **groups,
+    )


### PR DESCRIPTION
## Description

This draft PR is a proof of concept for #1756.

The current issue is that `--limit <group>` still allows host data from non-selected groups to be merged during inventory construction. If the same host exists in multiple groups with overlapping keys, values from later groups overwrite those from the selected group.

This implementation explores passing the `limit` iterable into the `Inventory` object so that host data from non-selected groups can be ignored during inventory construction.

The goal here is mainly to validate the approach; I do not expect this implementation to be merged as-is, since it was written fairly quickly and may not align with the intended architecture of the project. It may serve as inspiration for a proper implementation.

## Testing

The included tests pass with `scripts/dev-test.sh`, ~but I encountered the following error in one of my real deployments, which does not occur on pyinfra `v3.8.0`. So there is likely at least one edge case or unintended side effect in the current implementation.~ The error also happens on 3.8.0, so it might be my deployment that is flawed.

```
--> pyinfra error: Cycle detected in operation ordering DAG.
    Error: ('nodes are in a cycle', ['6122ecd5c8bf5453cf3cefd3b6786f892d5d01af', 'af7a299a1fa7001b19dc57f7f9a1249385411c40-0', 'b2c4a8bab430d883f638396faaf8251b721a058d-0', '0ae435d43f8108d80868fdf5c2a700ed581f139f-0', 'eccb013008ef20c412778a9b62f4dfbf3d7013f2-0', 'accace0f63f34b5b36b28d67ad44597a71d21803', '6122ecd5c8bf5453cf3cefd3b6786f892d5d01af'])

    This can happen when using loops in operation code, please see: https://docs.pyinfra.com/en/latest/deploy-process.html#loops-cycle-errors
```



## Checklist

- [x] Pull request is based on the default branch (`3.x` at this time)
- [ ] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
