### PR TITLE
feat(operations.util.files): normalize octal mode spellings in ensure_mode_int

### DIFF
--- a/src/pyinfra/operations/util/files.py
+++ b/src/pyinfra/operations/util/files.py
@@ -22,19 +22,39 @@ def unix_path_join(*parts) -> str:
 
 
 def ensure_mode_int(mode: str | int | None) -> int | str | None:
-    # Already an int (/None)?
-    if isinstance(mode, int) or mode is None:
+    """
+    Normalise the accepted mode spellings to the canonical octal-digit
+    integer pyinfra passes to ``chmod`` (and that facts emit), so ``644``,
+    ``"644"``, ``"0644"`` and ``"0o644"`` all mean ``rw-r--r--``.
+
+    Integers are read as their octal digit representation (``644`` means
+    ``rw-r--r--``), matching the existing operations/facts contract. A true
+    octal literal (``0o644``) is indistinguishable from its decimal value
+    (``420``) at runtime - use the ``"0o644"`` string form instead.
+
+    Symbolic modes (``"u+x"``) and ``None`` pass through unchanged.
+    """
+    if mode is None:
         return mode
 
-    try:
-        # Try making an int ('700' -> 700)
-        return int(mode)
+    if isinstance(mode, int):
+        digits = str(mode)
+    else:
+        digits = mode.strip().lower()
+        if digits.startswith("0o"):
+            digits = digits[2:]
+        if not digits.isdigit():
+            # Return as-is (ie +x which we don't need to normalise, it always gets run)
+            return mode
 
-    except (TypeError, ValueError):
-        pass
+    if any(c not in "01234567" for c in digits):
+        raise ValueError(
+            f"Invalid file mode: {mode!r} contains non-octal digits "
+            "(expected octal digits 0-7, eg 644, '0644' or '0o644')",
+        )
 
-    # Return as-is (ie +x which we don't need to normalise, it always gets run)
-    return mode
+    # Drop any leading zeros ('0644' -> 644) for the canonical digit int
+    return int(digits)
 
 
 def get_timestamp() -> str:

--- a/src/pyinfra/operations/util/files.py
+++ b/src/pyinfra/operations/util/files.py
@@ -34,7 +34,7 @@ def ensure_mode_int(mode: str | int | None) -> int | str | None:
 
     Symbolic modes (``"u+x"``) and ``None`` pass through unchanged.
     """
-    if mode is None:
+    if mode is None or isinstance(mode, bool):
         return mode
 
     if isinstance(mode, int):

--- a/tests/test_operations_utils.py
+++ b/tests/test_operations_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyinfra.facts.util.packages import PackageInfo, PackageStatus
 from pyinfra.operations.util.docker import parse_image_reference, parse_registry
-from pyinfra.operations.util.files import unix_path_join
+from pyinfra.operations.util.files import ensure_mode_int, unix_path_join
 from pyinfra.operations.util.packaging import ensure_packages
 
 
@@ -21,6 +21,40 @@ class TestUnixPathJoin(TestCase):
 
     def test_end_slash_path(self):
         assert unix_path_join("/", "home", "pyinfra/") == "/home/pyinfra/"
+
+
+class TestEnsureModeInt(TestCase):
+    def test_int_passes_through(self):
+        assert ensure_mode_int(644) == 644
+
+    def test_plain_string(self):
+        assert ensure_mode_int("644") == 644
+
+    def test_zero_prefixed_string(self):
+        assert ensure_mode_int("0644") == 644
+
+    def test_octal_prefixed_string(self):
+        assert ensure_mode_int("0o644") == 644
+
+    def test_uppercase_octal_prefixed_string(self):
+        assert ensure_mode_int("0O644") == 644
+
+    def test_none_passes_through(self):
+        assert ensure_mode_int(None) is None
+
+    def test_symbolic_mode_passes_through(self):
+        assert ensure_mode_int("u+x") == "u+x"
+
+    def test_setuid_mode(self):
+        assert ensure_mode_int("4755") == 4755
+
+    def test_non_octal_int_raises(self):
+        with pytest.raises(ValueError, match="non-octal digits"):
+            ensure_mode_int(899)
+
+    def test_non_octal_string_raises(self):
+        with pytest.raises(ValueError, match="non-octal digits"):
+            ensure_mode_int("0o899")
 
 
 class TestParseRegistry(TestCase):


### PR DESCRIPTION
## Summary
`files` operations now accept every common mode spelling: `644`, `"644"`, `"0644"`, and `"0o644"` all normalize to the canonical octal-digit integer that `chmod` and the file facts already use. Clearly invalid modes (containing digits 8 or 9) raise a `ValueError` instead of silently producing a wrong `chmod`.

## Why this matters
#1727 reports that working with `mode` values bitwise (e.g. masking `stat.S_ISUID`) is awkward because the value is the octal digit string as a plain int. Fizzadar suggested normalizing the accepted spellings under the existing `mode` argument so any input variant works. This implements that normalization in `ensure_mode_int` (`src/pyinfra/operations/util/files.py`), which all four `files` operation call sites already go through.

One caveat documented in the docstring: a true octal int literal (`0o644`) evaluates to `420` before pyinfra sees it, so it cannot be distinguished from a literal `420`. The `"0o644"` string form covers that intent explicitly.

## Testing
- `uv run pytest --disable-warnings -m 'not end_to_end'`: 1819 passed
- New `TestEnsureModeInt` cases in `tests/test_operations_utils.py` cover all accepted spellings, symbolic pass-through (`"u+x"`), `None`, setuid modes (`"4755"`), and the non-octal error paths
- `ruff check`, `ruff format --check`, and `mypy` clean on the touched files

Fixes #1727
