### PR TITLE
docs: restore loop cycle error guidance

### DIFF
--- a/docs/deploy-process.rst
+++ b/docs/deploy-process.rst
@@ -183,3 +183,84 @@ Since this gets executed before nginx is installed by ``apt.packages`` operation
         reloaded=True,
         _if=remove_default_site.did_change,
     )
+
+.. _loops-cycle-errors:
+
+Loops & Cycle Errors
+~~~~~~~~~~~~~~~~~~~~
+
+In CLI mode ``pyinfra`` builds a single DAG to determine the order in which
+operations are executed. This usually produces the order a deploy author
+expects, but loops can make the same operation line appear multiple times with
+different per-host paths through the deploy. When those paths disagree about
+which operation must run first, the ordering graph contains a cycle and
+``pyinfra`` raises a cycle error.
+
+Use ``host.loop`` when a loop contains operations. This gives ``pyinfra`` the
+loop position as an ordering hint:
+
+.. code:: python
+
+    from pyinfra import host
+    from pyinfra.operations import server
+
+    for i in host.loop(range(0, 2)):
+        server.shell(
+            name=f"Do a thing {i}",
+            commands="ls",
+        )
+
+For example, this deploy can generate a cycle because the first operation only
+appears on ``@local`` during the first loop iteration:
+
+.. code:: python
+
+    from pyinfra import host
+    from pyinfra.operations import server
+
+    for i in range(0, 2):
+        if i > 0 or (i == 0 and host.name == "@local"):
+            server.shell(
+                name="A",
+                commands="ls",
+            )
+
+        server.shell(
+            name="B",
+            commands="ls",
+        )
+
+The resulting per-host order is inconsistent:
+
+.. code:: shell
+
+    # @local: A -> B -> A-1 -> B-1
+    # Other:       B -> A   -> B-1
+
+Combining those host orders means ``A`` must run before ``B`` and ``B`` must
+run before ``A``. Switching the loop to ``host.loop`` includes the loop position
+in the operation order and removes the ambiguity:
+
+.. code:: python
+
+    from pyinfra import host
+    from pyinfra.operations import server
+
+    for i in host.loop(range(0, 2)):
+        if i > 0 or (i == 0 and host.name == "@local"):
+            server.shell(
+                name="A",
+                commands="ls",
+            )
+
+        server.shell(
+            name="B",
+            commands="ls",
+        )
+
+The graph can then be resolved consistently:
+
+.. code:: shell
+
+    # @local: 0A -> 0B -> 1A -> 1B
+    # Other:        0B -> 1A -> 1B


### PR DESCRIPTION
## Summary
- restore the missing `Loops & Cycle Errors` section in `docs/deploy-process.rst`
- add a stable `#loops-cycle-errors` anchor for the link referenced by the cycle error message
- document using `host.loop` to disambiguate operation ordering inside loops

Fixes #1494.

## Validation
- `git diff --check -- docs/deploy-process.rst`
- `DOCS_VERSION=latest uv run --python 3.14 --group docs sphinx-build -b html docs build/docs`
- `rg -n "loops-cycle-errors|Loops & Cycle Errors" build/docs/deploy-process.html docs/deploy-process.rst`
- `uv run --python 3.14 pytest tests/test_cli/test_cli_deploy.py::TestCliDeployState::test_deploy -q`

## AI assistance disclosure
This contribution was prepared with assistance from OpenAI Codex. I reviewed the AI policy, issue context, existing `host.loop` implementation, generated documentation output, and validation results before submitting.
