### PR TITLE
fix(operations.zfs): avoid mutable default properties leaking across operation calls

### DIFF
--- a/src/pyinfra/operations/zfs.py
+++ b/src/pyinfra/operations/zfs.py
@@ -14,7 +14,7 @@ def dataset(
     recursive=False,
     sparse=None,
     volume_size=None,
-    properties={},
+    properties=None,
     **extra_props,
 ):
     """
@@ -47,7 +47,7 @@ def dataset(
 
     noop_msg = f"{dataset_name} is already {'present' if present else 'absent'}"
 
-    properties.update(extra_props)
+    properties = {**(properties or {}), **extra_props}
 
     datasets = host.get_fact(ZfsDatasets)
 
@@ -85,7 +85,7 @@ def dataset(
 
 
 @operation()
-def snapshot(snapshot_name, present=True, recursive=False, properties={}, **extra_props):
+def snapshot(snapshot_name, present=True, recursive=False, properties=None, **extra_props):
     """
     Create or destroy a ZFS snapshot, or modify its properties.
 
@@ -102,7 +102,7 @@ def snapshot(snapshot_name, present=True, recursive=False, properties={}, **extr
         zfs.snapshot("tank/home@weekly_backup")
 
     """
-    properties.update(extra_props)
+    properties = {**(properties or {}), **extra_props}
     snapshots = host.get_fact(ZfsSnapshots)
 
     if snapshot_name in snapshots or not present:
@@ -117,7 +117,7 @@ def snapshot(snapshot_name, present=True, recursive=False, properties={}, **extr
 
 @operation()
 def volume(
-    volume_name, size, sparse=False, present=True, recursive=False, properties={}, **extra_props
+    volume_name, size, sparse=False, present=True, recursive=False, properties=None, **extra_props
 ):
     """
     Create or destroy a ZFS volume, or modify its properties.
@@ -137,7 +137,7 @@ def volume(
         zfs.volume("tank/vm-disks/db_srv_04", "32G")
 
     """
-    properties.update(extra_props)
+    properties = {**(properties or {}), **extra_props}
     yield from dataset._inner(
         volume_name,
         volume_size=size,
@@ -149,7 +149,7 @@ def volume(
 
 
 @operation()
-def filesystem(fs_name, present=True, recursive=False, properties={}, **extra_props):
+def filesystem(fs_name, present=True, recursive=False, properties=None, **extra_props):
     """
     Create or destroy a ZFS filesystem, or modify its properties.
 
@@ -166,7 +166,7 @@ def filesystem(fs_name, present=True, recursive=False, properties={}, **extra_pr
         zfs.filesystem("tank/vm-disks/db_srv_04", "32G")
 
     """
-    properties.update(extra_props)
+    properties = {**(properties or {}), **extra_props}
     yield from dataset._inner(
         fs_name,
         present=present,

--- a/tests/operations/zfs.dataset/set_props_extra.yaml
+++ b/tests/operations/zfs.dataset/set_props_extra.yaml
@@ -1,0 +1,13 @@
+args:
+  - tank/home/james
+kwargs:
+  present: true
+  quota: 1T
+  properties:
+    compression: lz4
+facts:
+  zfs.ZfsDatasets:
+    tank/home/james:
+      compression: zstd
+commands:
+  - zfs set compression=lz4 quota=1T tank/home/james


### PR DESCRIPTION
## Summary
ZFS operation `properties` no longer leak across calls. The mutable `{}` default argument is replaced with `None` plus a fresh dict per call.

## Why this matters
@sergpolly reported in #1781 that `zfs.dataset` properties leak across multiple calls. The operations used `properties={}` as a default argument, so every call without an explicit `properties` shared one dict, and `properties.update(extra_props)` mutated that shared object, carrying keys from one invocation into the next. This is the classic mutable-default-argument bug.

## Changes
- `dataset`, `snapshot`, `volume`, and `filesystem`: change `properties={}` to `properties=None` and build a fresh dict with `{**(properties or {}), **extra_props}` instead of mutating the default in place.

## Testing
Added a test fixture exercising extra props on `set` so the merge path is covered. `ruff check` passes; module imports cleanly.

Fixes #1781

AI was used for assistance.
