### PR TITLE
docs(facts.files): render import example as a code block

### DIFF
--- a/src/pyinfra/facts/files.py
+++ b/src/pyinfra/facts/files.py
@@ -3,7 +3,9 @@ The files facts provide information about the filesystem and it's contents on th
 
 Facts need to be imported before use, eg
 
-from pyinfra.facts.files import File
+.. code:: python
+
+    from pyinfra.facts.files import File
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #1790.

The `files` facts module intro rendered the import example as plain text instead of a code block:

> Facts need to be imported before use, eg
>
> from pyinfra.facts.files import File

The source is the module docstring in `src/pyinfra/facts/files.py`. Wrapping the import line in an RST `.. code:: python` directive (the convention used across the other fact modules) makes the docs pipeline render it as a fenced code block.

Docstring-only change; the 63 files-fact tests pass.
