### PR TITLE
fix(facts.openrc): make OpenrcStatus match service names containing a dot

### DIFF
--- a/src/pyinfra/facts/openrc.py
+++ b/src/pyinfra/facts/openrc.py
@@ -14,7 +14,7 @@ class OpenrcStatus(FactBase):
 
     default = dict
     regex = (
-        r"\s+([a-zA-Z0-9\-_]+)"
+        r"\s+([a-zA-Z0-9\-_.]+)"
         r"\s+\[\s+"
         r"([a-z]+)"
         r"(?:\s(?:[0-9]+\sday\(s\)\s)?"

--- a/tests/facts/openrc.OpenrcEnabled/services.json
+++ b/tests/facts/openrc.OpenrcEnabled/services.json
@@ -5,6 +5,7 @@
         "             bootmisc | boot",
         "              cgroups |",
         "                crond |      default",
+        "     nftables.default | boot",
         "            hwdrivers |                                 sysinit",
         " virtualbox-guest-additions |      default"
     ],
@@ -12,6 +13,7 @@
         "bootmisc": false,
         "cgroups": false,
         "crond": true,
+        "nftables.default": false,
         "hwdrivers": false,
         "virtualbox-guest-additions": true
     }

--- a/tests/facts/openrc.OpenrcEnabled/services_runlevel.json
+++ b/tests/facts/openrc.OpenrcEnabled/services_runlevel.json
@@ -6,6 +6,7 @@
         "             bootmisc | boot",
         "              cgroups |",
         "                crond |      default",
+        "     nftables.default | boot",
         "            hwdrivers |                                 sysinit",
         " virtualbox-guest-additions |      default"
     ],
@@ -13,6 +14,7 @@
         "bootmisc": true,
         "cgroups": false,
         "crond": false,
+        "nftables.default": true,
         "hwdrivers": false,
         "virtualbox-guest-additions": false
     }

--- a/tests/facts/openrc.OpenrcStatus/services.json
+++ b/tests/facts/openrc.OpenrcStatus/services.json
@@ -8,6 +8,7 @@
         "  sshd                                    [  started  ]",
         "  virtualbox-guest-additions              [  crashed  ]",
         "  crond                                    [  started  ]",
+        "  nftables.default                         [  started  ]",
         "  podman                                   [  started 00:34:14 (10) ]",
         "  podman-long-running                      [  started 15 day(s) 00:34:14 (10) ]"
     ],
@@ -16,6 +17,7 @@
         "sshd": true,
         "virtualbox-guest-additions": false,
         "crond": true,
+        "nftables.default": true,
         "podman": true,
         "podman-long-running": true
     }

--- a/tests/facts/openrc.OpenrcStatus/services_runlevel.json
+++ b/tests/facts/openrc.OpenrcStatus/services_runlevel.json
@@ -8,6 +8,7 @@
         "  sshd                                    [  started  ]",
         "  virtualbox-guest-additions              [  crashed  ]",
         "  crond                                    [  started  ]",
+        "  nftables.default                         [  started  ]",
         "  podman                                   [  started 00:34:14 (10) ]",
         "  podman-long-running                      [  started 15 day(s) 00:34:14 (10) ]"
     ],
@@ -16,6 +17,7 @@
         "sshd": true,
         "virtualbox-guest-additions": false,
         "crond": true,
+        "nftables.default": true,
         "podman": true,
         "podman-long-running": true
     }


### PR DESCRIPTION
Makes `pyinfra.facts.openrc.OpenrcStatus` match services containing a dot, e.g. to make `pyinfra.operations.openrc.service(...)` report a correct service state in such case.
Also, tests checking OpenrcStatus and OpenrcEnabled behaviour for services containing a dot were added.