### PR TITLE
fix(operations.files): handle large download cache time

### DIFF
--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -151,7 +151,12 @@ def download(
         if cache_time:
             # Time on files is not tz-aware, and will be the same tz as the server's time,
             # so we can safely remove the tzinfo from the Date fact before comparison.
-            ctime = host.get_fact(Date).replace(tzinfo=None) - timedelta(seconds=cache_time)
+            try:
+                ctime = host.get_fact(Date).replace(tzinfo=None) - timedelta(
+                    seconds=cache_time,
+                )
+            except OverflowError:
+                ctime = datetime.min if cache_time > 0 else datetime.max
             if info["mtime"] and info["mtime"] < ctime:
                 download = True
 

--- a/tests/operations/files.download/download_cache_time_underflow.yaml
+++ b/tests/operations/files.download/download_cache_time_underflow.yaml
@@ -1,0 +1,14 @@
+args:
+  - http://myfile
+kwargs:
+  dest: /home/myfile
+  cache_time: 9999999999999
+facts:
+  server.Date: datetime:2015-01-01T00:30:00
+  files.File:
+    path=/home/myfile:
+      mtime: datetime:2015-01-01T00:00:00
+  server.Which:
+    command=curl: "yes"
+commands: []
+noop_description: file /home/myfile has already been downloaded


### PR DESCRIPTION
## Summary
- prevent `files.download` from raising `OverflowError` when `cache_time` is too large to subtract from the current date
- treat overflowed positive cache windows as not expired
- add an operation fixture for the reported underflow case

Fixes #1394

## AI assistance
OpenAI GPT-5 helped draft this patch and run verification. This disclosure is included per `AI_POLICY.md`.

## Verification
Red test before the fix:
- `uv run pytest tests/test_operations.py -k 'files_download_download_cache_time_underflow' -q` failed with `OverflowError: date value out of range`

After the fix:
- `uv run pytest tests/test_operations.py -k 'files_download_download_cache_time_underflow' -q`
- `uv run pytest tests/test_operations.py -k 'files_download' -q`
- `uv run pytest tests/test_operations.py -q`
- `uv run ruff format --check src/pyinfra/operations/files.py`
- `uv run ruff check src/pyinfra/operations/files.py`
- `uv run mypy src/pyinfra/operations/files.py`
- `git diff --check`

Note: full `uv run ruff check` currently reports existing repository-wide findings outside this change, including `src/pyinfra/connectors/scp/client.py`, `src/pyinfra/facts/*.py`, `src/pyinfra/operations/docker.py`, `src/pyinfra/progress.py`, and `src/pyinfra_cli/*.py`.
