### PR TITLE
fix(facts.deb): choose package command by argument path

### DIFF
--- a/src/pyinfra/facts/deb.py
+++ b/src/pyinfra/facts/deb.py
@@ -73,8 +73,14 @@ class DebPackage(FactBase):
 
     @override
     def command(self, package):
+        if "/" in str(package):
+            return make_formatted_string_command(
+                "dpkg -I {0}",
+                QuoteString(package),
+            )
+
         return make_formatted_string_command(
-            "! test -e {0} && (dpkg -s {0} 2>/dev/null || true) || dpkg -I {0}",
+            "dpkg -s {0} 2>/dev/null || true",
             QuoteString(package),
         )
 

--- a/tests/facts/deb.DebPackage/archive_name_without_slash.json
+++ b/tests/facts/deb.DebPackage/archive_name_without_slash.json
@@ -1,0 +1,7 @@
+{
+    "arg": "package-name.deb",
+    "command": "dpkg -s package-name.deb 2>/dev/null || true",
+    "requires_command": "dpkg",
+    "output": [],
+    "fact": {}
+}

--- a/tests/facts/deb.DebPackage/current_directory_archive.json
+++ b/tests/facts/deb.DebPackage/current_directory_archive.json
@@ -1,6 +1,6 @@
 {
-    "arg": "package-name",
-    "command": "dpkg -s package-name 2>/dev/null || true",
+    "arg": "./package-name.deb",
+    "command": "dpkg -I ./package-name.deb",
     "requires_command": "dpkg",
     "output": [
         "Package: package-name",

--- a/tests/facts/deb.DebPackage/package_needs_quotes.json
+++ b/tests/facts/deb.DebPackage/package_needs_quotes.json
@@ -1,6 +1,6 @@
 {
     "arg": "/tmp/my package; whoami.deb",
-    "command": "! test -e '/tmp/my package; whoami.deb' && (dpkg -s '/tmp/my package; whoami.deb' 2>/dev/null || true) || dpkg -I '/tmp/my package; whoami.deb'",
+    "command": "dpkg -I '/tmp/my package; whoami.deb'",
     "requires_command": "dpkg",
     "output": [
         "Package: my-package",

--- a/tests/facts/deb.DebPackage/whitespace.json
+++ b/tests/facts/deb.DebPackage/whitespace.json
@@ -1,6 +1,6 @@
 {
     "arg": "/root/tivsm-api64.amd64.deb",
-    "command": "! test -e /root/tivsm-api64.amd64.deb && (dpkg -s /root/tivsm-api64.amd64.deb 2>/dev/null || true) || dpkg -I /root/tivsm-api64.amd64.deb",
+    "command": "dpkg -I /root/tivsm-api64.amd64.deb",
     "requires_command": "dpkg",
     "output": [
       " new Debian package, version 2.0.",


### PR DESCRIPTION
## Summary

- Make `deb.DebPackage` choose `dpkg -s` for package-name lookups and `dpkg -I` for slash-bearing archive paths instead of branching on remote filesystem state.
- Preserve explicit current-directory archive lookup through `./package-name.deb` while treating bare `package-name.deb` as an installed package lookup.
- Add regression fixtures covering package names, absolute/quoted archive paths, and current-directory archive paths.

Closes #1795.

## Checks

- `uv run pytest tests/test_facts.py -k "deb.DebPackage"`
- `uv run pytest tests/test_facts.py`
- `uv run pytest tests/test_operations.py -k "apt.deb"`
- `scripts/dev-test.sh`
- `scripts/dev-lint.sh`
