### PR TITLE
fix(operations.crontab): quote user input in crontab operation and fact

### DIFF
--- a/src/pyinfra/facts/crontab.py
+++ b/src/pyinfra/facts/crontab.py
@@ -3,7 +3,7 @@ from typing import TypedDict
 
 from typing_extensions import NotRequired, override
 
-from pyinfra.api import FactBase
+from pyinfra.api import FactBase, QuoteString, StringCommand
 from pyinfra.api.util import try_int
 
 
@@ -164,8 +164,8 @@ class Crontab(FactBase[CrontabFile]):
     @override
     def command(self, user=None):
         if user:
-            return f"crontab -l -u {user} || true"
-        return "crontab -l || true"
+            return StringCommand("crontab -l -u", QuoteString(user), "|| true")
+        return StringCommand("crontab -l || true")
 
     @override
     def process(self, output):

--- a/src/pyinfra/operations/crontab.py
+++ b/src/pyinfra/operations/crontab.py
@@ -187,19 +187,19 @@ def crontab(
             )
 
     if edit_commands:
-        crontab_args = []
+        crontab_args: list[str | QuoteString] = []
         if user:
-            crontab_args.append(f"-u {user}")
+            crontab_args += ["-u", QuoteString(user)]
 
         # List the crontab into a temporary file if it exists
         if ctb:
-            yield f"crontab -l {' '.join(crontab_args)} > {temp_filename}"
+            yield StringCommand("crontab -l", *crontab_args, ">", QuoteString(temp_filename))
 
         # Now yield any edits
         yield from edit_commands
 
         # Finally, use the tempfile to write a new crontab
-        yield f"crontab {' '.join(crontab_args)} {temp_filename}"
+        yield StringCommand("crontab", *crontab_args, QuoteString(temp_filename))
     else:
         host.noop(
             f"crontab {command} {'exists' if present else 'does not exist'}",

--- a/tests/facts/crontab.Crontab/user_quotes_injection.yaml
+++ b/tests/facts/crontab.Crontab/user_quotes_injection.yaml
@@ -1,0 +1,13 @@
+arg: "x; reboot"
+command: "crontab -l -u 'x; reboot' || true"
+requires_command: crontab
+output:
+  - "* * * * * apt update"
+fact:
+  - command: apt update
+    minute: "*"
+    hour: "*"
+    month: "*"
+    day_of_month: "*"
+    day_of_week: "*"
+    comments: []

--- a/tests/operations/crontab.crontab/add.json
+++ b/tests/operations/crontab.crontab/add.json
@@ -7,6 +7,6 @@
     },
     "commands": [
         "echo '* * * * * this_is_a_command' >> _tempfile_",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/add_named.json
+++ b/tests/operations/crontab.crontab/add_named.json
@@ -18,10 +18,10 @@
         }
     },
     "commands": [
-        "crontab -l  > _tempfile_",
+        "crontab -l > _tempfile_",
         "echo '' >> _tempfile_",
         "echo '# pyinfra-name=a-name' >> _tempfile_",
         "echo '* * * * * this_is_a_command' >> _tempfile_",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/add_named_needs_quotes.json
+++ b/tests/operations/crontab.crontab/add_named_needs_quotes.json
@@ -11,6 +11,6 @@
     "commands": [
         "echo '# pyinfra-name=evil job; $(whoami)' >> _tempfile_",
         "echo '* * * * * backup /etc; rm -rf /' >> _tempfile_",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/add_needs_quotes.json
+++ b/tests/operations/crontab.crontab/add_needs_quotes.json
@@ -7,6 +7,6 @@
     },
     "commands": [
         "echo '* * * * * backup /etc; rm -rf /' >> _tempfile_",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/add_special_time.json
+++ b/tests/operations/crontab.crontab/add_special_time.json
@@ -10,6 +10,6 @@
     },
     "commands": [
         "echo '@reboot this_is_a_command' >> _tempfile_",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/add_user_quotes_injection.json
+++ b/tests/operations/crontab.crontab/add_user_quotes_injection.json
@@ -1,16 +1,15 @@
 {
     "args": ["this_is_a_command"],
+    "kwargs": {
+        "user": "x; reboot"
+    },
     "facts": {
         "crontab.Crontab": {
-            "user=None": {
-                "this_is_another_command": {}
-            }
+            "user=x; reboot": {}
         }
     },
     "commands": [
-        "crontab -l > _tempfile_",
-        "echo '' >> _tempfile_",
         "echo '* * * * * this_is_a_command' >> _tempfile_",
-        "crontab _tempfile_"
+        "crontab -u 'x; reboot' _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/change_from_special_time.json
+++ b/tests/operations/crontab.crontab/change_from_special_time.json
@@ -15,8 +15,8 @@
         }
     },
     "commands": [
-        "crontab -l  > _tempfile_",
+        "crontab -l > _tempfile_",
         "sed -i.a-timestamp 's/.*this_is_a_command.*/5 1 * * * this_is_a_command/' _tempfile_ && rm -f _tempfile_.a-timestamp",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/change_to_special_time.json
+++ b/tests/operations/crontab.crontab/change_to_special_time.json
@@ -15,8 +15,8 @@
         }
     },
     "commands": [
-        "crontab -l  > _tempfile_",
+        "crontab -l > _tempfile_",
         "sed -i.a-timestamp 's/.*this_is_a_command.*/@reboot this_is_a_command/' _tempfile_ && rm -f _tempfile_.a-timestamp",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/edit.json
+++ b/tests/operations/crontab.crontab/edit.json
@@ -19,8 +19,8 @@
         }
     },
     "commands": [
-        "crontab -l  > _tempfile_",
+        "crontab -l > _tempfile_",
         "sed -i.a-timestamp 's/.*this_is_a_command.*/* * * 1 1,2,3 this_is_a_command/' _tempfile_ && rm -f _tempfile_.a-timestamp",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/edit_named.json
+++ b/tests/operations/crontab.crontab/edit_named.json
@@ -21,8 +21,8 @@
         }
     },
     "commands": [
-        "crontab -l  > _tempfile_",
+        "crontab -l > _tempfile_",
         "sed -i.a-timestamp 's/.*command_to_change.*/* * * 1 * command_to_be '\"'\"'with_a_quoted_argument'\"'\"'/' _tempfile_ && rm -f _tempfile_.a-timestamp",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/edit_special_time.json
+++ b/tests/operations/crontab.crontab/edit_special_time.json
@@ -14,8 +14,8 @@
         }
     },
     "commands": [
-        "crontab -l  > _tempfile_",
+        "crontab -l > _tempfile_",
         "sed -i.a-timestamp 's/.*this_is_a_command.*/@reboot this_is_a_command/' _tempfile_ && rm -f _tempfile_.a-timestamp",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }

--- a/tests/operations/crontab.crontab/remove.json
+++ b/tests/operations/crontab.crontab/remove.json
@@ -18,8 +18,8 @@
         }
     },
     "commands": [
-        "crontab -l  > _tempfile_",
+        "crontab -l > _tempfile_",
         "sed -i.a-timestamp '/.*this_is_a_command.*/d' _tempfile_ && rm -f _tempfile_.a-timestamp",
-        "crontab  _tempfile_"
+        "crontab _tempfile_"
     ]
 }


### PR DESCRIPTION
## Describe the bug
Both the `crontab.crontab` operation and the `Crontab` fact interpolate user input into shell commands with f-strings, so a crafted `user` runs arbitrary shell.

- Operation: `crontab.crontab` builds the `crontab -l`/`crontab` commands via `-u {user}` and the temp filename with f-strings.
- Fact: `Crontab.command` returns `f"crontab -l -u {user} || true"`, so reading the current crontab for a crafted user is also injectable.

This PR fixes both by composing the commands with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import crontab

crontab.crontab(command='/bin/true', user='x; reboot')
```

The same `user` flows into the `Crontab` fact, so the read path is affected too.

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `user` and temp filename are shell-escaped in both the operation and the fact. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. New injection fixtures cover both the operation and the fact.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
