### PR TITLE
fix(operations.vzctl): quote user input in vzctl commands

### DIFF
--- a/src/pyinfra/operations/vzctl.py
+++ b/src/pyinfra/operations/vzctl.py
@@ -5,7 +5,7 @@ Manage OpenVZ containers with ``vzctl``.
 from __future__ import annotations
 
 from pyinfra import host
-from pyinfra.api import OperationError, operation
+from pyinfra.api import OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.vzctl import OpenvzContainers
 
 
@@ -18,12 +18,12 @@ def start(ctid: str, force=False):
     + force: whether to force container start
     """
 
-    args = [f"{ctid}"]
+    command: list[str | QuoteString] = ["vzctl start", QuoteString(str(ctid))]
 
     if force:
-        args.append("--force")
+        command.append("--force")
 
-    yield f"vzctl start {' '.join(args)}"
+    yield StringCommand(*command)
 
 
 @operation(is_idempotent=False)
@@ -34,9 +34,7 @@ def stop(ctid: str):
     + ctid: CTID of the container to stop
     """
 
-    args = [f"{ctid}"]
-
-    yield f"vzctl stop {' '.join(args)}"
+    yield StringCommand("vzctl stop", QuoteString(str(ctid)))
 
 
 @operation(is_idempotent=False)
@@ -60,7 +58,7 @@ def mount(ctid: str):
     + ctid: CTID of the container to mount
     """
 
-    yield f"vzctl mount {ctid}"
+    yield StringCommand("vzctl mount", QuoteString(str(ctid)))
 
 
 @operation(is_idempotent=False)
@@ -71,7 +69,7 @@ def unmount(ctid: str):
     + ctid: CTID of the container to unmount
     """
 
-    yield f"vzctl umount {ctid}"
+    yield StringCommand("vzctl umount", QuoteString(str(ctid)))
 
 
 @operation(is_idempotent=False)
@@ -82,7 +80,7 @@ def delete(ctid: str):
     + ctid: CTID of the container to delete
     """
 
-    yield f"vzctl delete {ctid}"
+    yield StringCommand("vzctl delete", QuoteString(str(ctid)))
 
 
 @operation(is_idempotent=False)
@@ -100,12 +98,12 @@ def create(ctid: str, template: str | None = None):
             f"An OpenVZ container with CTID {ctid} already exists",
         )
 
-    args = [f"{ctid}"]
+    command: list[str | QuoteString] = ["vzctl create", QuoteString(str(ctid))]
 
     if template:
-        args.append(f"--ostemplate {template}")
+        command += ["--ostemplate", QuoteString(template)]
 
-    yield f"vzctl create {' '.join(args)}"
+    yield StringCommand(*command)
 
 
 @operation(is_idempotent=False)
@@ -122,16 +120,19 @@ def set(ctid: str, save=True, **settings):
         ``hostname='my-host.net'`` becomes ``--hostname my-host.net``.
     """
 
-    args = [f"{ctid}"]
+    command: list[str | QuoteString] = ["vzctl set", QuoteString(str(ctid))]
 
     if save:
-        args.append("--save")
+        command.append("--save")
 
+    # `key` comes from **settings so it is a Python identifier and safe; only the
+    # user-controlled values need quoting.
     for key, value in settings.items():
         # Handle list values (e.g. --nameserver X --nameserver X)
         if isinstance(value, list):
-            args.extend(f"--{key} {v}" for v in value)
+            for v in value:
+                command += [f"--{key}", QuoteString(str(v))]
         else:
-            args.append(f"--{key} {value}")
+            command += [f"--{key}", QuoteString(str(value))]
 
-    yield f"vzctl set {' '.join(args)}"
+    yield StringCommand(*command)

--- a/src/pyinfra/operations/vzctl.py
+++ b/src/pyinfra/operations/vzctl.py
@@ -125,14 +125,14 @@ def set(ctid: str, save=True, **settings):
     if save:
         command.append("--save")
 
-    # `key` comes from **settings so it is a Python identifier and safe; only the
-    # user-controlled values need quoting.
+    # Both keys and values come from **settings and are user-controlled, so quote
+    # both. shlex.quote leaves normal flags like --hostname untouched.
     for key, value in settings.items():
         # Handle list values (e.g. --nameserver X --nameserver X)
         if isinstance(value, list):
             for v in value:
-                command += [f"--{key}", QuoteString(str(v))]
+                command += [QuoteString(f"--{key}"), QuoteString(str(v))]
         else:
-            command += [f"--{key}", QuoteString(str(value))]
+            command += [QuoteString(f"--{key}"), QuoteString(str(value))]
 
     yield StringCommand(*command)

--- a/tests/operations/vzctl.set/set_quotes_injection.json
+++ b/tests/operations/vzctl.set/set_quotes_injection.json
@@ -1,0 +1,10 @@
+{
+    "args": [123],
+    "kwargs": {
+        "hostname": "x; rm -rf /"
+    },
+    "commands": [
+        "vzctl set 123 --save --hostname 'x; rm -rf /'"
+    ],
+    "idempotent": false
+}

--- a/tests/operations/vzctl.set/set_quotes_injection_key.json
+++ b/tests/operations/vzctl.set/set_quotes_injection_key.json
@@ -1,0 +1,10 @@
+{
+    "args": [123],
+    "kwargs": {
+        ";reboot": "x"
+    },
+    "commands": [
+        "vzctl set 123 --save '--;reboot' x"
+    ],
+    "idempotent": false
+}


### PR DESCRIPTION
## Describe the bug
`vzctl.*` interpolates `ctid`, `template` and `**settings` values into the vzctl commands with f-strings (no `QuoteString` in the file), so crafted values run arbitrary shell.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 4).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import vzctl

vzctl.set(ctid='1', hostname='x; reboot')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `ctid`, `template` and settings values are shell-escaped. Settings keys come from `**settings` so they are Python identifiers and need no quoting. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
