### PR TITLE
fix(facts.mysql): shell-quote mysql connection params

### DIFF
--- a/src/pyinfra/facts/mysql.py
+++ b/src/pyinfra/facts/mysql.py
@@ -19,24 +19,24 @@ def make_mysql_command(
     port: int | None = None,
     executable="mysql",
 ):
-    target_bits = [executable]
+    target_bits: list[str | StringCommand] = [executable]
 
     if database:
-        target_bits.append(database)
+        target_bits.append(StringCommand(QuoteString(database)))
 
     if user:
-        # Quote the username as in may contain special characters
-        target_bits.append(f'-u"{user}"')
+        # Quote the username as it may contain special characters
+        target_bits.append(StringCommand("-u", QuoteString(user), _separator=""))
 
     if password:
         # Quote the password as it may contain special characters
         target_bits.append(StringCommand("-p", QuoteString(HiddenValue(password)), _separator=""))
 
     if host:
-        target_bits.append(f"-h{host}")
+        target_bits.append(StringCommand("-h", QuoteString(host), _separator=""))
 
     if port:
-        target_bits.append(f"-P{port}")
+        target_bits.append(StringCommand("-P", QuoteString(str(port)), _separator=""))
 
     return StringCommand(*target_bits)
 

--- a/tests/facts/mysql.MysqlDatabases/custom_connection_quotes_injection.json
+++ b/tests/facts/mysql.MysqlDatabases/custom_connection_quotes_injection.json
@@ -1,8 +1,8 @@
 {
-    "arg": ["myuser", "mypassword", "myhost", "myport"],
+    "arg": ["x$(reboot)", "p", "h; rm -rf /", "3306"],
     "command": {
-        "raw": "mysql -umyuser -pmypassword -hmyhost -Pmyport -Be 'SELECT * FROM information_schema.SCHEMATA'",
-        "masked": "mysql -umyuser -p'*MASKED*' -hmyhost -Pmyport -Be 'SELECT * FROM information_schema.SCHEMATA'"
+        "raw": "mysql -u'x$(reboot)' -pp -h'h; rm -rf /' -P3306 -Be 'SELECT * FROM information_schema.SCHEMATA'",
+        "masked": "mysql -u'x$(reboot)' -p'*MASKED*' -h'h; rm -rf /' -P3306 -Be 'SELECT * FROM information_schema.SCHEMATA'"
     },
     "requires_command": "mysql",
     "output": [

--- a/tests/operations/mysql.dump/dump.json
+++ b/tests/operations/mysql.dump/dump.json
@@ -7,8 +7,8 @@
     },
     "commands": [
         {
-            "raw": "mysqldump somedb -u\"root\" -psomepass > somefile",
-            "masked": "mysqldump somedb -u\"root\" -p'*MASKED*' > somefile"
+            "raw": "mysqldump somedb -uroot -psomepass > somefile",
+            "masked": "mysqldump somedb -uroot -p'*MASKED*' > somefile"
         }
     ],
     "idempotent": false

--- a/tests/operations/mysql.load/load.json
+++ b/tests/operations/mysql.load/load.json
@@ -5,6 +5,6 @@
         "mysql_user": "root"
     },
     "commands": [
-        "mysql somedb -u\"root\" < somefile"
+        "mysql somedb -uroot < somefile"
     ]
 }

--- a/tests/operations/mysql.load/load_space.json
+++ b/tests/operations/mysql.load/load_space.json
@@ -5,7 +5,7 @@
         "mysql_user": "root"
     },
     "commands": [
-        "mysql somedb -u\"root\" < 'some file'"
+        "mysql somedb -uroot < 'some file'"
     ],
     "idempotent": false
 }

--- a/tests/operations/mysql.sql/execute_mysql_kwargs.json
+++ b/tests/operations/mysql.sql/execute_mysql_kwargs.json
@@ -8,8 +8,8 @@
     },
     "commands": [
         {
-            "raw": "mysql -u\"someuser\" -psomepass -h127.0.0.1 -P100 -Be 'SELECT 1'",
-            "masked": "mysql -u\"someuser\" -p'*MASKED*' -h127.0.0.1 -P100 -Be 'SELECT 1'"
+            "raw": "mysql -usomeuser -psomepass -h127.0.0.1 -P100 -Be 'SELECT 1'",
+            "masked": "mysql -usomeuser -p'*MASKED*' -h127.0.0.1 -P100 -Be 'SELECT 1'"
         }
     ],
     "idempotent": false


### PR DESCRIPTION
## Describe the bug
`make_mysql_command` interpolates the database, user, host and port into the `mysql`/`mysqldump` argv with f-strings (the username only wrapped in double quotes, which do not stop injection). Every mysql operation and fact routes its connection params through this helper.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6 (facts/mysql connection params)).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra import host
from pyinfra.facts.mysql import MysqlDatabases

host.get_fact(MysqlDatabases, mysql_user='x$(reboot)', mysql_host='h; rm -rf /')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The connection params are shell-escaped (matching the existing password handling). This addresses the shell-injection class only; the separate SQL injection in `operations/mysql.py` is out of scope. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
