### PR TITLE
docs: clarify fact-failure semantics for requires_command and check_preconditions

### DIFF
--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -167,12 +167,19 @@ See :doc:`facts` for a full list of available facts and arguments.
 Fact Errors
 ^^^^^^^^^^^
 
-When facts fail due to an error the host will be marked as failed just as it would when an operation fails. This can be avoided by passing the ``_ignore_errors`` argument:
+When a fact command exits with a non-zero status the host is marked as failed, just as when an operation fails. This can be avoided by passing the ``_ignore_errors`` argument:
 
 .. code:: python
 
     if host.get_fact(LinuxName, _ignore_errors=True):
         ...
+
+Two other "fact skipped" paths do **not** fail the host. They are phase-aware:
+
+- ``requires_command`` declares a binary that must be present on the host. If the binary is absent, the fact returns its ``default()`` value. In the prepare phase the skip is silent; in the execute phase a warning is logged. In v4 the execute phase will raise instead.
+- ``check_preconditions()`` lets a fact declare a runtime prerequisite (for example a kernel module loaded). When the precondition is not met the same phase-aware behavior applies.
+
+See :doc:`api/facts` for the full design and exception hierarchy.
 
 The ``inventory`` Object
 ------------------------

--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -176,6 +176,7 @@ When a fact command exits with a non-zero status the host is marked as failed, j
 
 .. Important::
     Facts may choose to silently ignore errors for missing commands (eg mysql not installed) and instead return a default value. In v4 this will raise an error during the execution phase.
+
 The ``inventory`` Object
 ------------------------
 

--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -174,13 +174,8 @@ When a fact command exits with a non-zero status the host is marked as failed, j
     if host.get_fact(LinuxName, _ignore_errors=True):
         ...
 
-Two other "fact skipped" paths do **not** fail the host. They are phase-aware:
-
-- ``requires_command`` declares a binary that must be present on the host. If the binary is absent, the fact returns its ``default()`` value. In the prepare phase the skip is silent; in the execute phase a warning is logged. In v4 the execute phase will raise instead.
-- ``check_preconditions()`` lets a fact declare a runtime prerequisite (for example a kernel module loaded). When the precondition is not met the same phase-aware behavior applies.
-
-See :doc:`api/facts` for the full design and exception hierarchy.
-
+.. Important::
+    Facts may choose to silently ignore errors for missing commands (eg mysql not installed) and instead return a default value. In v4 this will raise an error during the execution phase.
 The ``inventory`` Object
 ------------------------
 


### PR DESCRIPTION
## Summary

The "Fact Errors" section in `docs/using-operations.rst` stated that any fact failure marks the host as failed. That is only true when the fact command exits with a non-zero status.

The `requires_command` guard (added in #1647) and the `check_preconditions()` hook take a phase-aware silent path instead:

- prepare phase: skip is silent, fact returns `default()`
- execute phase (v3): warning logged, fact returns `default()`
- execute phase (v4): will raise

Update the section to cover all three paths and link out to the full design in `docs/api/facts.md`.

Closes #1768

