### PR TITLE
feat: add --exclude CLI argument to restrict target hosts

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,6 +98,24 @@ pyinfra inventory.py deploy.py --limit "db*"
 pyinfra inventory.py deploy.py --limit app_servers --limit db-1.net
 ```
 
+### Exclude
+
+It is possible to exclude hosts from the inventory at execution time using the `--exclude` argument. Multiple `--exclude`s can be provided. The value must either match a specific host by name or via glob style pattern, or match a group name:
+
+```sh
+# Execute against all hosts except db-1.net
+pyinfra inventory.py deploy.py --exclude db-1.net
+
+# Execute against all hosts except hosts in the `db_servers` group
+pyinfra inventory.py deploy.py --exclude db_servers
+
+# Execute against all hosts except names matching db*
+pyinfra inventory.py deploy.py --exclude "db*"
+
+# Apply exclusions after limits
+pyinfra inventory.py deploy.py --limit app_servers --exclude app-2.net
+```
+
 
 ## Ad-hoc command execution
 

--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -9,7 +9,7 @@ from os import chdir as os_chdir, environ, getcwd, path
 import click
 
 from pyinfra import __version__, logger, state
-from pyinfra.api import Config, State
+from pyinfra.api import Config, Host, Inventory, State
 from pyinfra.api.connect import connect_all, disconnect_all
 from pyinfra.api.exceptions import NoGroupError, PyinfraError
 from pyinfra.api.facts import get_facts
@@ -90,6 +90,11 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 @click.option(
     "--limit",
     help="Restrict the target hosts by name and group name.",
+    multiple=True,
+)
+@click.option(
+    "--exclude",
+    help="Exclude target hosts by name and group name.",
     multiple=True,
 )
 @click.option("--fail-percent", type=int, help="% of hosts that need to fail before exiting early.")
@@ -333,6 +338,7 @@ def _main(
     diff: bool,
     yes: bool,
     limit: Iterable,
+    exclude: Iterable,
     no_wait: bool,
     serial: bool,
     retry: int,
@@ -419,8 +425,9 @@ def _main(
     )
     ctx_inventory.set(inventory)
 
-    # Now that we have inventory, apply --limit config override
+    # Now that we have inventory, apply --limit/--exclude config override
     initial_limit = _apply_inventory_limit(inventory, limit)
+    initial_limit = _apply_inventory_exclude(inventory, initial_limit, exclude)
 
     # Initialise the state
     state.init(inventory, config, initial_limit=initial_limit)
@@ -750,24 +757,49 @@ def _set_fail_prompts(state: State, config: Config) -> None:
     state.should_raise_failed_hosts = should_raise_failed_hosts
 
 
-def _apply_inventory_limit(inventory, limit):
-    initial_limit = None
+def _get_inventory_pattern_matches(
+    inventory: Inventory,
+    patterns: Iterable[str],
+    option_name: str,
+) -> list[Host]:
+    all_hosts: list[Host] = []
+
+    for pattern in patterns:
+        try:
+            hosts = inventory.get_group(pattern)
+        except NoGroupError:
+            hosts = [host for host in inventory if fnmatch(host.name, pattern)]
+
+        if not hosts:
+            logger.warning(f"No host matches found for {option_name} pattern: {pattern}")
+
+        all_hosts.extend(hosts)
+
+    return list(set(all_hosts))
+
+
+def _apply_inventory_limit(
+    inventory: Inventory,
+    limit: Iterable[str] | None,
+) -> list[Host] | None:
     if limit:
-        all_limit_hosts = []
+        return _get_inventory_pattern_matches(inventory, limit, "--limit")
 
-        for limiter in limit:
-            try:
-                limit_hosts = inventory.get_group(limiter)
-            except NoGroupError:
-                limit_hosts = [host for host in inventory if fnmatch(host.name, limiter)]
+    return None
 
-            if not limit_hosts:
-                logger.warning(f"No host matches found for --limit pattern: {limiter}")
 
-            all_limit_hosts.extend(limit_hosts)
-        initial_limit = list(set(all_limit_hosts))
+def _apply_inventory_exclude(
+    inventory: Inventory,
+    initial_limit: list[Host] | None,
+    exclude: Iterable[str] | None,
+) -> list[Host] | None:
+    if not exclude:
+        return initial_limit
 
-    return initial_limit
+    excluded_hosts = set(_get_inventory_pattern_matches(inventory, exclude, "--exclude"))
+    limit_hosts = initial_limit if initial_limit is not None else list(inventory)
+
+    return [host for host in limit_hosts if host not in excluded_hosts]
 
 
 # Operations Execution

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -2,7 +2,8 @@ import json
 from os import path
 from unittest import TestCase
 
-from pyinfra_cli.cli import _main
+from pyinfra.api import Host, Inventory
+from pyinfra_cli.cli import _apply_inventory_exclude, _apply_inventory_limit, _main
 
 from ..paramiko_util import PatchSSHTestCase
 from .util import run_cli
@@ -226,6 +227,107 @@ class TestJsonOutput(PatchSSHTestCase):
         assert payload["results"] is not None
         assert set(payload["results"].keys()) == {"operations", "totals", "failed_hosts"}
 
+    def test_json_deploy_with_exclude(self):
+        result = run_cli(
+            "-y",
+            "--json",
+            "--exclude",
+            "somehost",
+            self.inventory,
+            "exec",
+            "--",
+            "echo hi",
+        )
+        payload = self._parse_stdout(result)
+        operation = payload["results"]["operations"][0]
+        assert operation["hosts"] == 1
+        assert operation["success"] == ["anotherhost"]
+
+
+class TestCliLimitExclude(TestCase):
+    def setUp(self):
+        self.inventory = Inventory(
+            (
+                [
+                    "app-1.net",
+                    "app-2.net",
+                    "db-1.net",
+                    "db-2.net",
+                ],
+                {},
+            ),
+            app_servers=(["app-1.net", "app-2.net"], {}),
+            db_servers=(["db-1.net", "db-2.net"], {}),
+        )
+
+    def _host_names(self, hosts: list[Host] | None) -> set[str]:
+        assert hosts is not None
+        return {host.name for host in hosts}
+
+    def test_apply_inventory_exclude_host(self):
+        initial_limit = _apply_inventory_limit(self.inventory, None)
+        limited_hosts = _apply_inventory_exclude(
+            self.inventory,
+            initial_limit,
+            ("app-2.net",),
+        )
+
+        assert self._host_names(limited_hosts) == {
+            "app-1.net",
+            "db-1.net",
+            "db-2.net",
+        }
+
+    def test_apply_inventory_exclude_glob(self):
+        initial_limit = _apply_inventory_limit(self.inventory, None)
+        limited_hosts = _apply_inventory_exclude(self.inventory, initial_limit, ("db*",))
+
+        assert self._host_names(limited_hosts) == {"app-1.net", "app-2.net"}
+
+    def test_apply_inventory_exclude_group(self):
+        initial_limit = _apply_inventory_limit(self.inventory, None)
+        limited_hosts = _apply_inventory_exclude(
+            self.inventory,
+            initial_limit,
+            ("db_servers",),
+        )
+
+        assert self._host_names(limited_hosts) == {"app-1.net", "app-2.net"}
+
+    def test_apply_inventory_limit_then_exclude(self):
+        initial_limit = _apply_inventory_limit(self.inventory, ("app_servers",))
+        limited_hosts = _apply_inventory_exclude(
+            self.inventory,
+            initial_limit,
+            ("app-2.net",),
+        )
+
+        assert self._host_names(limited_hosts) == {"app-1.net"}
+
+    def test_apply_inventory_exclude_no_match_warns(self):
+        initial_limit = _apply_inventory_limit(self.inventory, None)
+
+        with self.assertLogs("pyinfra", level="WARNING") as logs:
+            limited_hosts = _apply_inventory_exclude(
+                self.inventory,
+                initial_limit,
+                ("missing-host",),
+            )
+
+        assert self._host_names(limited_hosts) == {
+            "app-1.net",
+            "app-2.net",
+            "db-1.net",
+            "db-2.net",
+        }
+        assert "No host matches found for --exclude pattern: missing-host" in "\n".join(logs.output)
+
+    def test_apply_inventory_exclude_all_hosts(self):
+        initial_limit = _apply_inventory_limit(self.inventory, None)
+        limited_hosts = _apply_inventory_exclude(self.inventory, initial_limit, ("*",))
+
+        assert limited_hosts == []
+
 
 class TestDirectMainExecution(PatchSSHTestCase):
     """
@@ -260,6 +362,7 @@ class TestDirectMainExecution(PatchSSHTestCase):
                 dry=False,
                 yes=True,
                 limit=None,
+                exclude=tuple(),
                 no_wait=False,
                 serial=False,
                 shell_executable=None,


### PR DESCRIPTION
## Summary

Adds an `--exclude` CLI argument that removes hosts from the execution set, the inverse of `--limit`. It accepts the same matching forms as `--limit` (exact host name, glob pattern, group name), can be passed multiple times, warns on patterns that match nothing, and applies after limits so `--limit app_servers --exclude app-2.net` works the way you'd expect.

## Why this matters

#1381 asks for exactly this: "I would like to be able to use an `--exclude` filter, same as the `--limit`, but with the reverse functionality." Today the only way to skip one host is to enumerate every other host via `--limit`, which doesn't scale on larger inventories.

The implementation extracts the existing `--limit` pattern-matching into a shared helper so both flags resolve names, globs, and groups identically, then `_apply_inventory_exclude` subtracts the matches from the limited set, or from the full inventory when no limit is given.

## Testing

New unit tests cover exclude by host name, glob, and group, exclude combined with `--limit`, the exclude-everything edge, and the no-match warning path. A new `--json` end-to-end test asserts an excluded host is absent from operation results. Full suite: 1816 passed. `ruff check`, `ruff format`, and `mypy` are clean on the changed files, and `scripts/lint_arguments_sync.py` reports in sync. CLI docs gained an Exclude section mirroring the Limit examples.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

Fixes #1381
