### PR TITLE
fix(facts.deb): distinguish package names from deb paths

### DIFF
--- a/src/pyinfra/facts/deb.py
+++ b/src/pyinfra/facts/deb.py
@@ -73,8 +73,14 @@ class DebPackage(FactBase):
 
     @override
     def command(self, package):
+        if "/" in package:
+            return make_formatted_string_command(
+                "dpkg -I {0}",
+                QuoteString(package),
+            )
+
         return make_formatted_string_command(
-            "! test -e {0} && (dpkg -s {0} 2>/dev/null || true) || dpkg -I {0}",
+            "dpkg -s {0} 2>/dev/null || true",
             QuoteString(package),
         )
 

--- a/tests/facts/deb.DebPackage/package.json
+++ b/tests/facts/deb.DebPackage/package.json
@@ -1,6 +1,6 @@
 {
     "arg": "package-name",
-    "command": "! test -e package-name && (dpkg -s package-name 2>/dev/null || true) || dpkg -I package-name",
+    "command": "dpkg -s package-name 2>/dev/null || true",
     "requires_command": "dpkg",
     "output": [
         "Package: package-name",

--- a/tests/facts/deb.DebPackage/package_needs_quotes.json
+++ b/tests/facts/deb.DebPackage/package_needs_quotes.json
@@ -1,6 +1,6 @@
 {
     "arg": "/tmp/my package; whoami.deb",
-    "command": "! test -e '/tmp/my package; whoami.deb' && (dpkg -s '/tmp/my package; whoami.deb' 2>/dev/null || true) || dpkg -I '/tmp/my package; whoami.deb'",
+    "command": "dpkg -I '/tmp/my package; whoami.deb'",
     "requires_command": "dpkg",
     "output": [
         "Package: my-package",

--- a/tests/facts/deb.DebPackage/relative_path.yaml
+++ b/tests/facts/deb.DebPackage/relative_path.yaml
@@ -1,0 +1,9 @@
+arg: ./local-package.deb
+command: dpkg -I ./local-package.deb
+requires_command: dpkg
+output:
+  - "Package: local-package"
+  - "Version: 1.0"
+fact:
+  name: local-package
+  version: "1.0"

--- a/tests/facts/deb.DebPackage/whitespace.json
+++ b/tests/facts/deb.DebPackage/whitespace.json
@@ -1,6 +1,6 @@
 {
     "arg": "/root/tivsm-api64.amd64.deb",
-    "command": "! test -e /root/tivsm-api64.amd64.deb && (dpkg -s /root/tivsm-api64.amd64.deb 2>/dev/null || true) || dpkg -I /root/tivsm-api64.amd64.deb",
+    "command": "dpkg -I /root/tivsm-api64.amd64.deb",
     "requires_command": "dpkg",
     "output": [
       " new Debian package, version 2.0.",


### PR DESCRIPTION
## Summary

`deb.DebPackage` now chooses between installed-package lookup and `.deb` archive inspection from the argument shape instead of remote filesystem state.

Package names without a slash use `dpkg -s`, while paths such as `/tmp/package.deb` or `./package.deb` use `dpkg -I`. This avoids treating an installed package name as a local archive just because a file or directory with the same name exists in the remote working directory.

## What changed

- `src/pyinfra/facts/deb.py`: use `dpkg -s` for slash-free package names and `dpkg -I` for path-like arguments.
- `tests/facts/deb.DebPackage/*`: update the existing command fixtures and add a `./local-package.deb` fixture for the explicit current-directory archive case.

## Testing

```bash
PYTHONPATH= scripts/dev-test.sh
# 1823 passed, 15 deselected, 7 warnings

PYTHONPATH= scripts/dev-lint.sh
# ruff, format, mypy, and arguments sync passed
```

Closes #1795

## AI usage disclosure

This pull request was prepared with AI assistance from OpenAI Codex. I reviewed the issue, repository guidance, code changes, tests, and verification output before submission.
