### PR TITLE
fix(operations.apt): quote user input in apt commands

### DIFF
--- a/src/pyinfra/operations/apt.py
+++ b/src/pyinfra/operations/apt.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
 from pyinfra import host
-from pyinfra.api import OperationError, operation
+from pyinfra.api import OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.apt import (
     AptSourcesFile,
     AptSources,
@@ -381,10 +381,10 @@ def ppa(src: str, present=True):
     """
 
     if present:
-        yield f'apt-add-repository -y "{src}"'
+        yield StringCommand("apt-add-repository -y", QuoteString(src))
 
     if not present:
-        yield f'apt-add-repository -y --remove "{src}"'
+        yield StringCommand("apt-add-repository -y --remove", QuoteString(src))
 
 
 @operation()
@@ -442,19 +442,25 @@ def deb(src: str, present=True, force=False):
     if present:
         if not exists:
             # Install .deb file - ignoring failure (on unmet dependencies)
-            yield f"dpkg --force-confdef --force-confold -i {src} 2> /dev/null || true"
+            yield StringCommand(
+                "dpkg --force-confdef --force-confold -i",
+                QuoteString(src),
+                "2> /dev/null || true",
+            )
             # Attempt to install any missing dependencies
             yield f"{noninteractive_apt('install', force=force)} -f"
             # Now reinstall, and critically configure, the package - if there are still
             # missing deps, now we error
-            yield f"dpkg --force-confdef --force-confold -i {src}"
+            yield StringCommand("dpkg --force-confdef --force-confold -i", QuoteString(src))
         else:
             host.noop(f"deb {original_src} is installed")
 
     # Package exists but we don't want?
     if not present:
         if exists:
-            yield f"{noninteractive_apt('remove', force=force)} {info['name']}"
+            yield StringCommand(
+                noninteractive_apt("remove", force=force), QuoteString(info["name"])
+            )
         else:
             host.noop(f"deb {original_src} is not installed")
 

--- a/tests/operations/apt.ppa/add_quotes_injection.json
+++ b/tests/operations/apt.ppa/add_quotes_injection.json
@@ -1,10 +1,10 @@
 {
-    "args": ["ppa:some-repo"],
+    "args": ["x\"; reboot #"],
     "facts": {
         "apt_sources": {},
         "find_in_file:/etc/apt/sources.list": false
     },
     "commands": [
-        "apt-add-repository -y ppa:some-repo"
+        "apt-add-repository -y 'x\"; reboot #'"
     ]
 }

--- a/tests/operations/apt.ppa/remove.json
+++ b/tests/operations/apt.ppa/remove.json
@@ -10,6 +10,6 @@
         "find_in_file:/etc/apt/sources.list": false
     },
     "commands": [
-        "apt-add-repository -y --remove \"ppa:some-repo\""
+        "apt-add-repository -y --remove ppa:some-repo"
     ]
 }


### PR DESCRIPTION
## Describe the bug
`apt.ppa` interpolates the user-supplied `src` into `apt-add-repository` (only inside double quotes, which do not stop shell injection), and `apt.deb` interpolates `src` into `dpkg -i` and the package name into `apt-get remove`, all with f-strings. A crafted value runs arbitrary shell.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import apt

apt.ppa(src='ppa:x"; reboot #')
apt.deb(src='/tmp/pkg.deb; reboot')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `src` and package name are shell-escaped. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
