### PR TITLE
fix(operations.iptables): quote user input in iptables commands

### DIFF
--- a/src/pyinfra/operations/iptables.py
+++ b/src/pyinfra/operations/iptables.py
@@ -5,7 +5,7 @@ The iptables modules handles iptables rules
 from __future__ import annotations
 
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.api.exceptions import OperationError
 from pyinfra.facts.iptables import Ip6tablesChains, Ip6tablesRules, IptablesChains, IptablesRules
 
@@ -37,25 +37,28 @@ def chain(
         else host.get_fact(Ip6tablesChains, table=table)
     )
 
-    command = "iptables" if version == 4 else "ip6tables"
-    command = f"{command} -t {table}"
+    base: list[str | QuoteString] = [
+        "iptables" if version == 4 else "ip6tables",
+        "-t",
+        QuoteString(table),
+    ]
 
     if not present:
         if chain in chains:
-            yield f"{command} -X {chain}"
+            yield StringCommand(*base, "-X", QuoteString(chain))
         else:
             host.noop(f"iptables chain {chain} does not exist")
         return
 
     if present:
         if chain not in chains:
-            yield f"{command} -N {chain}"
+            yield StringCommand(*base, "-N", QuoteString(chain))
         else:
             host.noop(f"iptables chain {chain} exists")
 
         if policy:
             if chain not in chains or chains[chain] != policy:
-                yield f"{command} -P {chain} {policy}"
+                yield StringCommand(*base, "-P", QuoteString(chain), QuoteString(policy))
 
 
 @operation()
@@ -250,63 +253,65 @@ def rule(
 
     # Are we adding/removing a rule? Lets build it
     if action:
-        args = [
+        # `extras` is a raw, multi-token passthrough of iptables extension args, so it
+        # is left unquoted; every other value is user input wrapped in QuoteString.
+        args: list[str | QuoteString] = [
             "iptables" if version == 4 else "ip6tables",
             # Add the table
             "-t",
-            table,
+            QuoteString(table),
             # Add the action and target chain
             action,
-            chain,
+            QuoteString(chain),
         ]
 
         if protocol:
-            args.extend(("-p", protocol))
+            args.extend(("-p", QuoteString(protocol)))
 
         if source:
-            args.extend(("-s", source))
+            args.extend(("-s", QuoteString(source)))
 
         if destination:
-            args.extend(("-d", destination))
+            args.extend(("-d", QuoteString(destination)))
 
         if in_interface:
-            args.extend(("-i", in_interface))
+            args.extend(("-i", QuoteString(in_interface)))
 
         if out_interface:
-            args.extend(("-o", out_interface))
+            args.extend(("-o", QuoteString(out_interface)))
 
         if not_protocol:
-            args.extend(("!", "-p", not_protocol.lower()))
+            args.extend(("!", "-p", QuoteString(not_protocol.lower())))
 
         if not_source:
-            args.extend(("!", "-s", not_source))
+            args.extend(("!", "-s", QuoteString(not_source)))
 
         if not_destination:
-            args.extend(("!", "-d", not_destination))
+            args.extend(("!", "-d", QuoteString(not_destination)))
 
         if not_in_interface:
-            args.extend(("!", "-i", not_in_interface))
+            args.extend(("!", "-i", QuoteString(not_in_interface)))
 
         if not_out_interface:
-            args.extend(("!", "-o", not_out_interface))
+            args.extend(("!", "-o", QuoteString(not_out_interface)))
 
         if extras:
             args.append(extras.strip())
 
         # Add the jump
-        args.extend(("-j", jump))
+        args.extend(("-j", QuoteString(jump)))
 
         if log_prefix:
-            args.extend(("--log-prefix", log_prefix))
+            args.extend(("--log-prefix", QuoteString(log_prefix)))
 
         if to_destination:
-            args.extend(("--to-destination", to_destination))
+            args.extend(("--to-destination", QuoteString(to_destination)))
 
         if to_source:
-            args.extend(("--to-source", to_source))
+            args.extend(("--to-source", QuoteString(to_source)))
 
         if to_ports:
-            args.extend(("--to-ports", to_ports))
+            args.extend(("--to-ports", QuoteString(to_ports)))
 
         # Build the final iptables command
-        yield " ".join(args)
+        yield StringCommand(*args)

--- a/tests/operations/iptables.chain/add_chain_quotes_injection.json
+++ b/tests/operations/iptables.chain/add_chain_quotes_injection.json
@@ -1,0 +1,15 @@
+{
+    "args": ["x; reboot"],
+    "kwargs": {
+        "policy": "DROP"
+    },
+    "facts": {
+        "iptables.IptablesChains": {
+            "table=filter": {}
+        }
+    },
+    "commands": [
+        "iptables -t filter -N 'x; reboot'",
+        "iptables -t filter -P 'x; reboot' DROP"
+    ]
+}


### PR DESCRIPTION
## Describe the bug
`iptables.chain` and `iptables.rule` interpolate `table`, `chain`, `policy` and every rule field (protocol, source, destination, interfaces, jump, log_prefix, to_destination/source/ports) into the iptables/ip6tables commands with f-strings and `" ".join`.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import iptables

iptables.chain(chain='x; reboot')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
Every user value is shell-escaped. `extras` stays raw as it is a multi-token passthrough of extension args. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
