### PR TITLE
docs: warn that _if must be a callable

### DIFF
--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -233,6 +233,9 @@ All operations return an operation meta object which provides information about 
     server.shell(commands=["..."], _if=any_changed(create_user, create_otheruser))
     server.shell(commands=["..."], _if=all_changed(create_user, create_otheruser))
 
+.. Important::
+    ``_if`` must be a callable, or a list of callables. Passing a value directly (e.g. ``_if=host.get_fact(MyFact)``) does not gate the operation: most non-callable values raise ``ArgumentTypeError`` at prepare time, and ``None`` is treated as "no condition" so the operation always runs. Wrap the value in a lambda to gate on it: ``_if=lambda: bool(host.get_fact(MyFact))``.
+
 Output & Callbacks
 ------------------
 


### PR DESCRIPTION
## Summary

Users sometimes write `_if=host.get_fact(MyFact)` expecting truthy gating. For most non-callable values this already raises `ArgumentTypeError` at prepare time (`src/pyinfra/api/arguments.py:414-420`), but `_if=None` passes (`None` is in the declared type `list[Callable[[], bool]] | Callable[[], bool] | None`) and the operation runs unconditionally.

Add a short admonition next to the existing `_if` examples in `docs/using-operations.rst`, with the `_if=lambda: bool(...)` recipe.

No behavior change.

Closes #1769
