### PR TITLE
fix(api): allow facts to process empty return values

### DIFF
--- a/src/pyinfra/api/facts.py
+++ b/src/pyinfra/api/facts.py
@@ -348,20 +348,19 @@ def _get_fact(
     data = fact.default()
 
     if status:
-        if stdout_lines:
-            try:
-                data = fact.process(stdout_lines)
-            except FactProcessError as e:
-                log_error_or_warning(
-                    host,
-                    global_kwargs["_ignore_errors"],
-                    description=(f"could not process fact: {name} {get_kwargs_str(fact_kwargs)}"),
-                    exception=e,
-                )
+        try:
+            data = fact.process(stdout_lines)
+        except FactProcessError as e:
+            log_error_or_warning(
+                host,
+                global_kwargs["_ignore_errors"],
+                description=(f"could not process fact: {name} {get_kwargs_str(fact_kwargs)}"),
+                exception=e,
+            )
 
-                # Check we've not failed
-                if apply_failed_hosts and not global_kwargs["_ignore_errors"]:
-                    state.fail_hosts({host})
+            # Check we've not failed
+            if apply_failed_hosts and not global_kwargs["_ignore_errors"]:
+                state.fail_hosts({host})
 
     elif stderr_lines:
         # If we have error output and that error is sudo or su stating the user


### PR DESCRIPTION
Summary
========

Currently the example at [Writing Facts](https://docs.pyinfra.com/en/3.x/api/facts.html#example-getting-swap-status) fails silently. While this can be worked around using additional shell commands (e.g. using `swapon --show | wc -c` ), this seems like a more complicated solution that runs counter to the expected, and documented, way of interacting with the facts API.

Changes
=======

* Remove `stdout_lines` existence check from the `_get_fact` function in `pyinfra.api.facts`

Possible Issues
============

A very small number of facts may depend on the current contra-documented behavior and may throw errors if they are not expecting `output` to be empty.

