### PR TITLE
feat(connectors.ssh): add ssh_proxyjump connector data option

### DIFF
--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from random import uniform
 from shutil import which
 from socket import gaierror
@@ -35,6 +36,24 @@ if TYPE_CHECKING:
     from pyinfra.api.arguments import ConnectorArguments
 
 
+# Jump-host specs only ever need these characters (``[user@]host[:port]``,
+# comma-separated, with IPv6 brackets/zone-ids). Anything else — in particular
+# shell metacharacters — is rejected before the value can reach the rsync shell
+# command (which runs locally via ``shell=True``). ``%`` is kept for ssh token /
+# IPv6 zone-id expansion (e.g. ``%h``, ``fe80::1%eth0``), which ssh resolves
+# internally rather than in a shell.
+_PROXYJUMP_SAFE_RE = re.compile(r"\A[A-Za-z0-9._\-@:,\[\]%]+\Z")
+
+
+def _validate_proxyjump_shell_safe(proxyjump: str) -> None:
+    if proxyjump.startswith("-") or not _PROXYJUMP_SAFE_RE.match(proxyjump):
+        raise ValueError(
+            f"Invalid ssh_proxyjump value {proxyjump!r}: only letters, digits and the "
+            "characters . _ - @ : , [ ] % are allowed, and it must not start with '-'. "
+            "For anything more complex, use a ProxyJump entry in ssh_config.",
+        )
+
+
 class ConnectorData(TypedDict):
     ssh_hostname: str
     ssh_port: int
@@ -48,6 +67,7 @@ class ConnectorData(TypedDict):
     ssh_forward_agent: bool
 
     ssh_config_file: str
+    ssh_proxyjump: str
     ssh_known_hosts_file: str
     ssh_strict_host_key_checking: str
 
@@ -79,6 +99,10 @@ connector_data_meta: dict[str, DataMeta] = {
         False,
     ),
     "ssh_config_file": DataMeta("SSH config filename"),
+    "ssh_proxyjump": DataMeta(
+        "SSH ProxyJump host(s), e.g. ``user@bastion``; comma-separate for multiple "
+        "hops. IPv6 hops with explicit ports should use ssh_config Host aliases.",
+    ),
     "ssh_known_hosts_file": DataMeta("SSH known_hosts filename"),
     "ssh_strict_host_key_checking": DataMeta(
         "SSH strict host key checking",
@@ -156,6 +180,15 @@ class SSHConnector(BaseConnector):
             ("my-host-1.net", {"ssh_user": "ssh-user"}),
             ("my-host-2.net", {"ssh_user": "other-user"}),
         ]
+
+    Connecting via a jump/bastion host (also settable on the CLI with
+    ``--data ssh_proxyjump=user@bastion``):
+
+    .. code:: python
+
+        hosts = [
+            ("my-host.net", {"ssh_proxyjump": "user@bastion"}),
+        ]
     """
 
     handles_execution = True
@@ -182,6 +215,7 @@ class SSHConnector(BaseConnector):
             "_pyinfra_ssh_known_hosts_file": self.data["ssh_known_hosts_file"],
             "_pyinfra_ssh_strict_host_key_checking": self.data["ssh_strict_host_key_checking"],
             "_pyinfra_ssh_paramiko_connect_kwargs": self.data["ssh_paramiko_connect_kwargs"],
+            "_pyinfra_ssh_proxyjump": self.data["ssh_proxyjump"],
         }
 
         for key, value in (
@@ -713,6 +747,17 @@ class SSHConnector(BaseConnector):
         ssh_key = self.data["ssh_key"]
         if ssh_key:
             ssh_flags.append(f"-i {ssh_key}")
+
+        proxyjump = self.data["ssh_proxyjump"]
+        if proxyjump:
+            # Normalise hop whitespace and drop empty hops to match the paramiko path,
+            # so the same value (including a stray trailing comma) works for both
+            # command execution and rsync.
+            hops = [hop.strip() for hop in proxyjump.split(",") if hop.strip()]
+            if hops:
+                proxyjump = ",".join(hops)
+                _validate_proxyjump_shell_safe(proxyjump)
+                ssh_flags.append(StringCommand("-J", QuoteString(proxyjump)).get_raw_value())
 
         remote_rsync_command = "rsync"
         if _sudo:

--- a/src/pyinfra/connectors/sshuserclient/client.py
+++ b/src/pyinfra/connectors/sshuserclient/client.py
@@ -193,6 +193,7 @@ class SSHClient(ParamikoClient):
         _pyinfra_ssh_known_hosts_file=None,
         _pyinfra_ssh_strict_host_key_checking=None,
         _pyinfra_ssh_paramiko_connect_kwargs=None,
+        _pyinfra_ssh_proxyjump=None,
         **kwargs,
     ):
         (
@@ -208,6 +209,7 @@ class SSHClient(ParamikoClient):
             kwargs,
             ssh_config_file=_pyinfra_ssh_config_file,
             strict_host_key_checking=_pyinfra_ssh_strict_host_key_checking,
+            proxyjump=_pyinfra_ssh_proxyjump,
         )
         self.set_missing_host_key_policy(missing_host_key_policy)
         config.update(kwargs)
@@ -271,6 +273,7 @@ class SSHClient(ParamikoClient):
         initial_cfg=None,
         ssh_config_file=None,
         strict_host_key_checking=None,
+        proxyjump=None,
     ):
         cfg: dict = {"port": 22}
         cfg.update(initial_cfg or {})
@@ -283,15 +286,19 @@ class SSHClient(ParamikoClient):
 
         ssh_config = get_ssh_config(ssh_config_file)
         if not ssh_config:
-            return (
-                hostname,
-                cfg,
-                forward_agent,
-                missing_host_key_policy,
-                host_keys_files,
-                keep_alive,
-                identity_agent,
-            )
+            if not proxyjump:
+                return (
+                    hostname,
+                    cfg,
+                    forward_agent,
+                    missing_host_key_policy,
+                    host_keys_files,
+                    keep_alive,
+                    identity_agent,
+                )
+            # Honour an explicit ssh_proxyjump even when there is no ssh_config on
+            # disk: an empty config still resolves hop defaults (port 22, etc.).
+            ssh_config = SSHConfig()
 
         host_config = ssh_config.lookup(hostname)
         forward_agent = host_config.get("forwardagent") == "yes"
@@ -335,11 +342,19 @@ class SSHClient(ParamikoClient):
             if agent_path.lower() != "none":
                 identity_agent = path.expanduser(agent_path)
 
-        if "proxycommand" in host_config:
-            cfg["sock"] = ProxyCommand(host_config["proxycommand"])
+        proxy_command = host_config.get("proxycommand")
+        proxy_jump = host_config.get("proxyjump")
+        # An explicit pyinfra ssh_proxyjump overrides any ProxyJump/ProxyCommand
+        # from ssh_config for the target host. An empty string counts as "not set".
+        if proxyjump:
+            proxy_jump = proxyjump
+            proxy_command = None
 
-        elif "proxyjump" in host_config:
-            hops = host_config["proxyjump"].split(",")
+        if proxy_command:
+            cfg["sock"] = ProxyCommand(proxy_command)
+
+        elif proxy_jump:
+            hops = [hop.strip() for hop in proxy_jump.split(",") if hop.strip()]
             sock = None
             # Propagate the target's timeout down so hop connections and the
             # direct-tcpip channel don't hang forever when the network misbehaves
@@ -397,12 +412,19 @@ class SSHClient(ParamikoClient):
         if user:
             shorthand_config["username"] = user
 
-        # IPv6: can't reliably tell where addr ends and port begins, so don't
-        # try (and don't bother adding special syntax either, user should avoid
-        # this situation by using port=).
-        if hostport.count(":") > 1:
+        # Bracketed IPv6, optionally with a port: ``[2001:db8::1]`` or
+        # ``[2001:db8::1]:2222``.
+        if hostport.startswith("[") and "]" in hostport:
+            addr, _, port = hostport[1:].partition("]")
+            hostname = addr or None
+            if port.startswith(":") and port[1:]:
+                shorthand_config["port"] = int(port[1:])
+        # Bare IPv6 (no brackets): can't reliably tell where addr ends and port
+        # begins, so treat the whole thing as the hostname (use the bracketed
+        # form to attach a port).
+        elif hostport.count(":") > 1:
             hostname = hostport
-        # IPv4: can split on ':' reliably.
+        # IPv4 / hostname: can split on ':' reliably.
         else:
             host_port = hostport.rsplit(":", 1)
             hostname = host_port.pop(0) or None

--- a/src/pyinfra/connectors/sshuserclient/client.py
+++ b/src/pyinfra/connectors/sshuserclient/client.py
@@ -369,6 +369,15 @@ class SSHClient(ParamikoClient):
                 hop_connect_kwargs = dict(hop_config)
                 if "timeout" not in hop_connect_kwargs and target_timeout is not None:
                     hop_connect_kwargs["timeout"] = target_timeout
+                # Honour the connection's key-search policy (ssh_look_for_keys /
+                # ssh_allow_agent) on each jump leg rather than falling back to
+                # paramiko's defaults, which would re-scan ~/.ssh and re-prompt for key
+                # passphrases on every hop. Only the boolean policy is propagated, never
+                # credentials (pkey/password): those are per-host and must not be offered
+                # to intermediate jump hosts, and each hop's own ssh_config key applies.
+                for auth_key in ("allow_agent", "look_for_keys"):
+                    if auth_key in cfg and auth_key not in hop_connect_kwargs:
+                        hop_connect_kwargs[auth_key] = cfg[auth_key]
 
                 c = SSHClient()
                 c.connect(

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -413,6 +413,110 @@ class TestOperationsApi(PatchSSHTestCase):
             print_prefix=inventory.get_host("somehost").print_prefix,
         )
 
+    @patch("pyinfra.connectors.ssh.SSHConnector.check_can_rsync", lambda _: True)
+    def test_rsync_op_with_proxyjump(self):
+        inventory = make_inventory(hosts=(("somehost", {"ssh_proxyjump": "user@jump"}),))
+        state = State(inventory, Config())
+        state.current_stage = StateStage.Prepare
+        connect_all(state)
+
+        add_op(state, files.rsync, "src", "dest", _sudo=True, _sudo_user="root")
+
+        assert len(state.get_op_order()) == 1
+
+        with patch("pyinfra.connectors.ssh.run_local_process") as fake_run_local_process:
+            fake_run_local_process.return_value = 0, []
+            run_ops(state)
+
+        fake_run_local_process.assert_called_with(
+            (
+                "rsync -ax --delete --rsh "
+                '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=accept-new\\" -J user@jump"'
+                " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
+            ),
+            print_output=False,
+            print_prefix=inventory.get_host("somehost").print_prefix,
+        )
+
+    @patch("pyinfra.connectors.ssh.SSHConnector.check_can_rsync", lambda _: True)
+    def test_rsync_op_with_proxyjump_multiple_hops(self):
+        # A spaced multi-hop value must be normalised (same as the paramiko path)
+        # so rsync routes through both hops rather than failing validation.
+        inventory = make_inventory(hosts=(("somehost", {"ssh_proxyjump": "alice@j1, bob@j2"}),))
+        state = State(inventory, Config())
+        state.current_stage = StateStage.Prepare
+        connect_all(state)
+
+        add_op(state, files.rsync, "src", "dest", _sudo=True, _sudo_user="root")
+
+        assert len(state.get_op_order()) == 1
+
+        with patch("pyinfra.connectors.ssh.run_local_process") as fake_run_local_process:
+            fake_run_local_process.return_value = 0, []
+            run_ops(state)
+
+        fake_run_local_process.assert_called_with(
+            (
+                "rsync -ax --delete --rsh "
+                '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=accept-new\\" -J alice@j1,bob@j2"'
+                " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
+            ),
+            print_output=False,
+            print_prefix=inventory.get_host("somehost").print_prefix,
+        )
+
+    @patch("pyinfra.connectors.ssh.SSHConnector.check_can_rsync", lambda _: True)
+    def test_rsync_op_with_proxyjump_trailing_comma(self):
+        # A stray trailing comma is dropped rather than producing an empty hop.
+        inventory = make_inventory(hosts=(("somehost", {"ssh_proxyjump": "user@jump,"}),))
+        state = State(inventory, Config())
+        state.current_stage = StateStage.Prepare
+        connect_all(state)
+
+        add_op(state, files.rsync, "src", "dest", _sudo=True, _sudo_user="root")
+
+        with patch("pyinfra.connectors.ssh.run_local_process") as fake_run_local_process:
+            fake_run_local_process.return_value = 0, []
+            run_ops(state)
+
+        fake_run_local_process.assert_called_with(
+            (
+                "rsync -ax --delete --rsh "
+                '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=accept-new\\" -J user@jump"'
+                " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
+            ),
+            print_output=False,
+            print_prefix=inventory.get_host("somehost").print_prefix,
+        )
+
+    @patch("pyinfra.connectors.ssh.SSHConnector.check_can_rsync", lambda _: True)
+    def test_rsync_op_with_proxyjump_ipv6(self):
+        # A bracketed IPv6 jump host is passed through to the local ssh -J,
+        # matching how the paramiko command path resolves it.
+        inventory = make_inventory(
+            hosts=(("somehost", {"ssh_proxyjump": "user@[2001:db8::1]:2222"}),)
+        )
+        state = State(inventory, Config())
+        state.current_stage = StateStage.Prepare
+        connect_all(state)
+
+        add_op(state, files.rsync, "src", "dest", _sudo=True, _sudo_user="root")
+
+        with patch("pyinfra.connectors.ssh.run_local_process") as fake_run_local_process:
+            fake_run_local_process.return_value = 0, []
+            run_ops(state)
+
+        fake_run_local_process.assert_called_with(
+            (
+                "rsync -ax --delete --rsh "
+                '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=accept-new\\"'
+                " -J 'user@[2001:db8::1]:2222'\""
+                " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
+            ),
+            print_output=False,
+            print_prefix=inventory.get_host("somehost").print_prefix,
+        )
+
     def test_rsync_op_failure(self):
         inventory = make_inventory(hosts=("somehost",))
         state = State(inventory, Config())

--- a/tests/test_connectors/test_ssh.py
+++ b/tests/test_connectors/test_ssh.py
@@ -107,6 +107,7 @@ class TestSSHConnector(TestCase):
                 _pyinfra_ssh_known_hosts_file=None,
                 _pyinfra_ssh_strict_host_key_checking="accept-new",
                 _pyinfra_ssh_paramiko_connect_kwargs=None,
+                _pyinfra_ssh_proxyjump=None,
             )
 
         # Check that loading the same key again is cached in the state
@@ -117,6 +118,26 @@ class TestSSHConnector(TestCase):
         second_state.private_keys = state.private_keys
 
         connect_all(second_state)
+
+    def test_connect_with_proxyjump(self):
+        state = State(
+            make_inventory(hosts=(("somehost", {"ssh_proxyjump": "user@bastion"}),)),
+            Config(),
+        )
+        connect_all(state)
+        self.fake_connect_mock.assert_called_with(
+            "somehost",
+            allow_agent=True,
+            look_for_keys=True,
+            timeout=10,
+            username="vagrant",
+            _pyinfra_ssh_forward_agent=False,
+            _pyinfra_ssh_config_file=None,
+            _pyinfra_ssh_known_hosts_file=None,
+            _pyinfra_ssh_strict_host_key_checking="accept-new",
+            _pyinfra_ssh_paramiko_connect_kwargs=None,
+            _pyinfra_ssh_proxyjump="user@bastion",
+        )
 
     def test_retry_paramiko_agent_keys_single_key(self):
         connector = ssh.SSHConnector.__new__(ssh.SSHConnector)
@@ -1252,3 +1273,23 @@ class TestSSHConnector(TestCase):
             unresposivehost.connect(show_errors=False, raise_exceptions=True)
             fake_sleep.assert_called_once()
             assert fake_ssh_client().connect.call_count == 2
+
+    def test_validate_proxyjump_shell_safe(self):
+        # Safe jump-host specs pass through without raising.
+        ssh._validate_proxyjump_shell_safe("user@bastion")
+        ssh._validate_proxyjump_shell_safe("user@bastion:2222")
+        ssh._validate_proxyjump_shell_safe("a@j1,b@j2")
+        ssh._validate_proxyjump_shell_safe("[2001:db8::1]:22")
+
+        # Shell metacharacters are rejected.
+        for bad in (
+            "jump; touch pwned",
+            "$(touch pwned)",
+            "a`b`",
+            "jump host",
+            "a|b",
+            "goodhost\n",
+            "-D1080",
+        ):
+            with self.assertRaises(ValueError):
+                ssh._validate_proxyjump_shell_safe(bad)

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -223,6 +223,32 @@ class TestSSHUserConfigMissing(TestCase):
         assert fake_ssh_connect.call_count == 1
         assert fake_ssh_connect.call_args.args[0] == "jump"
 
+    @patch("pyinfra.connectors.sshuserclient.client.path.exists", lambda path: False)
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.connect")
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.gateway")
+    def test_proxyjump_hop_inherits_key_search_policy(self, fake_gateway, fake_ssh_connect):
+        # The jump leg honours the connection's ssh_look_for_keys / ssh_allow_agent so
+        # a ProxyJump doesn't re-scan keys / re-prompt for passphrases. Credentials
+        # (pkey/password) are per-host and must NOT be offered to intermediate hops.
+        client = SSHClient()
+        client.parse_config(
+            "10.0.0.5",
+            {
+                "port": 22,
+                "allow_agent": True,
+                "look_for_keys": False,
+                "pkey": object(),
+                "password": "hunter2",
+            },
+            proxyjump="root@bastion",
+        )
+        _, hop_kwargs = fake_ssh_connect.call_args
+        assert hop_kwargs["look_for_keys"] is False
+        assert hop_kwargs["allow_agent"] is True
+        # The target's credentials must not leak onto the jump leg.
+        assert "pkey" not in hop_kwargs
+        assert "password" not in hop_kwargs
+
 
 @patch(
     "pyinfra.connectors.sshuserclient.client.path.exists",

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -140,6 +140,89 @@ class TestSSHUserConfigMissing(TestCase):
         assert config.get("port") == 22
         assert identity_agent is None
 
+    @patch(
+        "pyinfra.connectors.sshuserclient.client.path.exists",
+        lambda path: False,
+    )
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.connect")
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.gateway")
+    def test_proxyjump_without_ssh_config(self, fake_gateway, fake_ssh_connect):
+        client = SSHClient()
+        _, config, *_ = client.parse_config(
+            "10.0.0.5",
+            {"port": 22},
+            proxyjump="bastionuser@bastion.example.com",
+        )
+        fake_ssh_connect.assert_called_once_with(
+            "bastion.example.com",
+            _pyinfra_ssh_config_file=None,
+            port=22,
+            sock=None,
+            username="bastionuser",
+        )
+        fake_gateway.assert_called_once_with("10.0.0.5", 22, "10.0.0.5", 22, timeout=None)
+        assert config.get("sock") is fake_gateway.return_value
+
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.gateway")
+    def test_empty_proxyjump_is_ignored(self, fake_gateway):
+        client = SSHClient()
+        _, config, *_ = client.parse_config("10.0.0.5", {"port": 22}, proxyjump="")
+        assert "sock" not in config
+        fake_gateway.assert_not_called()
+
+    @patch("pyinfra.connectors.sshuserclient.client.path.exists", lambda path: False)
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.connect")
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.gateway")
+    def test_proxyjump_override_multiple_hops(self, fake_gateway, fake_ssh_connect):
+        # A spaced multi-hop override builds a hop chain, stripping each hop.
+        client = SSHClient()
+        _, config, *_ = client.parse_config(
+            "10.0.0.5",
+            {"port": 22},
+            proxyjump="alice@jump1, bob@jump2",
+        )
+        assert fake_ssh_connect.call_count == 2
+        first_hop, second_hop = fake_ssh_connect.call_args_list
+        assert first_hop.args[0] == "jump1"
+        assert first_hop.kwargs["username"] == "alice"
+        assert second_hop.args[0] == "jump2"
+        assert second_hop.kwargs["username"] == "bob"
+        assert config.get("sock") is fake_gateway.return_value
+
+    @patch("pyinfra.connectors.sshuserclient.client.path.exists", lambda path: False)
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.connect")
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.gateway")
+    def test_proxyjump_override_bracketed_ipv6(self, fake_gateway, fake_ssh_connect):
+        # A bracketed IPv6 hop with a port resolves the same way the rsync -J
+        # path does, so command execution and rsync agree.
+        client = SSHClient()
+        client.parse_config(
+            "10.0.0.5",
+            {"port": 22},
+            proxyjump="user@[2001:db8::1]:2222",
+        )
+        fake_ssh_connect.assert_called_once_with(
+            "2001:db8::1",
+            _pyinfra_ssh_config_file=None,
+            port=2222,
+            sock=None,
+            username="user",
+        )
+
+    @patch("pyinfra.connectors.sshuserclient.client.path.exists", lambda path: False)
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.connect")
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.gateway")
+    def test_proxyjump_override_ignores_empty_hops(self, fake_gateway, fake_ssh_connect):
+        # A stray trailing comma must not produce an empty hop (connect(None)).
+        client = SSHClient()
+        client.parse_config(
+            "10.0.0.5",
+            {"port": 22},
+            proxyjump="user@jump,",
+        )
+        assert fake_ssh_connect.call_count == 1
+        assert fake_ssh_connect.call_args.args[0] == "jump"
+
 
 @patch(
     "pyinfra.connectors.sshuserclient.client.path.exists",
@@ -364,6 +447,62 @@ class TestSSHUserConfig(TestCase):
 
     @patch(
         "pyinfra.connectors.sshuserclient.client.open",
+        mock_open(read_data=SSH_CONFIG_DATA),
+        create=True,
+    )
+    @patch(
+        "pyinfra.connectors.sshuserclient.config.open",
+        mock_open(read_data=SSH_CONFIG_OTHER_FILE_PROXYJUMP),
+        create=True,
+    )
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.connect")
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.gateway")
+    def test_proxyjump_override_beats_config_proxyjump(self, fake_gateway, fake_ssh_connect):
+        client = SSHClient()
+        _, config, *_ = client.parse_config(
+            "192.168.1.2",
+            {"port": 1022},
+            ssh_config_file="other_file",
+            proxyjump="overrideuser@10.0.0.99",
+        )
+        # The hop is the override target, not the ssh_config ProxyJump host.
+        fake_ssh_connect.assert_called_once_with(
+            "10.0.0.99",
+            _pyinfra_ssh_config_file="other_file",
+            port=22,
+            sock=None,
+            username="overrideuser",
+        )
+        assert config.get("sock") is fake_gateway.return_value
+
+    @patch(
+        "pyinfra.connectors.sshuserclient.client.open",
+        mock_open(read_data=SSH_CONFIG_DATA),
+        create=True,
+    )
+    @patch(
+        "pyinfra.connectors.sshuserclient.config.open",
+        mock_open(read_data=SSH_CONFIG_OTHER_FILE),
+        create=True,
+    )
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.connect")
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.gateway")
+    def test_proxyjump_override_beats_config_proxycommand(self, fake_gateway, fake_ssh_connect):
+        client = SSHClient()
+        _, config, *_ = client.parse_config(
+            "127.0.0.1",
+            proxyjump="overrideuser@10.0.0.99",
+        )
+        # ssh_config ProxyCommand is ignored; a ProxyJump channel is built instead.
+        assert not isinstance(config.get("sock"), ProxyCommand)
+        assert config.get("sock") is fake_gateway.return_value
+        fake_ssh_connect.assert_called_once()
+        hop_args, hop_kwargs = fake_ssh_connect.call_args
+        assert hop_args[0] == "10.0.0.99"
+        assert hop_kwargs["username"] == "overrideuser"
+
+    @patch(
+        "pyinfra.connectors.sshuserclient.client.open",
         mock_open(read_data=SSH_CONFIG_CONNECTTIMEOUT),
         create=True,
     )
@@ -417,6 +556,15 @@ class TestSSHUserConfig(TestCase):
             port=22,
             test="kwarg",
         )
+
+    @patch("pyinfra.connectors.sshuserclient.client.open", mock_open(), create=True)
+    @patch("pyinfra.connectors.sshuserclient.client.ParamikoClient.connect")
+    def test_connect_threads_proxyjump_into_parse_config(self, fake_paramiko_connect):
+        client = SSHClient()
+        stub = ("hostname", {"port": 22}, False, AskPolicy(), (), 0, None)
+        with patch.object(SSHClient, "parse_config", return_value=stub) as fake_parse_config:
+            client.connect("hostname", _pyinfra_ssh_proxyjump="user@jump")
+        assert fake_parse_config.call_args.kwargs["proxyjump"] == "user@jump"
 
     def test_missing_hostkey(self):
         client = SSHClient()


### PR DESCRIPTION
Closes #1720

> Disclaimer: Writing the code in this PR was heavily AI assisted, but further manually reviewed by me. Decided to give it a shot when I ran into this feature limitation while tinkering on my homelab. 

## Summary
Adds an ssh_proxyjump SSH connector data option to route connections through a jump/bastion host — settable via inventory host/group data or --data ssh_proxyjump=user@bastion (no dedicated CLI flag, consistent with how ssh_config_file / ssh_forward_agent are exposed). 

- Applies to both the paramiko connection (command execution + SFTP/SCP) and the files.rsync operation.
- Overrides any ~/.ssh/config ProxyJump/ProxyCommand for the target host, supports comma-separated multi-hop chains (including bracketed IPv6 hops like [2001:db8::1]:2222), and works with or without an ~/.ssh/config on disk.
- The files.rsync path runs a local shell=True command, so the value is allowlist-validated for shell-safety and rendered via QuoteString.
- ProxyJump hops inherit the connection's key-search policy (ssh_look_for_keys / ssh_allow_agent) so a jump host doesn't re-scan ~/.ssh or re-prompt for passphrases; credentials (key/password) are deliberately not offered to intermediate hops.

> Note: this modifies the existing built-in SSH connector (it does not add a new connector), matching recent connector PRs like #1750 and #1679.

## Checklist

- [x] Pull request is based on the default branch (3.x at this time)
- [x] Pull request includes tests for any new/updated operations/facts - this is a connector change with tests in tests/test_connectors/test_ssh.py, tests/test_connectors/test_sshuserclient.py, tests/test_api/test_api_operations.py
- [x] Pull request includes documentation for any new/updated operations/facts - no new operations/facts; the option is documented via the SSH connector's __examples_doc__ and the auto-generated connector data table
- [x] Tests pass (scripts/dev-test.sh) - 1792 passed
- [x] Type checking & code style passes (scripts/dev-lint.sh) - ruff + mypy + arguments-sync all clean
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format