### PR TITLE
feat(operations.files): Ensure the operations do not fail at the prepare stage if the source does not exists

### DIFF
--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -18,7 +18,6 @@ from typing import IO, Any
 from jinja2 import TemplateRuntimeError, TemplateSyntaxError, UndefinedError
 
 from pyinfra import host, logger, state
-from pyinfra.api.output import format_text
 from pyinfra.api import (
     FileDownloadCommand,
     FileUploadCommand,
@@ -31,6 +30,7 @@ from pyinfra.api import (
     operation,
 )
 from pyinfra.api.command import make_formatted_string_command
+from pyinfra.api.output import format_text
 from pyinfra.api.util import (
     get_call_location,
     get_file_io,
@@ -1488,7 +1488,7 @@ def move(src: str, dest: str, overwrite=False):
     """
 
     if host.get_fact(File, src) is None:
-        raise OperationError(f"src {src} does not exist")
+        logger.warning(f"src {src} does not exist")
 
     if not host.get_fact(Directory, dest):
         raise OperationError(f"dest {dest} is not an existing directory")
@@ -1514,7 +1514,7 @@ def copy(src: str, dest: str, overwrite=False):
     """
     src_is_dir = host.get_fact(Directory, src)
     if not host.get_fact(File, src) and not src_is_dir:
-        raise OperationError(f"src {src} does not exist")
+        logger.warning(f"src {src} does not exist")
 
     if not host.get_fact(Directory, dest):
         raise OperationError(f"dest {dest} is not an existing directory")
@@ -2259,9 +2259,9 @@ def unarchive(
         yield FileUploadCommand(src, temp_archive)
         archive_path = temp_archive
     else:
-        # Validate the remote archive exists
+        # Check if the remote archive exists
         if host.get_fact(File, path=src) is None:
-            raise OperationError(f"Remote archive {src} does not exist")
+            logger.warning(f"Remote archive {src} does not exist")
         archive_path = src
 
     extras = list(extra_opts) if extra_opts else []

--- a/tests/operations/files.copy/invalid_src.json
+++ b/tests/operations/files.copy/invalid_src.json
@@ -1,4 +1,5 @@
 {
+  "require_platform": ["Darwin", "Linux"],
     "kwargs": {
         "src": "/tmp/src_dir/file",
         "dest": "/tmp/dest_dir",
@@ -14,8 +15,5 @@
             "path=/tmp/src_dir/file": null
         }
     },
-    "exception": {
-        "name": "OperationError",
-        "message": "src /tmp/src_dir/file does not exist"
-    }
+    "commands": ["cp -r /tmp/src_dir/file /tmp/dest_dir"]
 }

--- a/tests/operations/files.move/invalid_src.json
+++ b/tests/operations/files.move/invalid_src.json
@@ -3,7 +3,8 @@
     "args": ["tmp/testfile", "tmp2"],
     "facts": {
         "files.File": {
-            "path=tmp/testfile": null
+            "path=tmp/testfile": null,
+            "path=tmp2/testfile": null
         },
         "files.Directory": {
             "path=tmp2": {
@@ -11,8 +12,5 @@
             }
         }
     },
-    "exception": {
-        "name": "OperationError",
-        "message": "src tmp/testfile does not exist"
-    }
+    "commands": ["mv tmp/testfile tmp2"]
 }

--- a/tests/operations/files.unarchive/remote_archive_missing.json
+++ b/tests/operations/files.unarchive/remote_archive_missing.json
@@ -12,8 +12,5 @@
             "path=/tmp/missing.tar.gz": null
         }
     },
-    "exception": {
-        "name": "OperationError",
-        "message": "Remote archive /tmp/missing.tar.gz does not exist"
-    }
+    "commands": ["tar -xz -f /tmp/missing.tar.gz -C /opt/app"]
 }


### PR DESCRIPTION
    Updated the move, copy and unarchive operations to only log the fact
    that the source file does not exists, to prevent the operations from
    failing at the prepare stage.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

- [X] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [X] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
