### PR TITLE
fix(operations.yum): quote user input in yum.key

### DIFF
--- a/src/pyinfra/operations/yum.py
+++ b/src/pyinfra/operations/yum.py
@@ -5,7 +5,7 @@ Manage yum packages and repositories. Note that yum package names are case-sensi
 from __future__ import annotations
 
 from pyinfra import host, state
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.rpm import RpmPackageProvides, RpmPackages
 
 from .util.packaging import ensure_packages, ensure_rpm, ensure_yum_repo
@@ -36,7 +36,7 @@ def key(src: str):
 
     """
 
-    yield f"rpm --import {src}"
+    yield StringCommand("rpm --import", QuoteString(src))
 
 
 @operation()

--- a/tests/operations/yum.key/add_quotes_injection.json
+++ b/tests/operations/yum.key/add_quotes_injection.json
@@ -1,0 +1,6 @@
+{
+    "args": ["https://example.com/key; rm -rf /"],
+    "commands": [
+        "rpm --import 'https://example.com/key; rm -rf /'"
+    ]
+}


### PR DESCRIPTION
## Describe the bug
`yum.key` interpolates the user-supplied `src` into `rpm --import` with an f-string, so a crafted `src` runs arbitrary shell.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import yum

yum.key(src='https://example.com/key; reboot')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The `src` is shell-escaped. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
