### PR TITLE
fix(operations.git): keep git.repo src in sync with config origin (#1763)

### DIFF
--- a/src/pyinfra/operations/git.py
+++ b/src/pyinfra/operations/git.py
@@ -160,6 +160,9 @@ def repo(
 
     # Ensuring existing repo
     else:
+        # Keep repository origin in sync with src, which may differ from last run
+        git_commands.append(StringCommand("remote", "set-url", "origin", QuoteString(src)))
+
         is_tag = False
         current_branch = host.get_fact(GitBranch, repo=dest)
         if branch is not None and current_branch != branch:

--- a/tests/operations/git.repo/branch_pull.json
+++ b/tests/operations/git.repo/branch_pull.json
@@ -25,6 +25,7 @@
         }
     },
     "commands": [
+        "cd /home/myrepo && git remote set-url origin myrepo",
         "cd /home/myrepo && git fetch",
         "cd /home/myrepo && git checkout mybranch",
         "cd /home/myrepo && git pull"

--- a/tests/operations/git.repo/branch_switch_up_to_date.json
+++ b/tests/operations/git.repo/branch_switch_up_to_date.json
@@ -25,6 +25,7 @@
         }
     },
     "commands": [
+        "cd /home/myrepo && git remote set-url origin myrepo",
         "cd /home/myrepo && git fetch",
         "cd /home/myrepo && git checkout mybranch"
     ]

--- a/tests/operations/git.repo/checkout_branch_needs_quotes.json
+++ b/tests/operations/git.repo/checkout_branch_needs_quotes.json
@@ -17,6 +17,7 @@
         }
     },
     "commands": [
+        "cd /home/myrepo && git remote set-url origin myrepo",
         "cd /home/myrepo && git fetch",
         "cd /home/myrepo && git checkout 'feature/evil; rm -rf /'"
     ]

--- a/tests/operations/git.repo/clone_src_origin_changed_url.json
+++ b/tests/operations/git.repo/clone_src_origin_changed_url.json
@@ -1,0 +1,28 @@
+{
+    "args": [
+        "myrepo",
+        "/home/myrepo"
+    ],
+    "kwargs": {},
+    "facts": {
+        "files.Directory": {
+            "path=/home/myrepo": {},
+            "path=/home/myrepo/.git": {
+                "mode": 0
+            }
+        },
+        "git.GitBranch": {
+            "repo=/home/myrepo": "main"
+        },
+        "git.GitLocalCommit": {
+            "ref=main, repo=/home/myrepo": null
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=main, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+    },
+    "commands": [
+        "cd /home/myrepo && git remote set-url origin myrepo",
+        "cd /home/myrepo && git pull"
+    ]
+}

--- a/tests/operations/git.repo/clone_src_origin_same_url.json
+++ b/tests/operations/git.repo/clone_src_origin_same_url.json
@@ -1,0 +1,28 @@
+{
+    "args": [
+        "changedrepo",
+        "/home/myrepo"
+    ],
+    "kwargs": {},
+    "facts": {
+        "files.Directory": {
+            "path=/home/myrepo": {},
+            "path=/home/myrepo/.git": {
+                "mode": 0
+            }
+        },
+        "git.GitBranch": {
+            "repo=/home/myrepo": "main"
+        },
+        "git.GitLocalCommit": {
+            "ref=main, repo=/home/myrepo": null
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=main, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+    },
+    "commands": [
+        "cd /home/myrepo && git remote set-url origin changedrepo",
+        "cd /home/myrepo && git pull"
+    ]
+}

--- a/tests/operations/git.repo/rebase.json
+++ b/tests/operations/git.repo/rebase.json
@@ -21,6 +21,7 @@
         }
     },
     "commands": [
+        "cd /home/myrepo && git remote set-url origin myrepo",
         "cd /home/myrepo && git pull --rebase"
     ],
     "idempotent": false,

--- a/tests/operations/git.repo/recursive_submodules.json
+++ b/tests/operations/git.repo/recursive_submodules.json
@@ -22,6 +22,7 @@
         }
     },
     "commands": [
+        "cd /home/myrepo && git remote set-url origin myrepo",
         "cd /home/myrepo && git pull",
         "cd /home/myrepo && git submodule update --init --recursive"
     ],

--- a/tests/operations/git.repo/up_to_date.json
+++ b/tests/operations/git.repo/up_to_date.json
@@ -17,6 +17,8 @@
             "branch=master, remote=origin, repo=/home/myrepo": "1a2b3c4d5e6f7890abcdef1234567890abcdef12"
         }
     },
-    "commands": [],
+    "commands": [
+        "cd /home/myrepo && git remote set-url origin myrepo"
+    ],
     "noop_description": "git repository /home/myrepo is already up to date"
 }

--- a/tests/operations/git.repo/update_submodules.json
+++ b/tests/operations/git.repo/update_submodules.json
@@ -21,6 +21,7 @@
         }
     },
     "commands": [
+        "cd /home/myrepo && git remote set-url origin myrepo",
         "cd /home/myrepo && git pull",
         "cd /home/myrepo && git submodule update --init"
     ],


### PR DESCRIPTION
<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

Fixes #1763

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
