### PR TITLE
fix(operations.flatpak): quote user input in flatpak commands

### DIFF
--- a/src/pyinfra/operations/flatpak.py
+++ b/src/pyinfra/operations/flatpak.py
@@ -5,7 +5,7 @@ Manage flatpak packages. See https://www.flatpak.org/
 from __future__ import annotations
 
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.flatpak import FlatpakPackages
 
 
@@ -65,11 +65,8 @@ def packages(
     install_packages = []
     remove_packages = []
 
-    if remote is None:
-        remote = ""
-    else:
-        # ensure we have a space between the remote and packages
-        remote = remote.strip() + " "
+    if remote is not None:
+        remote = remote.strip()
 
     for package in packages:
         # it's installed
@@ -89,7 +86,14 @@ def packages(
                 host.noop(f"flatpak package {package} is not installed")
 
     if install_packages:
-        yield f"flatpak install --noninteractive {remote}{' '.join(install_packages)}"
+        command: list[str | QuoteString] = ["flatpak install --noninteractive"]
+        if remote:
+            command.append(QuoteString(remote))
+        command += [QuoteString(package) for package in install_packages]
+        yield StringCommand(*command)
 
     if remove_packages:
-        yield f"flatpak uninstall --noninteractive {' '.join(remove_packages)}"
+        yield StringCommand(
+            "flatpak uninstall --noninteractive",
+            *[QuoteString(package) for package in remove_packages],
+        )

--- a/tests/operations/flatpak.packages/install_quotes_injection.json
+++ b/tests/operations/flatpak.packages/install_quotes_injection.json
@@ -1,0 +1,11 @@
+{
+  "kwargs": {
+    "packages": ["x; reboot"],
+    "remote": "flathub"
+  },
+  "facts": {
+    "flatpak.FlatpakPackage": {},
+    "flatpak.FlatpakPackages": []
+  },
+  "commands": ["flatpak install --noninteractive flathub 'x; reboot'"]
+}


### PR DESCRIPTION
## Describe the bug
`flatpak.packages` interpolates the `remote` and package names into the `flatpak install`/`uninstall` commands with f-strings, so crafted values run arbitrary shell.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import flatpak

flatpak.packages(packages=['x; reboot'], remote='flathub')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `remote` and package names are shell-escaped. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
