### PR TITLE
fix(operations.lxd): quote user input in lxc commands

### DIFF
--- a/src/pyinfra/operations/lxd.py
+++ b/src/pyinfra/operations/lxd.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.lxd import LxdContainers
 
 
@@ -53,10 +53,10 @@ def container(
     if not present:
         if container:
             if container["status"] == "Running":
-                yield f"lxc stop {id}"
+                yield StringCommand("lxc stop", QuoteString(id))
 
             # Command to remove the container:
-            yield f"lxc delete {id}"
+            yield StringCommand("lxc delete", QuoteString(id))
         else:
             host.noop(f"container {id} does not exist")
 
@@ -64,6 +64,6 @@ def container(
     if present:
         if not container:
             # Command to create the container:
-            yield f"lxc launch {image} {id} < /dev/null"
+            yield StringCommand("lxc launch", QuoteString(image), QuoteString(id), "< /dev/null")
         else:
             host.noop(f"container {id} exists")

--- a/tests/operations/lxd.container/add_container_quotes_injection.json
+++ b/tests/operations/lxd.container/add_container_quotes_injection.json
@@ -1,0 +1,12 @@
+{
+    "kwargs": {
+        "id": "a; rm -rf /",
+        "image": "ubuntu:16.04"
+    },
+    "facts": {
+        "lxd.LxdContainers": []
+    },
+    "commands": [
+        "lxc launch ubuntu:16.04 'a; rm -rf /' < /dev/null"
+    ]
+}


### PR DESCRIPTION
## Describe the bug
`lxd.container` interpolates the container `id` and `image` arguments into `lxc stop`/`delete`/`launch` with f-strings (no `QuoteString` in the file), so crafted values run arbitrary shell.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 5).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import lxd

lxd.container(id='x; reboot', image='ubuntu:22.04')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `id` and `image` are shell-escaped. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
