### PR TITLE
fix(facts.zfs,facts.server.KernelModules): zfs operations broken on freebsd

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -567,28 +567,45 @@ class KernelModules(FactBase):
 
     @override
     def command(self):
-        return "! test -f /proc/modules || cat /proc/modules"
+        self._kernel = host.get_fact(Kernel)
+
+        if self._kernel.strip() == "FreeBSD":
+            return "kldstat | tail +2"
+        else:
+            return "! test -f /proc/modules || cat /proc/modules"
 
     default = dict
 
     @override
     def process(self, output):
         modules = {}
+        if self._kernel.strip() == "FreeBSD":
+            for line in output:
+                id, refs, address, size, name = line.split(None, 4)
 
-        for line in output:
-            name, size, instances, depends, state, _ = line.split(" ", 5)
-            instances = int(instances)
+                module = {
+                    "address": address,
+                    "id": id,
+                    "refs": refs,
+                    "size": size,
+                }
 
-            module = {
-                "size": size,
-                "instances": instances,
-                "state": state,
-            }
+                modules[name] = module
+        else:
+            for line in output:
+                name, size, instances, depends, state, _ = line.split(" ", 5)
+                instances = int(instances)
 
-            if depends != "-":
-                module["depends"] = [value for value in depends.split(",") if value]
+                module = {
+                    "size": size,
+                    "instances": instances,
+                    "state": state,
+                }
 
-            modules[name] = module
+                if depends != "-":
+                    module["depends"] = [value for value in depends.split(",") if value]
+
+                modules[name] = module
 
         return modules
 

--- a/src/pyinfra/facts/zfs.py
+++ b/src/pyinfra/facts/zfs.py
@@ -45,7 +45,7 @@ class ZfsDatasets(FactBase):
         from pyinfra.facts.server import KernelModules
 
         modules = host.get_fact(KernelModules) or {}
-        if "zfs" not in modules:
+        if "zfs" not in modules and "zfs.ko" not in modules:
             return "kernel module 'zfs' is not loaded"
 
     @override

--- a/tests/facts/server.KernelModules/freebsd_modules.json
+++ b/tests/facts/server.KernelModules/freebsd_modules.json
@@ -1,0 +1,45 @@
+{
+    "command": "kldstat | tail +2",
+    "facts": {
+        "server.Kernel": "FreeBSD"
+    },
+    "output": [
+        " 1   46 0xffffffff80200000  1f4dad0 kernel",
+        " 2    1 0xffffffff8214f000   620c10 zfs.ko",
+        " 3    1 0xffffffff82770000     8808 cryptodev.ko",
+        " 4    1 0xffffffff83018000     3570 fdescfs.ko",
+        " 5    1 0xffffffff8301c000     21e8 hms.ko"
+    ],
+    "fact": {
+        "kernel": {
+            "address": "0xffffffff80200000",
+            "id": "1",
+            "refs": "46",
+            "size": "1f4dad0"
+        },
+        "zfs.ko": {
+            "address": "0xffffffff8214f000",
+            "id": "2",
+            "refs": "1",
+            "size": "620c10"
+        },
+        "cryptodev.ko": {
+            "address": "0xffffffff82770000",
+            "id": "3",
+            "refs": "1",
+            "size": "8808"
+        },
+        "fdescfs.ko": {
+            "address": "0xffffffff83018000",
+            "id": "4",
+            "refs": "1",
+            "size": "3570"
+        },
+        "hms.ko": {
+            "address": "0xffffffff8301c000",
+            "id": "5",
+            "refs": "1",
+            "size": "21e8"
+        }
+    }
+}

--- a/tests/facts/server.KernelModules/linux_modules.json
+++ b/tests/facts/server.KernelModules/linux_modules.json
@@ -1,5 +1,8 @@
 {
     "command": "! test -f /proc/modules || cat /proc/modules",
+    "facts": {
+        "server.Kernel": "Linux"
+    },
     "output": [
         "libahci 32768 1 ahci, Live 0x0000000000000000",
         "i2c_piix4 24576 0 - Live 0x0000000000000000",


### PR DESCRIPTION
Commit 5698bf1 introduced a precondition check which breaks the ZFS operations on FreeBSD. I updated the fact used by this check to include FreeBSD support which fixes this problem.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
