### PR TITLE
feat: preserve package extras and make pip/pipx/uv installs extras-aware

### DIFF
--- a/src/pyinfra/facts/pip.py
+++ b/src/pyinfra/facts/pip.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import re
+
 from typing_extensions import override
 
-from pyinfra.api import FactBase
+from pyinfra.api import FactBase, QuoteString, StringCommand
+from pyinfra.api.command import make_formatted_string_command
 
-from .util.packaging import parse_packages
+from .util.packaging import parse_packages, pip_report_is_satisfied
 
 PIP_REGEX = r"^([a-zA-Z0-9_\-\+\.]+)==([0-9\.]+[a-z0-9\-]*)$"
+PIP_VERSION_REGEX = r"^pip\s+(\S+)"
 
 
 class PipPackages(FactBase):
@@ -39,3 +43,56 @@ class PipPackages(FactBase):
 
 class Pip3Packages(PipPackages):
     pip_command = "pip3"
+
+
+class PipVersion(FactBase[str | None]):
+    """
+    Returns the version of ``pip`` (e.g. ``"24.0"``), or ``None`` if it cannot be determined.
+    """
+
+    @override
+    def requires_command(self, pip=None) -> str:
+        return pip or "pip"
+
+    @override
+    def command(self, pip=None) -> StringCommand:
+        pip = pip or "pip"
+        return make_formatted_string_command("{0} --version", QuoteString(pip))
+
+    @override
+    def process(self, output: list[str]) -> str | None:
+        for line in output:
+            matches = re.match(PIP_VERSION_REGEX, line)
+            if matches:
+                return matches.group(1)
+        return None
+
+
+class PipInstallDryRun(FactBase[bool]):
+    """
+    Whether ``pip install <spec>`` would change nothing in the current environment, using
+    ``pip``'s own resolver via ``--dry-run``. Used to decide whether a spec carrying extras
+    (e.g. ``foo[bar]``) is already satisfied when the bare package is installed.
+
+    Requires pip >= 22.2 (for ``--dry-run``/``--report``).
+    """
+
+    default = bool  # False == not satisfied == install
+
+    @override
+    def requires_command(self, spec, pip=None) -> str:
+        return pip or "pip"
+
+    @override
+    def command(self, spec, pip=None) -> StringCommand:
+        pip = pip or "pip"
+        # --report - writes the JSON resolution report to stdout; stderr noise is discarded.
+        return make_formatted_string_command(
+            "{0} install --dry-run --quiet --report - {1} 2> /dev/null",
+            QuoteString(pip),
+            QuoteString(spec),
+        )
+
+    @override
+    def process(self, output: list[str]) -> bool:
+        return pip_report_is_satisfied(output)

--- a/src/pyinfra/facts/pipx.py
+++ b/src/pyinfra/facts/pipx.py
@@ -2,9 +2,10 @@ import re
 
 from typing_extensions import override
 
-from pyinfra.api import FactBase
+from pyinfra.api import FactBase, QuoteString, StringCommand
+from pyinfra.api.command import make_formatted_string_command
 
-from .util.packaging import parse_packages
+from .util.packaging import parse_packages, pip_report_is_satisfied
 
 
 # TODO: move to an utils file
@@ -48,6 +49,35 @@ class PipxPackages(FactBase):
     @override
     def process(self, output):
         return parse_packages(PIPX_REGEX, output)
+
+
+class PipxRunpipDryRun(FactBase[bool]):
+    """
+    Whether installing ``spec`` into an already-installed pipx app's venv would change nothing.
+
+    Runs ``pipx runpip <app> install --dry-run`` so pip's resolver inspects the app's own venv.
+    Used to decide whether an extra (e.g. ``foo[bar]``) is already satisfied for an installed app.
+
+    Requires the venv's pip >= 22.2 (for ``--dry-run``/``--report``).
+    """
+
+    default = bool  # False == not satisfied == (re)install
+
+    @override
+    def requires_command(self, app, spec) -> str:
+        return "pipx"
+
+    @override
+    def command(self, app, spec) -> StringCommand:
+        return make_formatted_string_command(
+            "pipx runpip {0} install --dry-run --quiet --report - {1} 2> /dev/null",
+            QuoteString(app),
+            QuoteString(spec),
+        )
+
+    @override
+    def process(self, output: list[str]) -> bool:
+        return pip_report_is_satisfied(output)
 
 
 class PipxEnvironment(FactBase):

--- a/src/pyinfra/facts/util/packaging.py
+++ b/src/pyinfra/facts/util/packaging.py
@@ -1,9 +1,34 @@
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Iterable
 
 PackageVersionDict = dict[str, set[str]]
+
+
+def pip_report_is_satisfied(output: Iterable[str]) -> bool:
+    """Whether a ``pip install --dry-run --report -`` JSON report would change nothing.
+
+    Returns ``True`` only when the report parses and lists no packages to install. Any
+    parse failure or resolver error is treated as "not satisfied" so the real install runs
+    (and surfaces the error).
+    """
+    try:
+        report = json.loads("\n".join(output))
+    except (json.JSONDecodeError, TypeError):
+        return False
+    if not isinstance(report, dict):
+        return False
+    return len(report.get("install", [None])) == 0
+
+
+def uv_dry_run_is_satisfied(output: Iterable[str]) -> bool:
+    """Whether a ``uv pip install --dry-run`` run would change nothing.
+
+    uv prints ``Would make no changes`` when the environment already satisfies the request.
+    """
+    return any("Would make no changes" in line for line in output)
 
 
 def parse_packages(regex: str, output: Iterable[str]) -> PackageVersionDict:

--- a/src/pyinfra/facts/uv.py
+++ b/src/pyinfra/facts/uv.py
@@ -18,9 +18,10 @@ from typing import cast
 from typing_extensions import override
 
 from pyinfra import logger
-from pyinfra.api import StringCommand
+from pyinfra.api import QuoteString, StringCommand
+from pyinfra.api.command import make_formatted_string_command
 from pyinfra.api.facts import FactBase
-from pyinfra.facts.util.packaging import PackageVersionDict
+from pyinfra.facts.util.packaging import PackageVersionDict, uv_dry_run_is_satisfied
 
 UV_CMD = "uv"
 MANAGED_PYTHON = "--managed-python"
@@ -69,6 +70,61 @@ class UvPipPackages(FactBase[PackageVersionDict]):
     @override
     def process(self, output: Iterable[str]) -> PackageVersionDict:
         return process_json(str(self.command()), output, "name", "version")
+
+
+class UvPipInstallDryRun(FactBase[bool]):
+    """
+    Whether ``uv pip install <spec>`` would change nothing in the current environment, using
+    uv's own resolver via ``--dry-run``. Used to decide whether a spec carrying extras
+    (e.g. ``foo[bar]``) is already satisfied when the bare package is installed.
+    """
+
+    default = bool  # False == not satisfied == install
+
+    @override
+    def requires_command(self, spec) -> str:
+        return UV_CMD
+
+    @override
+    def command(self, spec) -> StringCommand:
+        # uv logs to stderr, so fold it into stdout for parsing.
+        return make_formatted_string_command(
+            f"{UV_CMD} pip install --dry-run {{0}} 2>&1",
+            QuoteString(spec),
+        )
+
+    @override
+    def process(self, output: Iterable[str]) -> bool:
+        return uv_dry_run_is_satisfied(output)
+
+
+class UvToolVenvDryRun(FactBase[bool]):
+    """
+    Whether ``spec`` is already satisfied inside an installed ``uv tool`` app's venv.
+
+    ``uv tool install`` has no ``--dry-run``, so this probes the tool's venv directly with
+    ``uv pip install --dry-run --python <tool dir>/<name>/bin/python``. Used to decide whether
+    an extra (e.g. ``foo[bar]``) is already present for an installed tool.
+    """
+
+    default = bool  # False == not satisfied == (re)install
+
+    @override
+    def requires_command(self, tool, spec) -> str:
+        return UV_CMD
+
+    @override
+    def command(self, tool, spec) -> StringCommand:
+        return make_formatted_string_command(
+            f'{UV_CMD} pip install --dry-run --python "$({UV_CMD} tool dir)/{{0}}/bin/python" '
+            "{1} 2>&1",
+            QuoteString(tool),
+            QuoteString(spec),
+        )
+
+    @override
+    def process(self, output: Iterable[str]) -> bool:
+        return uv_dry_run_is_satisfied(output)
 
 
 class UvAvailablePythonsByImplementation(FactBase[PackageVersionDict]):

--- a/src/pyinfra/operations/pip.py
+++ b/src/pyinfra/operations/pip.py
@@ -5,13 +5,19 @@ a virtualenv (virtual environment).
 
 from __future__ import annotations
 
+from packaging.version import InvalidVersion, Version
+
 from pyinfra import host
-from pyinfra.api import QuoteString, StringCommand, operation
+from pyinfra.api import OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.files import File
-from pyinfra.facts.pip import PipPackages
+from pyinfra.facts.pip import PipInstallDryRun, PipPackages, PipVersion
 
 from . import files
 from .util.packaging import PkgInfo, ensure_packages
+
+# Minimum pip version that supports ``install --dry-run`` / ``--report``, required to check whether
+# a spec carrying extras (e.g. foo[bar]) is already satisfied for an installed package.
+MIN_PIP_EXTRAS_VERSION = Version("22.2")
 
 
 @operation()
@@ -149,6 +155,11 @@ def packages(
     Versions:
         Package versions can be pinned like pip: ``<pkg>==<version>``.
 
+    Extras:
+        Packages may request extras (e.g. ``foo[bar]``). When the bare package is already
+        installed, whether the extras are satisfied is checked via ``pip install --dry-run``,
+        which requires pip >= 22.2 (an ``OperationError`` is raised otherwise).
+
     **Example:**
 
     .. code:: python
@@ -193,16 +204,36 @@ def packages(
             packages = [packages]
         # PEP-0426 states that Python packages should be compared using lowercase, so lowercase the
         # current packages. PkgInfo.from_pep508 takes care of the package name
+        pkg_infos = list(filter(None, (PkgInfo.from_pep508(package) for package in packages)))
+
+        # Checking whether extras (e.g. foo[bar]) are already satisfied relies on pip's dry-run.
+        if present and any(pkg.has_extras for pkg in pkg_infos):
+            _require_pip_extras_support(pip)
+
         current_packages = host.get_fact(PipPackages, pip=pip)
         current_packages = {pkg.lower(): versions for pkg, versions in current_packages.items()}
 
         yield from ensure_packages(
             host,
-            list(filter(None, (PkgInfo.from_pep508(package) for package in packages))),
+            pkg_infos,
             current_packages,
             present,
             install_command=install_command,
             uninstall_command=uninstall_command,
             upgrade_command=upgrade_command,
             latest=latest,
+            extras_satisfied=lambda pkg: host.get_fact(PipInstallDryRun, spec=pkg.spec, pip=pip),
+        )
+
+
+def _require_pip_extras_support(pip: str) -> None:
+    pip_version = host.get_fact(PipVersion, pip=pip)
+    try:
+        too_old = pip_version is None or Version(pip_version) < MIN_PIP_EXTRAS_VERSION
+    except InvalidVersion:
+        too_old = True
+    if too_old:
+        raise OperationError(
+            f"pip >= {MIN_PIP_EXTRAS_VERSION} is required to install packages with extras "
+            f"(e.g. foo[bar]); found {pip_version or 'unknown'}"
         )

--- a/src/pyinfra/operations/pipx.py
+++ b/src/pyinfra/operations/pipx.py
@@ -4,7 +4,7 @@ Manage pipx (python) applications.
 
 from pyinfra import host
 from pyinfra.api import operation
-from pyinfra.facts.pipx import PipxEnvironment, PipxPackages
+from pyinfra.facts.pipx import PipxEnvironment, PipxPackages, PipxRunpipDryRun
 from pyinfra.facts.server import Path
 
 from .util.packaging import PkgInfo, ensure_packages
@@ -28,6 +28,11 @@ def packages(
     Versions:
         Package versions can be pinned like pip: ``<pkg>==<version>``.
 
+    Extras:
+        Packages may request extras (e.g. ``foo[bar]``). When the bare package is already
+        installed, whether the extras are satisfied is checked with ``pipx runpip ... --dry-run``;
+        if not, the app is reinstalled with ``pipx install --force``.
+
     **Example:**
 
     .. code:: python
@@ -47,6 +52,12 @@ def packages(
     if extra_args:
         prep_install_command.append(extra_args)
     install_command = " ".join(prep_install_command)
+
+    # pipx install errors on an already-installed app, so adding a missing extra to an installed
+    # app (detected via PipxRunpipDryRun) requires --force.
+    force_reinstall_command = " ".join(
+        ["pipx", "install", "--force", *([extra_args] if extra_args else [])]
+    )
 
     uninstall_command = "pipx uninstall"
     upgrade_command = "pipx upgrade"
@@ -72,6 +83,10 @@ def packages(
             uninstall_command=uninstall_command,
             upgrade_command=upgrade_command,
             latest=latest,
+            extras_satisfied=lambda pkg: host.get_fact(
+                PipxRunpipDryRun, app=pkg.name, spec=pkg.spec
+            ),
+            force_reinstall_command=force_reinstall_command,
         )
 
 

--- a/src/pyinfra/operations/util/packaging.py
+++ b/src/pyinfra/operations/util/packaging.py
@@ -26,13 +26,16 @@ class PkgInfo(NamedTuple):
     version: str
     operator: str
     url: str
+    extras: frozenset[str] = frozenset()
     inst_vers_format_fn: Callable = default_inst_vers_format_fn
     """
-    The key packaging information needed: version, operator and url are optional.
+    The key packaging information needed: version, operator, url and extras are optional.
     """
 
     @property
     def lkup_name(self) -> str | list[str]:
+        # NB: extras are intentionally excluded - installed-package facts are keyed by the bare
+        # name, so the lookup must match on it (extras are handled by the dry-run check instead).
         return self.name if self.version == "" else [self.name, self.version]
 
     @property
@@ -40,25 +43,52 @@ class PkgInfo(NamedTuple):
         return self.version != ""
 
     @property
-    def inst_vers(self) -> str:
-        """String that represents how a program can be installed.
+    def has_extras(self) -> bool:
+        return bool(self.extras)
 
-        - If self.url exists, then url is always returned.
-        - If self.version exists, then inst_vers_format_fn is used
-        to create the string. The default template is '{name}{operator}{version}'.
-        - Otherwise, self.name is returned.
+    @property
+    def extras_str(self) -> str:
+        """The ``[extra1,extra2]`` suffix (sorted for determinism), or ``""`` if none."""
+        return f"[{','.join(sorted(self.extras))}]" if self.extras else ""
 
-        Note, the result string will be quoted, so input is shell safe.
-        """
+    @property
+    def spec(self) -> str:
+        """Unquoted install spec (``name[extras]operator version``), for dry-run commands."""
+        return f"{self.name}{self.extras_str}{self.operator}{self.version}"
+
+    def _vers(self, *, include_extras: bool) -> str:
+        name = self.name + self.extras_str if include_extras else self.name
 
         if self.url:
             return StringCommand(QuoteString(self.url)).get_raw_value()
 
         if self.version:
             return StringCommand(
-                QuoteString(self.inst_vers_format_fn(self.name, self.operator, self.version))
+                QuoteString(self.inst_vers_format_fn(name, self.operator, self.version))
             ).get_raw_value()
-        return StringCommand(QuoteString(self.name)).get_raw_value()
+        return StringCommand(QuoteString(name)).get_raw_value()
+
+    @property
+    def inst_vers(self) -> str:
+        """String that represents how a program can be installed.
+
+        - If self.url exists, then url is always returned.
+        - If self.version exists, then inst_vers_format_fn is used
+        to create the string. The default template is '{name}[extras]{operator}{version}'.
+        - Otherwise, self.name (plus any extras) is returned.
+
+        Note, the result string will be quoted, so input is shell safe.
+        """
+        return self._vers(include_extras=True)
+
+    @property
+    def uninst_vers(self) -> str:
+        """Like :attr:`inst_vers` but without extras.
+
+        Extras (e.g. ``foo[bar]``) are not separately uninstallable - pip/pipx/uv operate on the
+        bare package - so the uninstall spec must omit them.
+        """
+        return self._vers(include_extras=False)
 
     @classmethod
     def from_possible_pair(cls, s: str, join: str | None) -> PkgInfo:
@@ -97,6 +127,7 @@ class PkgInfo(NamedTuple):
                     spec.version if spec is not None else "",
                     spec.operator if spec is not None else "",
                     reqt.url or "",
+                    frozenset(reqt.extras),
                 )
 
 
@@ -185,6 +216,8 @@ def ensure_packages(
     version_join: str | None = None,
     expand_package_fact: Callable[[str], list[str | list[str]]] | None = None,
     expand_match_any: bool = False,
+    extras_satisfied: Callable[[PkgInfo], bool] | None = None,
+    force_reinstall_command: str | StringCommand | None = None,
 ):
     """
     Handles this common scenario:
@@ -217,6 +250,13 @@ def ensure_packages(
             ``<apt_pkg>=<version>``.  Not allowed if (pkg, ver, url) tuples are provided.
         expand_package_fact: fact returning packages providing a capability \
             (ie ``yum whatprovides``)
+        extras_satisfied: callback returning whether a spec carrying extras (e.g. ``foo[bar]``) \
+            is already satisfied. Consulted only when the bare package is installed and the spec \
+            has extras (the installed-package facts are keyed by bare name and cannot answer this).
+        force_reinstall_command: command used to (re)install a package whose bare name is already \
+            installed but whose extras are not yet satisfied. Defaults to ``install_command`` \
+            (suitable for pip/uv pip, where a normal install adds the missing extra deps). pipx \
+            and uv tool pass a ``--force`` variant.
     """
 
     if packages_to_ensure is None:
@@ -241,6 +281,7 @@ def ensure_packages(
     diff_expanded_packages = {}
 
     upgrade_packages = []
+    reinstall_packages = []
 
     if present is True:
         for package in packages:
@@ -251,6 +292,14 @@ def ensure_packages(
             if not has_package:
                 diff_packages.append(package.inst_vers)
                 diff_expanded_packages[package.name] = expanded_packages
+            elif package.has_extras and extras_satisfied is not None:
+                # Bare package is installed, but it was requested with extras (e.g. foo[bar]).
+                # The installed-package facts only know the bare name, so ask the package
+                # manager's own resolver (via the callback) whether the extras are satisfied.
+                if extras_satisfied(package):
+                    host.noop(f"package {package.name} extras already satisfied")
+                else:
+                    reinstall_packages.append(package.inst_vers)
             else:
                 pkg_name = package.name
                 status = _get_package_status(current_packages, pkg_name)
@@ -286,7 +335,7 @@ def ensure_packages(
             )
 
             if has_package:
-                diff_packages.append(package.inst_vers)
+                diff_packages.append(package.uninst_vers)
                 diff_expanded_packages[package.name] = expanded_packages
             else:
                 host.noop(f"package {package.name} is not installed")
@@ -294,6 +343,12 @@ def ensure_packages(
     if diff_packages:
         command = install_command if present else uninstall_command
         yield f"{command} {' '.join([pkg for pkg in diff_packages])}"
+
+    if reinstall_packages:
+        command = (
+            force_reinstall_command if force_reinstall_command is not None else install_command
+        )
+        yield f"{command} {' '.join([pkg for pkg in reinstall_packages])}"
 
     if latest and upgrade_command and upgrade_packages:
         yield f"{upgrade_command} {' '.join([pkg for pkg in upgrade_packages])}"

--- a/src/pyinfra/operations/uv.py
+++ b/src/pyinfra/operations/uv.py
@@ -20,9 +20,11 @@ from pyinfra.facts.uv import (
     MANAGED_PYTHON,
     UV_CMD,
     UvInstalledPythonsByVersion,
+    UvPipInstallDryRun,
     UvPipPackages,
     UvToolDir,
     UvTools,
+    UvToolVenvDryRun,
 )
 from pyinfra.operations import files
 from pyinfra.operations.util.packaging import PkgInfo, ensure_packages
@@ -59,6 +61,10 @@ def packages(
         Package versions can be specified in the `usual manner`_, e.g. ``<pkg>==<version>``.
 
     .. _usual manner: https://pip.pypa.io/en/stable/reference/requirement-specifiers/
+
+    Extras:
+        Packages may request extras (e.g. ``foo[bar]``). When the bare package is already
+        installed, whether the extras are satisfied is checked via ``uv pip install --dry-run``.
 
     **Example:**
 
@@ -99,6 +105,7 @@ def packages(
             uninstall_command=uninstall_command,
             upgrade_command=upgrade_command,
             latest=latest,
+            extras_satisfied=lambda pkg: host.get_fact(UvPipInstallDryRun, spec=pkg.spec),
         )
 
     if (not requirements) and (not packages):
@@ -172,6 +179,11 @@ def tools(
         Tool versions may be, but are not required to be, specified in the
         `usual manner`_: ``<pkg>==<version>``.
 
+    Extras:
+        Tools may request extras (e.g. ``foo[bar]``). When the bare tool is already installed,
+        whether the extras are satisfied is checked by probing the tool's venv; if not, the tool
+        is reinstalled with ``uv tool install --force``.
+
     **Example:**
 
     .. code:: python
@@ -186,6 +198,9 @@ def tools(
     install_command = f"{UV_CMD} tool install --no-progress{extras}"
     uninstall_command = f"{UV_CMD} tool uninstall --no-progress{extras}"
     upgrade_command = f"{UV_CMD} tool install --upgrade --no-progress{extras}"
+    # uv tool install has no --dry-run; an already-installed tool whose extras are missing is
+    # reinstalled with --force (probed via the tool's own venv - see UvToolVenvDryRun).
+    force_reinstall_command = f"{UV_CMD} tool install --force --no-progress{extras}"
 
     already_installed = {pkg.lower(): version for pkg, version in host.get_fact(UvTools).items()}
 
@@ -203,6 +218,10 @@ def tools(
                 uninstall_command=uninstall_command,
                 upgrade_command=upgrade_command,
                 latest=latest,
+                extras_satisfied=lambda pkg: host.get_fact(
+                    UvToolVenvDryRun, tool=pkg.name, spec=pkg.spec
+                ),
+                force_reinstall_command=force_reinstall_command,
             )
     else:
         host.noop("no tools requested to be (un)installed")

--- a/tests/facts/pip.PipInstallDryRun/invalid_output_not_satisfied.yaml
+++ b/tests/facts/pip.PipInstallDryRun/invalid_output_not_satisfied.yaml
@@ -1,0 +1,7 @@
+arg:
+- foo[bar]
+- pip
+command: pip install --dry-run --quiet --report - 'foo[bar]' 2> /dev/null
+requires_command: pip
+output: []
+fact: false

--- a/tests/facts/pip.PipInstallDryRun/not_satisfied.yaml
+++ b/tests/facts/pip.PipInstallDryRun/not_satisfied.yaml
@@ -1,0 +1,8 @@
+arg:
+- foo[bar]
+- pip
+command: pip install --dry-run --quiet --report - 'foo[bar]' 2> /dev/null
+requires_command: pip
+output:
+- '{"version": "1", "install": [{"metadata": {"name": "bar-dep"}}]}'
+fact: false

--- a/tests/facts/pip.PipInstallDryRun/satisfied.yaml
+++ b/tests/facts/pip.PipInstallDryRun/satisfied.yaml
@@ -1,0 +1,8 @@
+arg:
+- foo[bar]
+- pip
+command: pip install --dry-run --quiet --report - 'foo[bar]' 2> /dev/null
+requires_command: pip
+output:
+- '{"version": "1", "install": []}'
+fact: true

--- a/tests/facts/pip.PipVersion/version.yaml
+++ b/tests/facts/pip.PipVersion/version.yaml
@@ -1,0 +1,7 @@
+arg:
+- pip
+command: pip --version
+requires_command: pip
+output:
+- pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)
+fact: "24.0"

--- a/tests/facts/pipx.PipxRunpipDryRun/not_satisfied.yaml
+++ b/tests/facts/pipx.PipxRunpipDryRun/not_satisfied.yaml
@@ -1,0 +1,8 @@
+arg:
+- foo
+- foo[bar]
+command: pipx runpip foo install --dry-run --quiet --report - 'foo[bar]' 2> /dev/null
+requires_command: pipx
+output:
+- '{"version": "1", "install": [{"metadata": {"name": "bar-dep"}}]}'
+fact: false

--- a/tests/facts/pipx.PipxRunpipDryRun/satisfied.yaml
+++ b/tests/facts/pipx.PipxRunpipDryRun/satisfied.yaml
@@ -1,0 +1,8 @@
+arg:
+- foo
+- foo[bar]
+command: pipx runpip foo install --dry-run --quiet --report - 'foo[bar]' 2> /dev/null
+requires_command: pipx
+output:
+- '{"version": "1", "install": []}'
+fact: true

--- a/tests/facts/uv.UvPipInstallDryRun/not_satisfied.yaml
+++ b/tests/facts/uv.UvPipInstallDryRun/not_satisfied.yaml
@@ -1,0 +1,9 @@
+arg: foo[bar]
+command: uv pip install --dry-run 'foo[bar]' 2>&1
+requires_command: uv
+output:
+- Resolved 1 package in 136ms
+- Would download 1 package
+- Would install 1 package
+- ' + bar-dep==6.1'
+fact: false

--- a/tests/facts/uv.UvPipInstallDryRun/satisfied.yaml
+++ b/tests/facts/uv.UvPipInstallDryRun/satisfied.yaml
@@ -1,0 +1,7 @@
+arg: foo[bar]
+command: uv pip install --dry-run 'foo[bar]' 2>&1
+requires_command: uv
+output:
+- Checked 1 package in 3ms
+- Would make no changes
+fact: true

--- a/tests/facts/uv.UvToolVenvDryRun/not_satisfied.yaml
+++ b/tests/facts/uv.UvToolVenvDryRun/not_satisfied.yaml
@@ -1,0 +1,10 @@
+arg:
+- foo
+- foo[bar]
+command: uv pip install --dry-run --python $(uv tool dir)/foo/bin/python 'foo[bar]' 2>&1
+requires_command: uv
+output:
+- Resolved 1 package in 136ms
+- Would install 1 package
+- ' + bar-dep==6.1'
+fact: false

--- a/tests/facts/uv.UvToolVenvDryRun/satisfied.yaml
+++ b/tests/facts/uv.UvToolVenvDryRun/satisfied.yaml
@@ -1,0 +1,9 @@
+arg:
+- foo
+- foo[bar]
+command: uv pip install --dry-run --python $(uv tool dir)/foo/bin/python 'foo[bar]' 2>&1
+requires_command: uv
+output:
+- Checked 1 package in 57ms
+- Would make no changes
+fact: true

--- a/tests/operations/pip.packages/add_packages.json
+++ b/tests/operations/pip.packages/add_packages.json
@@ -1,14 +1,15 @@
 {
-    "args": [["pyinfra==1.1", "pytask", "test==1.1", "another>1"]],
+    "args": [["pyinfra==1.1", "pytask", "test==1.1", "another>1", "foo[bar]"]],
     "facts": {
         "pip.PipPackages": {
             "pip=pip": {
                 "pyinfra": ["1.0"],
                 "test": ["1.1"]
             }
+        },
+        "pip.PipVersion": {
+            "pip=pip": "24.0"
         }
     },
-    "commands": [
-        "pip install pyinfra==1.1 pytask 'another>1'"
-    ]
+    "commands": ["pip install pyinfra==1.1 pytask 'another>1' 'foo[bar]'"]
 }

--- a/tests/operations/pip.packages/extras_already_satisfied.yaml
+++ b/tests/operations/pip.packages/extras_already_satisfied.yaml
@@ -1,0 +1,12 @@
+args:
+- ["foo[bar]"]
+facts:
+  pip.PipVersion:
+    pip=pip: "24.0"
+  pip.PipPackages:
+    pip=pip:
+      foo: ["1.0"]
+  pip.PipInstallDryRun:
+    pip=pip, spec=foo[bar]: true
+commands: []
+noop_description: package foo extras already satisfied

--- a/tests/operations/pip.packages/extras_not_satisfied.yaml
+++ b/tests/operations/pip.packages/extras_not_satisfied.yaml
@@ -1,0 +1,12 @@
+args:
+- ["foo[bar]"]
+facts:
+  pip.PipVersion:
+    pip=pip: "24.0"
+  pip.PipPackages:
+    pip=pip:
+      foo: ["1.0"]
+  pip.PipInstallDryRun:
+    pip=pip, spec=foo[bar]: false
+commands:
+- pip install 'foo[bar]'

--- a/tests/operations/pip.packages/extras_require_modern_pip.json
+++ b/tests/operations/pip.packages/extras_require_modern_pip.json
@@ -1,0 +1,12 @@
+{
+    "args": [["foo[bar]"]],
+    "facts": {
+        "pip.PipVersion": {
+            "pip=pip": "21.0"
+        }
+    },
+    "exception": {
+        "names": ["OperationError"],
+        "message": "pip >= 22.2 is required to install packages with extras (e.g. foo[bar]); found 21.0"
+    }
+}

--- a/tests/operations/pipx.packages/add_packages.json
+++ b/tests/operations/pipx.packages/add_packages.json
@@ -1,10 +1,7 @@
 {
-    "args": [["copier==0.9.1", "invoke", "ensurepath"]],
+    "args": [["copier==0.9.1", "invoke", "ensurepath", "foo[bar]"]],
     "facts": {
-        "pipx.PipxPackages": {"ensurepath": ["0.1.1"]}
-        },
-    "commands": [
-        "pipx install copier==0.9.1",
-        "pipx install invoke"
-    ]
+        "pipx.PipxPackages": { "ensurepath": ["0.1.1"] }
+    },
+    "commands": ["pipx install copier==0.9.1", "pipx install invoke", "pipx install 'foo[bar]'"]
 }

--- a/tests/operations/pipx.packages/extras_already_satisfied.yaml
+++ b/tests/operations/pipx.packages/extras_already_satisfied.yaml
@@ -1,0 +1,9 @@
+args:
+- ["foo[bar]"]
+facts:
+  pipx.PipxPackages:
+    foo: ["1.0"]
+  pipx.PipxRunpipDryRun:
+    app=foo, spec=foo[bar]: true
+commands: []
+noop_description: package foo extras already satisfied

--- a/tests/operations/pipx.packages/extras_not_satisfied.yaml
+++ b/tests/operations/pipx.packages/extras_not_satisfied.yaml
@@ -1,0 +1,9 @@
+args:
+- ["foo[bar]"]
+facts:
+  pipx.PipxPackages:
+    foo: ["1.0"]
+  pipx.PipxRunpipDryRun:
+    app=foo, spec=foo[bar]: false
+commands:
+- pipx install --force 'foo[bar]'

--- a/tests/operations/uv.packages/extras_already_satisfied.yaml
+++ b/tests/operations/uv.packages/extras_already_satisfied.yaml
@@ -1,0 +1,9 @@
+args:
+- ["foo[bar]"]
+facts:
+  uv.UvPipPackages:
+    foo: ["1.0"]
+  uv.UvPipInstallDryRun:
+    spec=foo[bar]: true
+commands: []
+noop_description: package foo extras already satisfied

--- a/tests/operations/uv.packages/extras_not_satisfied.yaml
+++ b/tests/operations/uv.packages/extras_not_satisfied.yaml
@@ -1,0 +1,9 @@
+args:
+- ["foo[bar]"]
+facts:
+  uv.UvPipPackages:
+    foo: ["1.0"]
+  uv.UvPipInstallDryRun:
+    spec=foo[bar]: false
+commands:
+- uv pip install --no-progress  'foo[bar]'

--- a/tests/operations/uv.packages/install_3_packages_with_2_installed.json
+++ b/tests/operations/uv.packages/install_3_packages_with_2_installed.json
@@ -1,6 +1,6 @@
 {
-    "args": [["ruff", "mypy", "pyrefly"]],
-    "kwargs": {"present": true, "extra_args": "--no-cache"},
-    "facts": {"uv.UvPipPackages": {"ruff": ["1.2.3"], "mypy": ["4.5.6"]}},
-    "commands": ["uv pip install --no-progress --no-cache pyrefly"],
+    "args": [["ruff", "mypy", "pyrefly", "foo[bar]>=1.2"]],
+    "kwargs": { "present": true, "extra_args": "--no-cache" },
+    "facts": { "uv.UvPipPackages": { "ruff": ["1.2.3"], "mypy": ["4.5.6"] } },
+    "commands": ["uv pip install --no-progress --no-cache pyrefly 'foo[bar]>=1.2'"]
 }

--- a/tests/operations/uv.packages/remove_package_with_extras.yaml
+++ b/tests/operations/uv.packages/remove_package_with_extras.yaml
@@ -1,0 +1,9 @@
+args:
+- ["foo[bar]"]
+kwargs:
+  present: false
+facts:
+  uv.UvPipPackages:
+    foo: ["1.0"]
+commands:
+- uv pip uninstall --no-progress  foo

--- a/tests/operations/uv.tools/extras_already_satisfied.yaml
+++ b/tests/operations/uv.tools/extras_already_satisfied.yaml
@@ -1,0 +1,9 @@
+args:
+- ["foo[bar]"]
+facts:
+  uv.UvTools:
+    foo: ["1.0"]
+  uv.UvToolVenvDryRun:
+    spec=foo[bar], tool=foo: true
+commands: []
+noop_description: package foo extras already satisfied

--- a/tests/operations/uv.tools/extras_not_satisfied.yaml
+++ b/tests/operations/uv.tools/extras_not_satisfied.yaml
@@ -1,0 +1,9 @@
+args:
+- ["foo[bar]"]
+facts:
+  uv.UvTools:
+    foo: ["1.0"]
+  uv.UvToolVenvDryRun:
+    spec=foo[bar], tool=foo: false
+commands:
+- uv tool install --force --no-progress  'foo[bar]'

--- a/tests/operations/uv.tools/install_3_tools_with_1_existing.json
+++ b/tests/operations/uv.tools/install_3_tools_with_1_existing.json
@@ -1,9 +1,10 @@
 {
-    "args": [["ruff==0.14.4", "mypy", "sphinx >= 8.2"]],
-    "kwargs": {"present": true, "extra_args": "--no-cache"},
-    "facts": {"uv.UvTools": {"mypy": ["1.17.1"]}},
+    "args": [["ruff==0.14.4", "mypy", "sphinx >= 8.2", "foo [bar] >= 1.2"]],
+    "kwargs": { "present": true, "extra_args": "--no-cache" },
+    "facts": { "uv.UvTools": { "mypy": ["1.17.1"] } },
     "commands": [
         "uv tool install --no-progress --no-cache ruff==0.14.4",
         "uv tool install --no-progress --no-cache 'sphinx>=8.2'",
-    ],
+        "uv tool install --no-progress --no-cache 'foo[bar]>=1.2'"
+    ]
 }


### PR DESCRIPTION
PkgInfo.from_pep508 parsed specs with packaging.Requirement but kept only reqt.name, silently dropping extras - so `foo[bar]` was installed as `foo`.

Keep extras on PkgInfo (as the raw frozenset, rendered only at point of use) and include them in the install command, while the installed-package lookup stays keyed by the bare name. The uninstall path uses a new extras-free `uninst_vers`, since extras are not separately uninstallable.

For idempotency, rather than reimplementing a resolver, ask each package manager's own resolver via --dry-run whether an already-installed bare package satisfies the requested extras:

  - pip / uv pip: `<tool> install --dry-run`
  - pipx:         `pipx runpip <app> install --dry-run`
  - uv tool:      probe the tool venv with `uv pip install --dry-run --python`
                  (uv tool install has no --dry-run); reinstall with --force

The dry-run check runs only when a spec carries extras, so plain installs are unaffected and stay offline. pip >= 22.2 is required on the extras path (for --dry-run/--report); pipx and uv tool reinstall missing extras with --force.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
