### PR TITLE
docs: remove stray 'LINK' in chmod/chown FAQ entry (#1762)

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -41,7 +41,7 @@ Sudo is controlled by one of the :ref:`privilege and user escalation arguments <
 How do I chmod or chown a file/directory/link?
 ----------------------------------------------
 
-Use the LINK ``files.file``, ``files.directory`` or ``files.link`` operations to set the permissions and ownership of files, directories & links:
+Use the ``files.file``, ``files.directory`` or ``files.link`` operations to set the permissions and ownership of files, directories & links:
 
 .. code:: python
 


### PR DESCRIPTION
Removes the stray `LINK` token from the chmod/chown FAQ entry. The entry was reading:

> Use the **LINK** `files.file`, `files.directory` or `files.link` operations to set the permissions and ownership of files, directories & links:

`LINK` looks like a leftover placeholder marker — the entry already lists `files.file`, `files.directory` and `files.link` as the answer, so the word doesn't carry information. Drop it.

Closes #1762.

The issue body also suggested hyperlinking the three operation references; I left that as a separate change to keep the diff atomic and small (PR checklist: "one change per PR"). Happy to follow up if you'd like a separate PR that adds `:py:func:` cross-references.

### Change Type

- [x] Documentation (FAQ wording fix)