### PR TITLE
fix(operations.openrc): quote user input in rc-update commands

### DIFF
--- a/src/pyinfra/operations/openrc.py
+++ b/src/pyinfra/operations/openrc.py
@@ -5,7 +5,7 @@ Manage OpenRC init services.
 from __future__ import annotations
 
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.openrc import OpenrcEnabled, OpenrcStatus
 
 from .util.service import handle_service_control
@@ -50,14 +50,14 @@ def service(
 
         if enabled is True:
             if not is_enabled:
-                yield f"rc-update add {service} {runlevel}"
+                yield StringCommand("rc-update add", QuoteString(service), QuoteString(runlevel))
                 openrc_enabled[service] = True
             else:
                 host.noop(f"service {service} is enabled")
 
         if enabled is False:
             if is_enabled:
-                yield f"rc-update del {service} {runlevel}"
+                yield StringCommand("rc-update del", QuoteString(service), QuoteString(runlevel))
                 openrc_enabled[service] = False
             else:
                 host.noop(f"service {service} is disabled")

--- a/tests/operations/openrc.service/enable_quotes_injection.json
+++ b/tests/operations/openrc.service/enable_quotes_injection.json
@@ -1,0 +1,21 @@
+{
+    "args": ["x; reboot"],
+    "kwargs": {
+        "enabled": true
+    },
+    "facts": {
+        "openrc.OpenrcStatus": {
+            "runlevel=default": {
+                "x; reboot": true
+            }
+        },
+        "openrc.OpenrcEnabled": {
+            "runlevel=default": {
+                "x; reboot": false
+            }
+        }
+    },
+    "commands": [
+        "rc-update add 'x; reboot' default"
+    ]
+}


### PR DESCRIPTION
## Describe the bug
`openrc.service` interpolates `service` and `runlevel` into the `rc-update add`/`del` commands with f-strings, so crafted values run arbitrary shell.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import openrc

openrc.service(service='x; reboot', enabled=True)
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `service` and `runlevel` are shell-escaped. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
