### PR TITLE
docs: Add missing apostrophes

### DIFF
--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -751,7 +751,7 @@ def user_authorized_keys(
 
     + user: name of the user to ensure
     + public_keys: list of public keys to attach to this user, ``home`` must be specified
-    + group: the users primary group
+    + group: the user's primary group
     + delete_keys: whether to remove any keys not specified in ``public_keys``
 
     Public keys:
@@ -874,10 +874,10 @@ def user(
 
     + user: name of the user to ensure
     + present: whether this user should exist
-    + home: the users home directory
-    + shell: the users shell
-    + group: the users primary group
-    + groups: the users secondary groups
+    + home: the user's home directory
+    + shell: the user's shell
+    + group: the user's primary group
+    + groups: the user's secondary groups
     + append: whether to add `user` to `groups`, w/o losing membership of other groups
     + public_keys: list of public keys to attach to this user, ``home`` must be specified
     + delete_keys: whether to remove any keys not specified in ``public_keys``

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -893,7 +893,7 @@ def user(
         When ``ensure_home`` or ``public_keys`` are provided, ``home`` defaults to
         ``/home/{name}``. When ``create_home`` is ``True`` any newly created users
         will be created with the ``-m`` flag to build a new home directory from the
-        systems skeleton directory.
+        system's skeleton directory.
 
     Public keys:
         These can be provided as strings containing the public key or as a path to


### PR DESCRIPTION
<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

This fixes missing apostrophes in a few possessive nouns in docstrings.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
