### PR TITLE
feat(connectors): add chain connector

### DIFF
--- a/docs/api/connectors.md
+++ b/docs/api/connectors.md
@@ -246,6 +246,53 @@ Without proper command wrapping, shell operators and complex commands will fail.
 
 For complete examples see pyinfra's built-in connectors in `pyinfra/connectors/docker.py`, `pyinfra/connectors/chroot.py`, `pyinfra/connectors/ssh.py` and `pyinfra/connectors/local.py`, as well as the command wrapping utilities in `pyinfra/connectors/util.py`.
 
+## Making a connector chain-compatible
+
+To allow a connector to be used as an **inner** layer in a :doc:`chain </connectors/chain>`,
+it must implement three wrapping methods and declare how to resolve its runtime identifier.
+
+### Runtime identifier
+
+Set the `runtime_id_field` class attribute to the data key that holds the connector's
+runtime identifier (container name, chroot directory, etc.). The default
+`get_runtime_id()` implementation reads `self.data[self.runtime_id_field]`:
+
+```py
+class MyConnector(BaseConnector):
+    runtime_id_field = "my_container_id"
+```
+
+For more complex resolution (e.g. combining multiple data keys), override
+`get_runtime_id()` directly:
+
+```py
+class MyConnector(BaseConnector):
+    def get_runtime_id(self) -> str:
+        return f"{self.data['remote']}:{self.data['name']}"
+```
+
+`get_runtime_id()` is called *before* `connect()`, so it must work solely from data
+available at construction time.
+
+### Command wrapping
+
+```py
+def wrap_exec_command(self, command: StringCommand, container_id: str) -> StringCommand:
+    """Return a command that runs ``command`` inside this connector's target."""
+    return StringCommand("my-tool", "exec", container_id, "--", "sh", "-c", QuoteString(command))
+
+def wrap_copy_into(self, src_on_parent: str, dest: str, container_id: str) -> StringCommand:
+    """Return a command that copies from parent into this connector's target."""
+    return StringCommand("my-tool", "cp", src_on_parent, f"{container_id}/{dest}")
+
+def wrap_copy_out(self, src: str, dest_on_parent: str, container_id: str) -> StringCommand:
+    """Return a command that copies from this connector's target to parent."""
+    return StringCommand("my-tool", "cp", f"{container_id}/{src}", dest_on_parent)
+```
+
+The `container_id` parameter is the value returned by `get_runtime_id()`. The returned
+command will be executed in the *parent* connector's context.
+
 
 ## pyproject.toml
 

--- a/docs/connectors.rst
+++ b/docs/connectors.rst
@@ -44,6 +44,11 @@ Each connector page is listed below and contains examples as well as a list of a
 
    Connect to the local machine running pyinfra.
 
+.. admonition:: :doc:`connectors/chain`
+   :class: note flex-half
+
+   Chain multiple connectors to reach nested targets.
+
 .. raw:: html
 
    </div>

--- a/docs/connectors/chain.md
+++ b/docs/connectors/chain.md
@@ -1,0 +1,59 @@
+# Chain Connector
+
+The `@chain` connector enables arbitrary nesting of connectors using the `/@` delimiter
+syntax. It allows you to target hosts that are only reachable through a chain of
+intermediate connectors — for example, a Docker container running on a remote SSH host.
+
+## Syntax
+
+```
+pyinfra @outer/arg/@inner/arg[/@deeper/arg...] <operations>
+```
+
+- The left-most connector is the **outermost** (it owns the real network connection).
+- The right-most connector is the **innermost** (closest to the target).
+- The `/@` delimiter separates connectors in the chain.
+
+## Examples
+
+```shell
+# Execute in a Docker container on a remote host via SSH
+pyinfra @ssh/mydoodba/@docker/myodoodev16-odoo-1 files.put src/ /opt/odoo/
+
+# Chroot into a build rootfs on a remote host via SSH
+pyinfra @ssh/build-server/@chroot/rootfs server.shell "ls /"
+
+# Three-level chain: local → SSH → Docker
+pyinfra @ssh/jumpbox/@docker/mycontainer server.shell "whoami"
+```
+
+## How it works
+
+1. **Parsing**: `/@` in an inventory name is detected and routed to `ChainedConnector`.
+2. **Data collection**: Each connector's `make_names_data` is called to collect inventory data.
+3. **Connection**: Only the outermost connector is connected (e.g. SSH socket).
+4. **Command execution**: Commands are wrapped innermost-to-outermost into a single shell
+   string, then executed via the outer connector.
+5. **File transfer**: Files are pipelined through temp paths at each layer — uploaded to the
+   outer host, copied inward layer by layer, and cleaned up after.
+
+## Requirements for inner connectors
+
+A connector that can be used as an **inner** layer in a chain must implement:
+
+- `wrap_exec_command(command, container_id)` — wraps a command to run inside the target
+- `wrap_copy_into(src, dest, container_id)` — copies a file from the parent into the target
+- `wrap_copy_out(src, dest, container_id)` — copies a file from the target to the parent
+
+The `container_id` parameter is the runtime identifier returned by the connector's
+`get_runtime_id()` method. By default, `get_runtime_id()` reads the data key specified by
+the `runtime_id_field` class attribute.
+
+Connectors that only work as an **outer** layer (e.g. SSH, which depends on paramiko
+sockets) raise `NotImplementedError` when used as an inner connector.
+
+## Limitations
+
+- Two connectors of the same type cannot appear in the same chain (they share conflicting
+  data keys in `host.data`). Use SSH `ProxyJump` in `~/.ssh/config` for ssh-over-ssh.
+- The chain syntax cannot appear inside a multi-host comma-separated list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ local = "pyinfra.connectors.local:LocalConnector"
 ssh = "pyinfra.connectors.ssh:SSHConnector"
 dockerssh = "pyinfra.connectors.dockerssh:DockerSSHConnector"
 podmanssh = "pyinfra.connectors.dockerssh:PodmanSSHConnector"
+chain = "pyinfra.connectors.chain:ChainedConnector"
 # Inventory only connectors
 terraform = "pyinfra.connectors.terraform:TerraformInventoryConnector"
 vagrant = "pyinfra.connectors.vagrant:VagrantInventoryConnector"

--- a/src/pyinfra/api/inventory.py
+++ b/src/pyinfra/api/inventory.py
@@ -97,6 +97,13 @@ class Inventory:
                 if "/" in connector_name:
                     connector_name, arg_string = connector_name.split("/", 1)
 
+                # Chain syntax: @outer/arg/@inner/arg[/@deeper/arg...]
+                # The sentinel "/@" cannot appear in a hostname, image tag, or container name.
+                if arg_string and "/@" in arg_string:
+                    # Re-prepend the outer connector and route to the chain connector.
+                    arg_string = f"@{connector_name}/{arg_string}"
+                    connector_name = "chain"
+
                 if connector_name not in get_all_connectors():
                     raise NoConnectorError(
                         f"Invalid connector: {connector_name}",

--- a/src/pyinfra/connectors/base.py
+++ b/src/pyinfra/connectors/base.py
@@ -13,7 +13,7 @@ from collections.abc import Iterable, Iterator
 
 from typing_extensions import TypedDict, Unpack
 
-from pyinfra.api.exceptions import ConnectorDataTypeError
+from pyinfra.api.exceptions import ConnectError, ConnectorDataTypeError
 from pyinfra.api.util import raise_if_bad_type
 
 if TYPE_CHECKING:
@@ -72,6 +72,12 @@ class BaseConnector(abc.ABC):
 
     data_cls: type[Any] = ConnectorData
     data_meta: dict[str, DataMeta] = {}
+
+    # Set to the data key that holds this connector's runtime identifier
+    # (e.g. "docker_identifier", "chroot_directory"). BaseConnector.get_runtime_id()
+    # reads self.data[self.runtime_id_field]. Override get_runtime_id() directly
+    # for more complex resolution.
+    runtime_id_field: str | None = None
 
     def __init__(self, state: State, host: Host):
         self.state = state
@@ -153,6 +159,73 @@ class BaseConnector(abc.ABC):
         Returns:
             bool: indicating success or failure.
         """
+
+    def get_runtime_id(self) -> str:
+        """
+        Return the runtime identifier for this connector when used as an inner
+        layer in a :class:`~pyinfra.connectors.chain.ChainedConnector`.
+
+        The default implementation reads ``self.data[self.runtime_id_field]``.
+        Override this method for more complex resolution (e.g. combining multiple
+        data keys or applying transformations).
+
+        This is called *before* :meth:`connect()`, so it must work solely from
+        data available at construction time.
+
+        Raises ``NotImplementedError`` by default if ``runtime_id_field`` is
+        ``None`` — connectors that cannot be used as an inner layer do not need
+        to implement this.
+        """
+        if self.runtime_id_field is None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} cannot be used as an inner connector in a chain"
+            )
+        value = self.data.get(self.runtime_id_field)
+        if not value:
+            raise ConnectError(
+                f"{self.__class__.__name__} used as inner layer but "
+                f"no {self.runtime_id_field} found in host data"
+            )
+        return str(value)
+
+    def wrap_exec_command(self, command: StringCommand, container_id: str) -> StringCommand:
+        """
+        Return a command that, when executed in the *parent* connector's context,
+        runs ``command`` inside this connector's target.
+
+        Only connectors that can be used as an *inner* layer in a chain need to
+        implement this.  The ``container_id`` parameter carries the runtime
+        identifier returned by :meth:`get_runtime_id`.
+
+        Raises ``NotImplementedError`` by default — connectors that cannot be
+        used as an inner layer (e.g. SSH, which depends on paramiko sockets
+        rather than a plain shell string) are excluded automatically.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} cannot be used as an inner connector in a chain"
+        )
+
+    def wrap_copy_into(self, src_on_parent: str, dest: str, container_id: str) -> StringCommand:
+        """
+        Return a command that, when executed in the *parent* connector's context,
+        copies the file at ``src_on_parent`` (a path already present on the parent)
+        into this connector's target at ``dest``.
+
+        Same conventions as :meth:`wrap_exec_command`.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} cannot be used as an inner connector in a chain"
+        )
+
+    def wrap_copy_out(self, src: str, dest_on_parent: str, container_id: str) -> StringCommand:
+        """
+        Return a command that, when executed in the *parent* connector's context,
+        copies the file at ``src`` inside this connector's target to
+        ``dest_on_parent`` on the parent.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} cannot be used as an inner connector in a chain"
+        )
 
     def check_can_rsync(self) -> None:
         raise NotImplementedError("This connector does not support rsync")

--- a/src/pyinfra/connectors/chain.py
+++ b/src/pyinfra/connectors/chain.py
@@ -1,0 +1,415 @@
+"""
+Chained connector — run operations through a stack of connectors.
+
+Syntax::
+
+    @outer/arg/@inner/arg[/@deeper/arg...]
+
+Example::
+
+    pyinfra @ssh/mydoodba/@docker/myodoodev16-odoo-1 files.put ...
+    pyinfra @ssh/bastion/@chroot/rootfs server.shell "ls /"
+
+The left-most connector is the *outermost* (it owns the real network
+connection); the right-most is the *innermost* (closest to the target).
+
+Each inner connector must implement :meth:`~.base.BaseConnector.wrap_exec_command`,
+:meth:`~.base.BaseConnector.wrap_copy_into`, and
+:meth:`~.base.BaseConnector.wrap_copy_out` — connectors that only work as an
+outer layer (e.g. SSH, which depends on paramiko sockets) will raise
+``NotImplementedError`` when used as inner, producing a clear error message.
+
+Two connectors of the same type in the same chain are rejected immediately
+because they would share conflicting data keys in ``host.data``.
+"""
+
+from __future__ import annotations
+
+import re
+from tempfile import mkstemp
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+from typing_extensions import Unpack, override
+
+from pyinfra.api.exceptions import ConnectError, InventoryError
+from pyinfra.api import StringCommand
+from pyinfra.api.output import echo
+
+from .base import BaseConnector
+from .util import extract_control_arguments, make_unix_command_for_host
+
+if TYPE_CHECKING:
+    from pyinfra.api.arguments import ConnectorArguments
+    from pyinfra.api.host import Host
+    from pyinfra.api.state import State
+
+    from .util import CommandOutput
+
+# Segment pattern: @connector_name/optional_arg
+# connector names are alphanum + hyphens
+_SEGMENT_RE = re.compile(r"^@([A-Za-z0-9_-]+)(?:/(.*))?$")
+
+
+def _parse_chain(full_name: str) -> list[tuple[str, str | None]]:
+    """
+    Parse ``@outer/arg/@inner/arg[/@deeper/arg...]`` into an ordered list of
+    ``(connector_name, arg_string)`` tuples — outermost first.
+
+    Raises ``InventoryError`` on malformed input or duplicate connector types.
+    """
+    # Split on "/@" — delimiter cannot appear inside any valid host/image/container name
+    raw_segments = full_name.split("/@")
+    if len(raw_segments) < 2:
+        raise InventoryError(
+            f"@chain: expected at least two segments separated by '/@', got: {full_name!r}"
+        )
+
+    parsed: list[tuple[str, str | None]] = []
+    seen_connectors: set[str] = set()
+
+    for i, seg in enumerate(raw_segments):
+        # First segment already starts with "@" (passed as-is from inventory.py).
+        # Subsequent segments do NOT start with "@" (it was the split delimiter).
+        if i > 0:
+            seg = f"@{seg}"
+
+        m = _SEGMENT_RE.match(seg)
+        if not m:
+            raise InventoryError(
+                f"@chain: cannot parse segment {seg!r} — expected @connector[/arg]"
+            )
+
+        connector_name = m.group(1)
+        arg_string = m.group(2) or None
+
+        if connector_name in seen_connectors:
+            raise InventoryError(
+                f"@chain: connector type {connector_name!r} appears more than once in the chain "
+                f"({full_name!r}).  Two connectors of the same type share conflicting data keys "
+                f"(e.g. ssh_hostname). Use SSH ProxyJump in ~/.ssh/config for ssh-over-ssh."
+            )
+        seen_connectors.add(connector_name)
+        parsed.append((connector_name, arg_string))
+
+    return parsed
+
+
+class ChainedConnector(BaseConnector):
+    """
+    Generic N-level connector chain.
+
+    Instantiated automatically when pyinfra detects ``/@`` in a host name.
+    Do not reference this connector directly in inventory files.
+    """
+
+    handles_execution = True
+
+    # Stack of instantiated connectors: index 0 = outermost, -1 = innermost.
+    _connectors: list[BaseConnector]
+    # Runtime container IDs / chroot paths per inner layer, keyed by layer index.
+    _container_ids: dict[int, str]
+
+    def __init__(self, state: State, host: Host):
+        super().__init__(state, host)
+        self._connectors = []
+        self._container_ids = {}
+
+    def _build_connector_stack(self) -> None:
+        """
+        Instantiate connector objects from ``host.host_data["chain_segments"]``.
+        Called lazily during :meth:`connect` so that state/host are fully
+        initialised before we look up connector classes.
+        """
+        from pyinfra.api.connectors import get_all_connectors
+
+        segments: list[tuple[str, str | None]] = self.host.host_data["chain_segments"]
+        all_connectors = get_all_connectors()
+
+        for connector_name, _ in segments:
+            if connector_name not in all_connectors:
+                raise ConnectError(f"@chain: unknown connector {connector_name!r}")
+            connector_cls = all_connectors[connector_name]
+            self._connectors.append(connector_cls(self.state, self.host))
+
+    @override
+    @staticmethod
+    def make_names_data(name: str | None) -> Iterator[tuple[str, dict, list[str]]]:  # type: ignore[override]
+        if not name:
+            raise InventoryError("@chain: no connector chain provided")
+
+        segments = _parse_chain(name)
+
+        # Delegate to each connector's make_names_data to collect & validate data
+        # and accumulate all yielded data into one merged dict.
+        from pyinfra.api.connectors import get_all_connectors
+
+        all_connectors = get_all_connectors()
+
+        merged_data: dict = {}
+        sub_groups: list[str] = ["@chain"]
+
+        for connector_name, arg_string in segments:
+            if connector_name not in all_connectors:
+                raise InventoryError(f"@chain: unknown connector {connector_name!r}")
+
+            connector_cls = all_connectors[connector_name]
+
+            # Each connector yields (canonical_name, data, groups) tuples.
+            # We take the first yield only (chains are single-host by definition).
+            for _sub_name, sub_data, connector_groups in connector_cls.make_names_data(arg_string):
+                merged_data.update(sub_data)
+                sub_groups.extend(connector_groups)
+                break  # only the first yield per connector
+
+        # Store the parsed segments for use during connect()
+        merged_data["chain_segments"] = segments
+
+        canonical_name = name  # e.g. "@ssh/mydoodba/@docker/myodoodev16-odoo-1"
+
+        yield (canonical_name, merged_data, sub_groups)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @override
+    def connect(self) -> None:
+        self._build_connector_stack()
+
+        # Connect the outermost connector (the one that owns the real socket).
+        self._connectors[0].connect()
+
+        # For inner connectors we do NOT call their connect() — doing so would
+        # trigger a `docker run` / `chroot ls` that either creates an ephemeral
+        # container or requires local tool access.  Inner connectors are purely
+        # about *command wrapping*, not about establishing a new connection.
+        # We store the runtime identifier for each inner layer instead.
+        segments: list[tuple[str, str | None]] = self.host.host_data["chain_segments"]
+
+        for i, (connector_name, arg_string) in enumerate(segments[1:], start=1):
+            connector = self._connectors[i]
+            # Each connector self-reports its own runtime identifier via get_runtime_id().
+            runtime_id = self._runtime_id_for(connector, arg_string)
+            self._container_ids[i] = runtime_id
+
+    def _runtime_id_for(self, connector: BaseConnector, arg_string: str | None) -> str:
+        """
+        Return the runtime identifier for an *inner* connector layer.
+
+        Each connector self-reports its identifier via :meth:`~.base.BaseConnector.get_runtime_id`.
+        Falls back to the raw ``arg_string`` for connectors that do not implement
+        ``get_runtime_id`` (backward compatibility with third-party connectors).
+        """
+        try:
+            return connector.get_runtime_id()
+        except NotImplementedError:
+            if arg_string:
+                return arg_string
+            raise ConnectError(
+                f"@chain: cannot determine runtime ID for inner connector "
+                f"{connector.__class__.__name__!r} — connector does not provide "
+                f"get_runtime_id() and no arg_string fallback available."
+            )
+
+    @override
+    def disconnect(self) -> None:
+        # Only disconnect the outermost connector.
+        # Inner connectors are "exec wrappers" with no socket to close.
+        if self._connectors:
+            self._connectors[0].disconnect()
+
+    # ------------------------------------------------------------------
+    # Command execution
+    # ------------------------------------------------------------------
+
+    @override
+    def run_shell_command(
+        self,
+        command,
+        print_output: bool = False,
+        print_input: bool = False,
+        **arguments: Unpack[ConnectorArguments],
+    ) -> tuple[bool, CommandOutput]:
+        local_arguments = extract_control_arguments(arguments)
+
+        # Apply sudo/env/chdir wrapping once, for the innermost context.
+        wrapped = make_unix_command_for_host(self.state, self.host, command, **arguments)
+
+        # Walk inner layers from innermost to second-outermost, wrapping the
+        # command at each level.
+        for i in range(len(self._connectors) - 1, 0, -1):
+            connector = self._connectors[i]
+            container_id = self._container_ids[i]
+            wrapped = connector.wrap_exec_command(wrapped, container_id)
+
+        # Execute the final wrapped command via the outermost connector.
+        return self._connectors[0].run_shell_command(
+            wrapped,
+            print_output=print_output,
+            print_input=print_input,
+            **local_arguments,
+        )
+
+    # ------------------------------------------------------------------
+    # File transfer
+    # ------------------------------------------------------------------
+
+    @override
+    def put_file(
+        self,
+        filename_or_io,
+        remote_filename: str,
+        remote_temp_filename: str | None = None,
+        print_output: bool = False,
+        print_input: bool = False,
+        **kwargs,
+    ) -> bool:
+        """
+        Upload ``filename_or_io`` to ``remote_filename`` inside the innermost target.
+
+        Pipeline for a 2-layer chain (ssh → docker):
+        1. Upload local file → SSH host temp path (via outer connector's put_file).
+        2. ``docker cp <host_tmp> container:<remote_filename>`` (via SSH).
+        3. ``rm <host_tmp>`` (via SSH).
+        """
+        from pyinfra.api.util import get_file_io
+
+        outer = self._connectors[0]
+        depth = len(self._connectors)
+
+        # Step 1: upload to the outermost layer's filesystem via a temp path.
+        outer_tmp = self.host.get_temp_filename(remote_filename)
+        fd, local_tmp = mkstemp()
+        import os
+
+        try:
+            with get_file_io(filename_or_io) as file_io:
+                with open(local_tmp, "wb") as f:
+                    data = file_io.read()
+                    f.write(data.encode() if isinstance(data, str) else data)
+
+            outer_status = outer.put_file(local_tmp, outer_tmp)
+        finally:
+            os.close(fd)
+            os.remove(local_tmp)
+
+        if not outer_status:
+            raise OSError("@chain: failed to upload file to outer connector")
+
+        # Step 2+: for each subsequent layer, copy from the previous temp path
+        # deeper into the chain.  Execute these copies via the outer connector
+        # (since we only have one real connection — to the outer host).
+        prev_tmp = outer_tmp
+        for i in range(1, depth):
+            connector = self._connectors[i]
+            container_id = self._container_ids[i]
+
+            if i < depth - 1:
+                # Intermediate layer: copy into this layer's temp path
+                next_tmp = self.host.get_temp_filename(f"chain-{i}-{remote_filename}")
+                copy_cmd = connector.wrap_copy_into(prev_tmp, next_tmp, container_id)
+            else:
+                # Innermost layer: copy to the final destination
+                next_tmp = remote_filename
+                copy_cmd = connector.wrap_copy_into(prev_tmp, remote_filename, container_id)
+
+            # Wrap the copy command through all layers above this one (outer → i-1)
+            wrapped_copy = copy_cmd
+            for j in range(i - 1, 0, -1):
+                wrapped_copy = self._connectors[j].wrap_exec_command(
+                    wrapped_copy, self._container_ids[j]
+                )
+
+            status, output = outer.run_shell_command(
+                wrapped_copy,
+                print_output=print_output,
+                print_input=print_input,
+            )
+            if not status:
+                raise OSError(f"@chain: layer {i} copy failed: {output.stderr}")
+
+            # Clean up the previous temp on its host
+            rm_cmd = StringCommand("rm", "-f", prev_tmp)
+            wrapped_rm = rm_cmd
+            for j in range(i - 1, 0, -1):
+                wrapped_rm = self._connectors[j].wrap_exec_command(
+                    wrapped_rm, self._container_ids[j]
+                )
+            outer.run_shell_command(wrapped_rm, print_output=False, print_input=False)
+
+            prev_tmp = next_tmp
+
+        if print_output:
+            echo(
+                f"{self.host.print_prefix}file uploaded: {remote_filename}",
+                err=True,
+            )
+
+        return True
+
+    @override
+    def get_file(
+        self,
+        remote_filename: str,
+        filename_or_io,
+        remote_temp_filename: str | None = None,
+        print_output: bool = False,
+        print_input: bool = False,
+        **kwargs,
+    ) -> bool:
+        """
+        Download ``remote_filename`` from the innermost target to ``filename_or_io``.
+
+        Reverse of :meth:`put_file` — copies outward layer by layer, then
+        downloads to local via the outer connector's get_file.
+        """
+        outer = self._connectors[0]
+        depth = len(self._connectors)
+
+        # Start from innermost: copy out to a temp on the layer above
+        # We build the transfer chain in reverse (innermost → outermost).
+        current_src = remote_filename
+
+        for i in range(depth - 1, 0, -1):
+            connector = self._connectors[i]
+            container_id = self._container_ids[i]
+            dest_tmp = self.host.get_temp_filename(f"chain-out-{i}-{remote_filename}")
+
+            copy_cmd = connector.wrap_copy_out(current_src, dest_tmp, container_id)
+
+            # Wrap through layers between outer and i (exclusive)
+            wrapped_copy = copy_cmd
+            for j in range(i - 1, 0, -1):
+                wrapped_copy = self._connectors[j].wrap_exec_command(
+                    wrapped_copy, self._container_ids[j]
+                )
+
+            status, output = outer.run_shell_command(
+                wrapped_copy,
+                print_output=print_output,
+                print_input=print_input,
+            )
+            if not status:
+                raise OSError(f"@chain: layer {i} copy-out failed: {output.stderr}")
+
+            current_src = dest_tmp
+
+        # current_src is now a path on the outer host — download it locally
+        outer_status = outer.get_file(current_src, filename_or_io)
+
+        # Clean up outer temp
+        outer.run_shell_command(
+            StringCommand("rm", "-f", current_src), print_output=False, print_input=False
+        )
+
+        if not outer_status:
+            raise OSError("@chain: failed to download file from outer connector")
+
+        if print_output:
+            echo(
+                f"{self.host.print_prefix}file downloaded: {remote_filename}",
+                err=True,
+            )
+
+        return True

--- a/src/pyinfra/connectors/chroot.py
+++ b/src/pyinfra/connectors/chroot.py
@@ -3,7 +3,7 @@ import shlex
 from tempfile import mkstemp
 from typing import TYPE_CHECKING
 
-from typing_extensions import Unpack, override
+from typing_extensions import TypedDict, Unpack, override
 
 from pyinfra import local, logger
 from pyinfra.api.output import echo
@@ -12,7 +12,7 @@ from pyinfra.api.exceptions import ConnectError, InventoryError, PyinfraError
 from pyinfra.api.util import get_file_io, memoize
 from pyinfra.progress import progress_spinner
 
-from .base import BaseConnector
+from .base import BaseConnector, DataMeta
 from .local import LocalConnector
 from .util import extract_control_arguments, make_unix_command_for_host
 
@@ -27,12 +27,25 @@ def show_warning() -> None:
     logger.warning("The @chroot connector is in beta!")
 
 
+class ConnectorData(TypedDict):
+    chroot_directory: str
+
+
+connector_data_meta: dict[str, DataMeta] = {
+    "chroot_directory": DataMeta("Directory to chroot into"),
+}
+
+
 class ChrootConnector(BaseConnector):
     """
     The chroot connector allows you to execute operations within another root.
     """
 
     handles_execution = True
+
+    data_cls = ConnectorData
+    data_meta = connector_data_meta
+    runtime_id_field = "chroot_directory"
 
     local: LocalConnector
 
@@ -72,6 +85,32 @@ class ChrootConnector(BaseConnector):
             raise ConnectError(e.args[0])
 
         self.host.connector_data["chroot_directory"] = chroot_directory
+
+    @override
+    def wrap_exec_command(self, command: "StringCommand", container_id: str) -> "StringCommand":
+        return StringCommand(
+            "chroot",
+            QuoteString(container_id),
+            "sh",
+            "-c",
+            QuoteString(command),
+        )
+
+    @override
+    def wrap_copy_into(self, src_on_parent: str, dest: str, container_id: str) -> "StringCommand":
+        return StringCommand(
+            "cp",
+            QuoteString(src_on_parent),
+            QuoteString(f"{container_id}/{dest.lstrip('/')}"),
+        )
+
+    @override
+    def wrap_copy_out(self, src: str, dest_on_parent: str, container_id: str) -> "StringCommand":
+        return StringCommand(
+            "cp",
+            QuoteString(f"{container_id}/{src.lstrip('/')}"),
+            QuoteString(dest_on_parent),
+        )
 
     @override
     def run_shell_command(

--- a/src/pyinfra/connectors/docker.py
+++ b/src/pyinfra/connectors/docker.py
@@ -84,6 +84,8 @@ class DockerConnector(BaseConnector):
     data_meta = connector_data_meta
     data: ConnectorData
 
+    runtime_id_field = "docker_identifier"
+
     local: LocalConnector
 
     container_id: str
@@ -185,6 +187,36 @@ class DockerConnector(BaseConnector):
 
         logger.info(
             f"{self.host.print_prefix}{self.docker_cmd} build complete, image ID: {format_text(image_id, bold=True)}",
+        )
+
+    @override
+    def wrap_exec_command(self, command: StringCommand, container_id: str) -> StringCommand:
+        return StringCommand(
+            self.docker_cmd,
+            "exec",
+            "-i",
+            QuoteString(container_id),
+            "sh",
+            "-c",
+            QuoteString(command),
+        )
+
+    @override
+    def wrap_copy_into(self, src_on_parent: str, dest: str, container_id: str) -> StringCommand:
+        return StringCommand(
+            self.docker_cmd,
+            "cp",
+            QuoteString(src_on_parent),
+            QuoteString(f"{container_id}:{dest}"),
+        )
+
+    @override
+    def wrap_copy_out(self, src: str, dest_on_parent: str, container_id: str) -> StringCommand:
+        return StringCommand(
+            self.docker_cmd,
+            "cp",
+            QuoteString(f"{container_id}:{src}"),
+            QuoteString(dest_on_parent),
         )
 
     @override

--- a/tests/test_connectors/test_chain.py
+++ b/tests/test_connectors/test_chain.py
@@ -1,0 +1,256 @@
+"""
+Tests for the @chain connector.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from pyinfra.api.exceptions import ConnectError, InventoryError
+from pyinfra.connectors.chain import ChainedConnector, _parse_chain
+
+from ..util import make_inventory
+
+
+class TestParseChain(TestCase):
+    def test_two_levels(self):
+        result = _parse_chain("@ssh/mydoodba/@docker/mycontainer")
+        assert result == [("ssh", "mydoodba"), ("docker", "mycontainer")]
+
+    def test_three_levels(self):
+        result = _parse_chain("@ssh/host/@docker/container/@chroot/rootfs")
+        assert result == [
+            ("ssh", "host"),
+            ("docker", "container"),
+            ("chroot", "rootfs"),
+        ]
+
+    def test_arg_with_colon(self):
+        # Docker image tags use colons — must not be confused with separators
+        result = _parse_chain("@ssh/myhost/@docker/ubuntu:20.04")
+        assert result == [("ssh", "myhost"), ("docker", "ubuntu:20.04")]
+
+    def test_too_few_segments_raises(self):
+        with self.assertRaises(InventoryError):
+            _parse_chain("@ssh/host")  # no /@ separator
+
+    def test_duplicate_connector_raises(self):
+        with self.assertRaises(InventoryError) as ctx:
+            _parse_chain("@ssh/bastion/@ssh/inner")
+        assert "appears more than once" in str(ctx.exception)
+
+    def test_malformed_segment_raises(self):
+        with self.assertRaises(InventoryError):
+            _parse_chain("not-at-sign/@docker/c")
+
+
+class TestChainMakeNamesData(TestCase):
+    def test_make_names_data_two_levels(self):
+        with patch(
+            "pyinfra.api.connectors.get_all_connectors",
+        ) as mock_connectors:
+            # Mock ssh connector
+            ssh_cls = MagicMock()
+            ssh_cls.make_names_data.return_value = iter(
+                [("@ssh/host", {"ssh_hostname": "host"}, ["@ssh"])]
+            )
+            # Mock docker connector
+            docker_cls = MagicMock()
+            docker_cls.make_names_data.return_value = iter(
+                [("@docker/mycontainer", {"docker_identifier": "mycontainer"}, ["@docker"])]
+            )
+            mock_connectors.return_value = {
+                "ssh": ssh_cls,
+                "docker": docker_cls,
+            }
+
+            results = list(ChainedConnector.make_names_data("@ssh/host/@docker/mycontainer"))
+
+        assert len(results) == 1
+        name, data, groups = results[0]
+        assert name == "@ssh/host/@docker/mycontainer"
+        assert data["ssh_hostname"] == "host"
+        assert data["docker_identifier"] == "mycontainer"
+        assert data["chain_segments"] == [("ssh", "host"), ("docker", "mycontainer")]
+        assert "@chain" in groups
+        assert "@ssh" in groups
+        assert "@docker" in groups
+
+    def test_make_names_data_no_name_raises(self):
+        with self.assertRaises(InventoryError):
+            list(ChainedConnector.make_names_data(None))
+
+    def test_make_names_data_unknown_connector_raises(self):
+        with patch(
+            "pyinfra.api.connectors.get_all_connectors",
+            return_value={},
+        ):
+            with self.assertRaises(InventoryError):
+                list(ChainedConnector.make_names_data("@ssh/host/@unknown/foo"))
+
+
+class TestChainInventory(TestCase):
+    """Integration tests: chain detection in inventory parsing."""
+
+    def test_chain_detected_in_inventory(self):
+        inventory = make_inventory(hosts=("@ssh/mydoodba/@docker/mycontainer",))
+        host = inventory.get_host("@ssh/mydoodba/@docker/mycontainer")
+        assert host is not None
+        # The connector class should be ChainedConnector
+        assert host.connector_cls is ChainedConnector
+
+    def test_no_chain_unchanged(self):
+        """Ensure single-connector hosts still resolve to their original connector."""
+        from pyinfra.connectors.ssh import SSHConnector
+
+        inventory = make_inventory(hosts=("@ssh/somehost",))
+        host = inventory.get_host("@ssh/somehost")
+        assert host.connector_cls is SSHConnector
+
+
+class TestChainWrapMethods(TestCase):
+    """Unit tests for the wrap_* methods on inner connectors."""
+
+    def test_docker_wrap_exec_command(self):
+        from pyinfra.api import Config, State
+        from pyinfra.connectors.docker import DockerConnector
+        from pyinfra.api import StringCommand
+
+        inventory = make_inventory(hosts=("@docker/mycontainer",))
+        State(inventory, Config())
+        host = inventory.get_host("@docker/mycontainer")
+
+        connector = DockerConnector(host.state, host)
+        cmd = StringCommand("ls", "/tmp")
+        result = connector.wrap_exec_command(cmd, "mycontainer")
+        raw = result.get_raw_value()
+        assert "docker" in raw
+        assert "exec" in raw
+        assert "mycontainer" in raw
+
+    def test_chroot_wrap_exec_command(self):
+        from pyinfra.api import Config, State
+        from pyinfra.connectors.chroot import ChrootConnector
+        from pyinfra.api import StringCommand
+
+        inventory = make_inventory(hosts=("@chroot/rootfs",))
+        State(inventory, Config())
+        host = inventory.get_host("@chroot/rootfs")
+
+        connector = ChrootConnector(host.state, host)
+        cmd = StringCommand("ls", "/etc")
+        result = connector.wrap_exec_command(cmd, "/rootfs")
+        raw = result.get_raw_value()
+        assert "chroot" in raw
+        assert "/rootfs" in raw
+
+    def test_docker_wrap_copy_into(self):
+        from pyinfra.api import Config, State
+        from pyinfra.connectors.docker import DockerConnector
+
+        inventory = make_inventory(hosts=("@docker/mycontainer",))
+        State(inventory, Config())
+        host = inventory.get_host("@docker/mycontainer")
+
+        connector = DockerConnector(host.state, host)
+        result = connector.wrap_copy_into("/tmp/staging.whl", "/tmp/foo.whl", "mycontainer")
+        raw = result.get_raw_value()
+        assert "docker" in raw
+        assert "cp" in raw
+        assert "mycontainer:/tmp/foo.whl" in raw
+
+    def test_ssh_wrap_exec_raises(self):
+        """SSH cannot be used as an inner connector."""
+        from pyinfra.connectors.ssh import SSHConnector
+        from pyinfra.api import Config, State
+        from pyinfra.api import StringCommand
+
+        inventory = make_inventory(hosts=("@ssh/somehost",))
+        State(inventory, Config())
+        host = inventory.get_host("@ssh/somehost")
+        connector = SSHConnector.__new__(SSHConnector)
+        connector.state = host.state
+        connector.host = host
+        cmd = StringCommand("ls")
+        with self.assertRaises(NotImplementedError):
+            connector.wrap_exec_command(cmd, "somehost")
+
+
+class TestGetRuntimeId(TestCase):
+    """Tests for get_runtime_id() on connectors."""
+
+    def test_get_runtime_id_from_field(self):
+        """Connector with runtime_id_field set reads from self.data."""
+        from pyinfra.connectors.base import BaseConnector
+        from pyinfra.api import Config, State
+
+        class MockConnector(BaseConnector):
+            runtime_id_field = "my_id"
+
+            @staticmethod
+            def make_names_data(name=None):
+                raise NotImplementedError()
+
+            def run_shell_command(self, *a, **kw):
+                raise NotImplementedError()
+
+            def put_file(self, *a, **kw):
+                raise NotImplementedError()
+
+            def get_file(self, *a, **kw):
+                raise NotImplementedError()
+
+        inventory = make_inventory(hosts=("@ssh/somehost",))
+        state = State(inventory, Config())
+        host = inventory.get_host("@ssh/somehost")
+        connector = MockConnector.__new__(MockConnector)
+        connector.state = state
+        connector.host = host
+        connector.data = {"my_id": "test-id"}
+        assert connector.get_runtime_id() == "test-id"
+
+    def test_get_runtime_id_not_implemented(self):
+        """Connectors without runtime_id_field raise NotImplementedError."""
+        from pyinfra.connectors.ssh import SSHConnector
+        from pyinfra.api import Config, State
+
+        inventory = make_inventory(hosts=("@ssh/somehost",))
+        State(inventory, Config())
+        host = inventory.get_host("@ssh/somehost")
+        connector = SSHConnector.__new__(SSHConnector)
+        connector.state = host.state
+        connector.host = host
+        # SSHConnector has no runtime_id_field
+        with self.assertRaises(NotImplementedError):
+            connector.get_runtime_id()
+
+
+class TestRuntimeIdFor(TestCase):
+    """Tests for ChainedConnector._runtime_id_for()."""
+
+    def test_delegates_to_get_runtime_id(self):
+        """_runtime_id_for calls connector.get_runtime_id()."""
+        connector = MagicMock()
+        connector.get_runtime_id.return_value = "runtime-42"
+
+        chain = ChainedConnector.__new__(ChainedConnector)
+        result = chain._runtime_id_for(connector, "fallback")
+        assert result == "runtime-42"
+        connector.get_runtime_id.assert_called_once()
+
+    def test_falls_back_to_arg_string(self):
+        """When get_runtime_id() raises NotImplementedError, use arg_string."""
+        connector = MagicMock()
+        connector.get_runtime_id.side_effect = NotImplementedError()
+
+        chain = ChainedConnector.__new__(ChainedConnector)
+        result = chain._runtime_id_for(connector, "fallback-id")
+        assert result == "fallback-id"
+
+    def test_no_runtime_id_and_no_arg_string_raises(self):
+        """When both get_runtime_id() and arg_string are unavailable, raise ConnectError."""
+        connector = MagicMock()
+        connector.get_runtime_id.side_effect = NotImplementedError()
+
+        chain = ChainedConnector.__new__(ChainedConnector)
+        with self.assertRaises(ConnectError):
+            chain._runtime_id_for(connector, None)


### PR DESCRIPTION
## What

A new "transparent" `@chain` connector that lets you nest pyinfra connectors with a natural `/@` delimiter, so you can target hosts that sit behind other hosts:

```shell
# Docker container on a remote host via SSH
pyinfra @ssh/mydoodba/@docker/myodoodev16-odoo-1 files.put src/ /opt/odoo/

# Chroot on a remote host via SSH
pyinfra @ssh/build-server/@chroot/rootfs server.shell "ls /"

# Three levels deep
pyinfra @ssh/jumpbox/@docker/mycontainer server.shell "whoami"
```

The `/@` delimiter reads like a path — it's obvious at a glance that you're descending through layers. It also avoids conflicting with existing connector syntax (`@connector/arg`).

## How it works

- `/@` in a hostname is detected at inventory time and routed to `ChainedConnector`
- Only the **outermost** connector establishes a real connection (SSH socket, local shell, ...)
- **Inner** connectors just *wrap* shell commands — `docker exec`, `chroot`, `cp` — which are composed into a single shell string and sent to the outer connector
- File uploads are pipelined through temp paths at each layer, cleaned up after

## What's chain-compatible today

| Connector | Outer | Inner | Why not inner? |
|-----------|-------|-------|-----------------|
| `ssh` | yes | no | needs paramiko sockets, not a plain shell string |
| `local` | yes | no | not wired for it |
| `docker` | yes | **yes** | `docker exec` / `docker cp` |
| `chroot` | yes | **yes** | `chroot` / `cp` |
| `dockerssh` | yes | no | SSH part is bypassed as inner, use `docker` instead |

Making a connector chain-compatible is a few lines of boilerplate — three `wrap_*` methods + a `runtime_id_field`. The PR includes docs on how to do it.

## Backward compatibility

Zero impact on existing code. No existing connector is modified in a breaking way. The chain syntax only activates when `/@` is present in a hostname. Everything else — `@ssh/host`, `@docker/container`, `@chroot/path` — works exactly as before.

## Files changed

- `src/pyinfra/connectors/chain.py` — the `ChainedConnector` itself (415 lines)
- `src/pyinfra/connectors/base.py` — `get_runtime_id()` + `wrap_*` interface
- `src/pyinfra/connectors/docker.py` — chain support for Docker
- `src/pyinfra/connectors/chroot.py` — chain support for Chroot
- `src/pyinfra/api/inventory.py` — `/@` detection
- `docs/connectors/chain.md` — user-facing docs
- `docs/api/connectors.md` — developer docs for making connectors chain-compatible
- `tests/test_connectors/test_chain.py` — 20 tests covering parsing, inventory detection, wrapping, runtime IDs, and error paths

Built using gemma4, Opus 4.6, DeepSeek v4

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [ ] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
