### PR TITLE
fix(operations.sysvinit): quote user input in service enable/disable

### DIFF
--- a/src/pyinfra/facts/files.py
+++ b/src/pyinfra/facts/files.py
@@ -489,6 +489,7 @@ class FindFilesBase(FactBase):
         fname: str | None = None,
         iname: str | None = None,
         regex: str | None = None,
+        path_match: str | None = None,
         args: list[str] | None = None,
         quote_path=True,
     ):
@@ -507,6 +508,9 @@ class FindFilesBase(FactBase):
 
         @param iname: Like -name, but the match is case insensitive.
         @param regex: True if the whole path of the file matches pattern using regular expression.
+        @param path_match: glob matched against the whole path via ``-path``. The pattern is
+                           always shell-quoted so the shell passes it literally and find itself
+                           does the globbing, which keeps glob matching without an unquoted path.
         @param args: additional arguments to pass to find
         @param quote_path: if the path should be quoted
         @return:
@@ -559,6 +563,10 @@ class FindFilesBase(FactBase):
         if regex is not None and "-regex" not in args:
             command.append("-regex")
             command.append(maybe_quote(regex))
+
+        if path_match is not None and "-path" not in args:
+            command.append("-path")
+            command.append(QuoteString(path_match))
 
         command.extend(args)
 

--- a/src/pyinfra/operations/sysvinit.py
+++ b/src/pyinfra/operations/sysvinit.py
@@ -5,7 +5,7 @@ Manage sysvinit services (``/etc/init.d``).
 from __future__ import annotations
 
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.files import FindLinks
 from pyinfra.facts.server import LinuxDistribution
 from pyinfra.facts.sysvinit import InitdStatus
@@ -80,20 +80,20 @@ def service(
             distro = host.get_fact(LinuxDistribution).get("name")
 
             if distro in ("Ubuntu", "Debian"):
-                yield f"update-rc.d {service} defaults"
+                yield StringCommand("update-rc.d", QuoteString(service), "defaults")
 
             elif distro in ("CentOS", "Fedora", "Red Hat Enterprise Linux"):
-                yield f"chkconfig {service} --add"
-                yield f"chkconfig {service} on"
+                yield StringCommand("chkconfig", QuoteString(service), "--add")
+                yield StringCommand("chkconfig", QuoteString(service), "on")
 
             elif distro == "Gentoo":
-                yield f"rc-update add {service} default"
+                yield StringCommand("rc-update add", QuoteString(service), "default")
 
         # Remove any /etc/rcX.d/<service> start links
         elif enabled is False:
             # No state checking, just blindly remove any that exist
             for link in start_links:
-                yield f"rm -f {link}"
+                yield StringCommand("rm -f", QuoteString(link))
 
 
 @operation()

--- a/src/pyinfra/operations/sysvinit.py
+++ b/src/pyinfra/operations/sysvinit.py
@@ -71,8 +71,8 @@ def service(
     if isinstance(enabled, bool):
         start_links = host.get_fact(
             FindLinks,
-            path=f"/etc/rc*.d/S*{service}",
-            quote_path=False,  # enable path glob matching
+            path="/etc",
+            path_match=f"/etc/rc*.d/S*{service}",
         )
 
         # If no links exist, attempt to enable the service using distro-specific commands

--- a/tests/facts/files.FindLinks/links_path_match_quotes_injection.yaml
+++ b/tests/facts/files.FindLinks/links_path_match_quotes_injection.yaml
@@ -1,0 +1,8 @@
+arg:
+  path: /etc
+  path_match: "/etc/rc*.d/S*x; reboot"
+command: "find /etc -type l -path '/etc/rc*.d/S*x; reboot' || true"
+output:
+  - /etc/rc2.d/S20x; reboot
+fact:
+  - /etc/rc2.d/S20x; reboot

--- a/tests/operations/files.sync/sync_delete_posix.json
+++ b/tests/operations/files.sync/sync_delete_posix.json
@@ -48,14 +48,14 @@
             "path=/home/somedir/underthat": null
         },
         "files.FindFiles": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, quote_path=True, regex=None, size=None": [
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, path_match=None, quote_path=True, regex=None, size=None": [
                 "/home/somedir/deleteme.txt",
                 "/home/somedir/nodelete.pyc"
             ],
             "path=/home/somedir/underthat": []
         },
         "files.FindLinks": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, quote_path=True, regex=None, size=None": []
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, path_match=None, quote_path=True, regex=None, size=None": []
         },
         "files.Link": {
             "path=/home/somedir": false

--- a/tests/operations/files.sync/sync_delete_symlinks.json
+++ b/tests/operations/files.sync/sync_delete_symlinks.json
@@ -27,10 +27,10 @@
             "path=/home/somedir": null
         },
         "files.FindFiles": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, quote_path=True, regex=None, size=None": []
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, path_match=None, quote_path=True, regex=None, size=None": []
         },
         "files.FindLinks": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, quote_path=True, regex=None, size=None": [
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, path_match=None, quote_path=True, regex=None, size=None": [
                 "/home/somedir/deletelink",
                 "/home/somedir/keeplink"
             ]

--- a/tests/operations/files.sync/sync_delete_windows.json
+++ b/tests/operations/files.sync/sync_delete_windows.json
@@ -63,7 +63,7 @@
             "path=/home/somedir/underthat/evendeeper/a-very-deep-file.txt": null
         },
         "files.FindFiles": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, quote_path=True, regex=None, size=None": [
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, path_match=None, quote_path=True, regex=None, size=None": [
                 "/home/somedir/deleteme.txt",
                 "/home/somedir/nodelete.pyc"
             ],
@@ -71,7 +71,7 @@
             "path=/home/somedir/underthat/evendeeper": []
         },
         "files.FindLinks": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, quote_path=True, regex=None, size=None": []
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/home/somedir, path_match=None, quote_path=True, regex=None, size=None": []
         },
         "files.Link": {
             "path=/home/somedir": false

--- a/tests/operations/sysvinit.service/disabled.json
+++ b/tests/operations/sysvinit.service/disabled.json
@@ -8,7 +8,7 @@
             "nginx": true
         },
         "files.FindLinks": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc/rc*.d/S*nginx, quote_path=False, regex=None, size=None": [
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc, path_match=/etc/rc*.d/S*nginx, quote_path=True, regex=None, size=None": [
                 "somelink"
             ]
         }

--- a/tests/operations/sysvinit.service/disabled_quotes_injection.json
+++ b/tests/operations/sysvinit.service/disabled_quotes_injection.json
@@ -1,0 +1,19 @@
+{
+    "args": ["x; reboot"],
+    "kwargs": {
+        "enabled": false
+    },
+    "facts": {
+        "sysvinit.InitdStatus": {
+            "x; reboot": true
+        },
+        "files.FindLinks": {
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc, path_match=/etc/rc*.d/S*x; reboot, quote_path=True, regex=None, size=None": [
+                "/etc/rc2.d/S20x; reboot"
+            ]
+        }
+    },
+    "commands": [
+        "rm -f '/etc/rc2.d/S20x; reboot'"
+    ]
+}

--- a/tests/operations/sysvinit.service/enable_centos_quotes_injection.json
+++ b/tests/operations/sysvinit.service/enable_centos_quotes_injection.json
@@ -1,0 +1,21 @@
+{
+    "args": ["x; reboot"],
+    "kwargs": {
+        "enabled": true
+    },
+    "facts": {
+        "sysvinit.InitdStatus": {
+            "x; reboot": true
+        },
+        "files.FindLinks": {
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc/rc*.d/S*x; reboot, quote_path=False, regex=None, size=None": []
+        },
+        "server.LinuxDistribution": {
+            "name": "CentOS"
+        }
+    },
+    "commands": [
+        "chkconfig 'x; reboot' --add",
+        "chkconfig 'x; reboot' on"
+    ]
+}

--- a/tests/operations/sysvinit.service/enable_centos_quotes_injection.json
+++ b/tests/operations/sysvinit.service/enable_centos_quotes_injection.json
@@ -8,7 +8,7 @@
             "x; reboot": true
         },
         "files.FindLinks": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc/rc*.d/S*x; reboot, quote_path=False, regex=None, size=None": []
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc, path_match=/etc/rc*.d/S*x; reboot, quote_path=True, regex=None, size=None": []
         },
         "server.LinuxDistribution": {
             "name": "CentOS"

--- a/tests/operations/sysvinit.service/enabled_chkconfig.json
+++ b/tests/operations/sysvinit.service/enabled_chkconfig.json
@@ -8,7 +8,7 @@
             "nginx": true
         },
         "files.FindLinks": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc/rc*.d/S*nginx, quote_path=False, regex=None, size=None": []
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc, path_match=/etc/rc*.d/S*nginx, quote_path=True, regex=None, size=None": []
         },
         "server.LinuxDistribution": {
             "name": "CentOS"

--- a/tests/operations/sysvinit.service/enabled_rc-update.json
+++ b/tests/operations/sysvinit.service/enabled_rc-update.json
@@ -8,7 +8,7 @@
             "nginx": true
         },
         "files.FindLinks": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc/rc*.d/S*nginx, quote_path=False, regex=None, size=None": []
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc, path_match=/etc/rc*.d/S*nginx, quote_path=True, regex=None, size=None": []
         },
         "server.LinuxDistribution": {
             "name": "Gentoo"

--- a/tests/operations/sysvinit.service/enabled_update-rc.d.json
+++ b/tests/operations/sysvinit.service/enabled_update-rc.d.json
@@ -8,7 +8,7 @@
             "nginx": true
         },
         "files.FindLinks": {
-            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc/rc*.d/S*nginx, quote_path=False, regex=None, size=None": []
+            "args=None, fname=None, iname=None, max_size=None, maxdepth=None, min_size=None, path=/etc, path_match=/etc/rc*.d/S*nginx, quote_path=True, regex=None, size=None": []
         },
         "server.LinuxDistribution": {
             "name": "Ubuntu"


### PR DESCRIPTION
## Describe the bug
`sysvinit.service` interpolates `service` into the update-rc.d, chkconfig and rc-update enable commands, and the discovered link path into `rm -f`, all with f-strings.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import sysvinit

sysvinit.service(service='x; reboot', enabled=True)
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `service` and link path are shell-escaped. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
