### PR TITLE
fix: parse flat apt repos with empty component list (#1775)

### DIFF
--- a/src/pyinfra/facts/apt.py
+++ b/src/pyinfra/facts/apt.py
@@ -261,7 +261,15 @@ def parse_apt_repo(name: str) -> AptRepo | None:
     Returns:
         AptRepo instance or None if parsing failed
     """
-    regex = r"^(deb(?:-src)?)(?:\s+\[([^\]]+)\])?\s+([^\s]+)\s+([^\s]+)\s+([a-z-\s\d]*)$"
+    # Components are optional: "flat" repositories (#1775) use a suite ending in "/"
+    # and supply no components, e.g.
+    #   deb [signed-by=/etc/.../key.gpg] https://example.com/path /
+    # The components group is also kept optional for non-flat lines that omit
+    # the trailing whitespace, matching apt's tolerance.
+    regex = (
+        r"^(deb(?:-src)?)(?:\s+\[([^\]]+)\])?\s+([^\s]+)\s+([^\s]+)"
+        r"(?:\s+([a-z-\s\d]+))?\s*$"
+    )
 
     matches = re.match(regex, name)
 
@@ -279,11 +287,14 @@ def parse_apt_repo(name: str) -> AptRepo | None:
 
             options[key] = value
 
+    components_match = matches.group(5)
+    components = list(components_match.split()) if components_match else []
+
     return AptRepo(
         type=matches.group(1),
         url=matches.group(3),
         distribution=matches.group(4),
-        components=list(matches.group(5).split()),
+        components=components,
         options=options,
     )
 

--- a/tests/facts/apt.AptSources/flat_repo_signed_by.json
+++ b/tests/facts/apt.AptSources/flat_repo_signed_by.json
@@ -1,0 +1,20 @@
+{
+    "output": [
+        "##PYINFRA_FILE /etc/apt/sources.list.d/nvidia-container-toolkit.list",
+        "deb [signed-by=/etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/amd64 /",
+        "#deb [signed-by=/etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/experimental/ubuntu18.04/amd64 /"
+    ],
+    "command": "sh -c 'for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do [ -e \"$f\" ] || continue; echo \"##PYINFRA_FILE $f\"; cat \"$f\"; echo; done'",
+    "requires_command": "apt",
+    "fact": [
+        {
+            "url": "https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/amd64",
+            "distribution": "/",
+            "type": "deb",
+            "components": [],
+            "options": {
+                "signed-by": "/etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

`parse_apt_repo` required mandatory whitespace plus a non-empty components capture at the end of every deb line, so flat repositories — those that use a suite ending in `/` and supply no components — never matched and silently dropped out of the `AptSources` fact. #1775's NVIDIA container-toolkit example is exactly that layout.

## Repro (matches #1775)

The line from the bug report (after APT expands `$(ARCH)`):

```
deb [signed-by=/etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/amd64 /
```

Before this change, `pyinfra @docker fact apt.AptSources` returned no entry for that repo; after, it returns:

```python
AptRepo(
    type='deb',
    url='https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/amd64',
    distribution='/',
    components=[],
    options={'signed-by': '/etc/apt/keyrings/nvidia-container-toolkit-keyring.gpg'},
)
```

## What changed

- `src/pyinfra/facts/apt.py`: make the components capture group optional in `parse_apt_repo`'s regex (`(?:\s+([a-z-\s\d]+))?\s*$`) and treat a `None` match as an empty list rather than crashing on `None.split()`. Comment and whitespace-only lines still fail the regex.
- `tests/facts/apt.AptSources/flat_repo_signed_by.json`: new fact fixture that exercises the exact bug-report layout (single deb line with `signed-by` + flat suite, plus a commented sibling), so future regressions are caught by `tests/test_facts.py -k AptSources`.

## Verification

```bash
uv run pytest tests/test_facts.py -k "AptSources" --disable-warnings
# 11 passed (10 existing + 1 new)
uv run ruff check src/pyinfra/facts/apt.py
uv run ruff format --check src/pyinfra/facts/apt.py
```

Closes #1775
