### PR TITLE
fix: DebPackage fact incorrectly interprets package names as paths

### DIFF
--- a/src/pyinfra/facts/deb.py
+++ b/src/pyinfra/facts/deb.py
@@ -73,8 +73,15 @@ class DebPackage(FactBase):
 
     @override
     def command(self, package):
+        # Always query installed packages first with dpkg -s.
+        # Only fall back to dpkg -I (inspect .deb file) if:
+        #   1. dpkg -s returns nothing (package not installed), AND
+        #   2. a regular file with this name exists (not a directory).
+        # This prevents CWD files/directories with the same name as a package
+        # from being incorrectly treated as .deb archives.
         return make_formatted_string_command(
-            "! test -e {0} && (dpkg -s {0} 2>/dev/null || true) || dpkg -I {0}",
+            "dpkg -s {0} 2>/dev/null || "
+            "([[ -f {0} ]] && dpkg -I {0}) || true",
             QuoteString(package),
         )
 


### PR DESCRIPTION
Fixes the DebPackage fact command that incorrectly checks for file existence before querying installed packages.

**Problem:** The old command `! test -e {pkg} && (dpkg -s {pkg}) || dpkg -I {pkg}` meant that if any file/directory existed in CWD with the same name as a package, it would run `dpkg -I` (inspect .deb file) instead of `dpkg -s` (query installed package). This made it impossible to check installed packages when a same-named file existed in CWD.

**Fix:** The new command `dpkg -s {pkg} 2>/dev/null || ([[ -f {pkg} ]] && dpkg -I {pkg}) || true` always tries `dpkg -s` first, and only falls back to `dpkg -I` if the package is not installed AND a regular file (not directory) with that name exists.

Closes #1795.