### PR TITLE
docs: correct python.raise_exception example

### DIFF
--- a/src/pyinfra/operations/python.py
+++ b/src/pyinfra/operations/python.py
@@ -61,9 +61,9 @@ def raise_exception(exception: Exception, *args, **kwargs):
     .. code:: python
 
         python.raise_exception(
+            NotImplementedError,
+            "This is not implemented",
             name="Raise NotImplementedError exception",
-            exception=NotImplementedError,
-            message="This is not implemented",
         )
     """
 


### PR DESCRIPTION
## Summary

- update the `python.raise_exception` example to pass the exception class and message as positional arguments
- keep `name=` as operation metadata rather than an argument to the exception constructor

Fixes #1261

## Validation

- `uv run python -m compileall -q src/pyinfra/operations/python.py`
- `uv run ruff check src/pyinfra/operations/python.py`
- `uv run ruff format --check src/pyinfra/operations/python.py`
- `uv run --group test python scripts/lint_arguments_sync.py`
- `DOCS_VERSION=latest uv run --python 3.14 --group docs sphinx-build -b html docs build/docs`
- `scripts/dev-lint.sh`
- `git diff --check`
- `git diff HEAD^ --check`

The generated `build/docs/operations/python.html` contains the corrected positional `NotImplementedError` example.

## AI usage disclosure

OpenAI GPT-5 assisted with repository navigation, drafting the focused documentation edit, and selecting validation commands. I reviewed the final change and validation output and understand the doc behavior being corrected.

## Checklist

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts (docs-only correction; no operation behavior changed)
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format