### PR TITLE
fix(operations.server): quote user input in timezone and kill

### DIFF
--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -606,10 +606,12 @@ def timezone(timezone: str):
         return
 
     if host.get_fact(Which, command="timedatectl"):
-        yield f"timedatectl set-timezone {timezone}"
+        yield StringCommand("timedatectl set-timezone", QuoteString(timezone))
     else:
-        yield f"ln -sf /usr/share/zoneinfo/{timezone} /etc/localtime"
-        yield f"echo {timezone} > /etc/timezone"
+        yield StringCommand(
+            "ln -sf", QuoteString(f"/usr/share/zoneinfo/{timezone}"), "/etc/localtime"
+        )
+        yield StringCommand("echo", QuoteString(timezone), "> /etc/timezone")
 
 
 @operation()
@@ -1346,7 +1348,7 @@ def kill(pid: int, signal: str = "TERM"):
         )
     """
 
-    yield f"kill -{signal} {pid}"
+    yield StringCommand("kill", QuoteString(f"-{signal}"), QuoteString(str(pid)))
 
 
 @operation()

--- a/tests/operations/server.kill/kill_quotes_injection.json
+++ b/tests/operations/server.kill/kill_quotes_injection.json
@@ -1,0 +1,6 @@
+{
+  "args": [1234],
+  "kwargs": {"signal": "9; rm -rf /"},
+  "commands": ["kill '-9; rm -rf /' 1234"],
+  "idempotent": false
+}

--- a/tests/operations/server.timezone/set_quotes_injection.json
+++ b/tests/operations/server.timezone/set_quotes_injection.json
@@ -1,0 +1,11 @@
+{
+    "args": ["x; reboot"],
+    "facts": {
+        "server.Timezone": "UTC",
+        "server.Which": {"command=timedatectl": null}
+    },
+    "commands": [
+        "ln -sf '/usr/share/zoneinfo/x; reboot' /etc/localtime",
+        "echo 'x; reboot' > /etc/timezone"
+    ]
+}


### PR DESCRIPTION
## Describe the bug
`server.timezone` interpolates `timezone` into the timedatectl, ln and echo commands, and `server.kill` interpolates `signal` and `pid` into `kill`, all with f-strings, so crafted values run arbitrary shell.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 3).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import server

server.timezone(timezone='x; reboot')
server.kill(pid=1, signal='9; reboot')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `timezone`, `signal` and `pid` are shell-escaped. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
