### PR TITLE
fix(operations.puppet): quote user input in puppet agent

### DIFF
--- a/src/pyinfra/operations/puppet.py
+++ b/src/pyinfra/operations/puppet.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 
 
 @operation(is_idempotent=False)
@@ -31,11 +31,11 @@ def agent(server: str | None = None, port: int | None = None):
 
     """
 
-    args = []
+    command: list[str | QuoteString] = ["puppet agent -t"]
 
     if server:
-        args.append(f"--server={server}")
+        command.append(QuoteString(f"--server={server}"))
     if port:
-        args.append(f"--masterport={port}")
+        command.append(QuoteString(f"--masterport={port}"))
 
-    yield f"puppet agent -t {' '.join(args)}"
+    yield StringCommand(*command)

--- a/tests/operations/puppet.agent/run_agent_quotes_injection.json
+++ b/tests/operations/puppet.agent/run_agent_quotes_injection.json
@@ -1,0 +1,9 @@
+{
+    "kwargs": {
+        "server": "x; reboot"
+    },
+    "commands": [
+        "puppet agent -t '--server=x; reboot'"
+    ],
+    "idempotent": false
+}


### PR DESCRIPTION
## Describe the bug
`puppet.agent` interpolates `server` and `port` into the `puppet agent -t` command with f-strings, so crafted values run arbitrary shell.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import puppet

puppet.agent(server='x; reboot')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `server` and `port` are shell-escaped. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
