### PR TITLE
fix(operations.files.line): strip regex anchors from appended lines

### DIFF
--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -70,6 +70,7 @@ from .util.files import (
     get_timestamp,
     sed_delete,
     sed_replace,
+    strip_regex_anchors,
     unix_path_join,
 )
 
@@ -337,6 +338,11 @@ def line(
         it does, like: ``^.*LINE.*$``. This means we don't swap parts of lines out. To
         change bits of lines, see ``files.replace``.
 
+        Because of this wrapping, ``line="foo"`` also matches a commented-out ``#foo`` or
+        any line that merely contains ``foo``. To match a whole line exactly, anchor it
+        yourself with ``^`` and/or ``$`` (eg ``line="^foo$"``); the anchors are used only
+        for matching and are stripped before the line is appended to the file.
+
     Regex line escaping:
         If matching special characters (eg a crontab line containing ``*``), remember to escape
         it first using Python's ``re.escape``.
@@ -429,6 +435,11 @@ def line(
     # We must provide some kind of replace to sed_replace_command below
     else:
         replace = ""
+        # `line` is the regex used to match; when appending it as a literal we must
+        # drop the anchors a user added to match a whole line (eg `^foo$`), otherwise
+        # they leak into the file. Skip when escaping, where the line is taken literally.
+        if not escape_regex_characters:
+            line = strip_regex_anchors(line)
 
     # Save commands for re-use in dynamic script when file not present at fact stage
     if ensure_newline:

--- a/src/pyinfra/operations/util/files.py
+++ b/src/pyinfra/operations/util/files.py
@@ -245,6 +245,22 @@ def adjust_regex(line: str, escape_regex_characters: bool) -> str:
     return match_line
 
 
+def strip_regex_anchors(line: str) -> str:
+    """
+    Strip a leading ``^`` and trailing ``$`` regex anchor from a line.
+
+    Used when appending a missing line to a file: the user-supplied ``line`` is a
+    regex used to find existing matches, but the text written to the file must be
+    literal. Anchors that only have meaning while matching must not leak into the
+    file. An escaped trailing anchor (``\\$``) is left untouched.
+    """
+    if line.startswith("^"):
+        line = line[1:]
+    if line.endswith("$") and not line.endswith("\\$"):
+        line = line[:-1]
+    return line
+
+
 def generate_color_diff(
     current_lines: list[str], desired_lines: list[str]
 ) -> Generator[str, None, None]:

--- a/tests/operations/files.line/add_anchored.yaml
+++ b/tests/operations/files.line/add_anchored.yaml
@@ -1,0 +1,8 @@
+args:
+  - /etc/apk/repositories
+  - ^https://dl-cdn.alpinelinux.org/alpine/v3.21/community$
+facts:
+  files.FindInFile:
+    "extended_regex=False, interpolate_variables=False, path=/etc/apk/repositories, pattern=^https://dl-cdn.alpinelinux.org/alpine/v3.21/community$": []
+commands:
+  - echo https://dl-cdn.alpinelinux.org/alpine/v3.21/community >> /etc/apk/repositories

--- a/tests/operations/files.line/add_escaped_caret_literal.yaml
+++ b/tests/operations/files.line/add_escaped_caret_literal.yaml
@@ -1,0 +1,12 @@
+args:
+  - somefile
+  - ^foo
+kwargs:
+  escape_regex_characters: true
+facts:
+  files.FindInFile:
+    # With escape_regex_characters the leading caret is a literal, so it must be
+    # kept when the line is appended (anchors are only stripped for raw regexes).
+    "extended_regex=False, interpolate_variables=False, path=somefile, pattern=^.*\\^foo.*$": []
+commands:
+  - echo '^foo' >> somefile


### PR DESCRIPTION
Fixes #1783.

## Problem

`files.line` wraps the search pattern as `^.*LINE.*$`, so `line="https://...community"` also matches a commented-out `#https://...community` line (the `.*` padding eats the `#`) and treats it as already present. The documented workaround, anchoring the line with `^`, was itself broken: when the line was missing and no `replace` was given, the append path echoed the raw `line`, leaking the literal `^`/`$` anchor into the file.

## Fix

- Add a `strip_regex_anchors` helper in `operations/util/files.py`.
- In `files.line`, when appending a missing line with no `replace`, strip a leading `^` and trailing `$` from the literal before echoing it. Skipped when `escape_regex_characters` is set, where the line is taken literally (so a literal `^foo` is preserved).
- Clarify the docstring: explain the partial-match behavior and how to anchor for whole-line matching.
- Add fixtures `add_anchored.yaml` (anchored line appends clean) and `add_escaped_caret_literal.yaml` (literal caret is kept under `escape_regex_characters`).

Now `files.line(line="^https://...community$")` skips the `#`-commented line and appends the clean URL.

## Checklist

- [x] Based on the default branch (`3.x`)
- [x] Tests included
- [x] Documentation included (docstring)
- [x] Tests pass (full suite, 1824 passed)
- [x] Type checking & code style passes
