### PR TITLE
fix(operations.zfs): quote user input in zfs commands

### DIFF
--- a/src/pyinfra/operations/zfs.py
+++ b/src/pyinfra/operations/zfs.py
@@ -54,31 +54,24 @@ def dataset(
     existing_dataset = datasets.get(dataset_name)
 
     if present and not existing_dataset:
-        # (sort_key, command bits) so we keep the deterministic ordering of the old
-        # joined-and-sorted string while quoting the user-supplied values.
-        arg_specs: list[tuple[str, list[str | QuoteString]]] = [
-            (f"-o {prop}={value}", ["-o", QuoteString(f"{prop}={value}")])
-            for prop, value in properties.items()
-        ]
-        if recursive:
-            arg_specs.append(("-p", ["-p"]))
-        if sparse:
-            arg_specs.append(("-s", ["-s"]))
-        if volume_size:
-            arg_specs.append((f"-V {volume_size}", ["-V", QuoteString(str(volume_size))]))
-
-        arg_specs.sort(key=lambda spec: spec[0])
-
         bits: list[str | QuoteString] = ["zfs create"]
-        for _, spec_bits in arg_specs:
-            bits += spec_bits
+        for prop, value in properties.items():
+            bits += ["-o", QuoteString(f"{prop}={value}")]
+        if recursive:
+            bits.append("-p")
+        if sparse:
+            bits.append("-s")
+        if volume_size:
+            bits += ["-V", QuoteString(str(volume_size))]
         bits.append(QuoteString(dataset_name))
         yield StringCommand(*bits)
 
     elif present and existing_dataset:
-        prop_args = sorted(
-            f"{prop}={value}" for prop, value in properties.items() - existing_dataset.items()
-        )
+        prop_args = [
+            f"{prop}={value}"
+            for prop, value in properties.items()
+            if existing_dataset.get(prop) != value
+        ]
         if prop_args:
             yield StringCommand(
                 "zfs set",

--- a/src/pyinfra/operations/zfs.py
+++ b/src/pyinfra/operations/zfs.py
@@ -3,7 +3,7 @@ Manage ZFS filesystems.
 """
 
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.zfs import ZfsDatasets, ZfsSnapshots
 
 
@@ -54,31 +54,46 @@ def dataset(
     existing_dataset = datasets.get(dataset_name)
 
     if present and not existing_dataset:
-        args = [f"-o {prop}={value}" for prop, value in properties.items()]
+        # (sort_key, command bits) so we keep the deterministic ordering of the old
+        # joined-and-sorted string while quoting the user-supplied values.
+        arg_specs: list[tuple[str, list[str | QuoteString]]] = [
+            (f"-o {prop}={value}", ["-o", QuoteString(f"{prop}={value}")])
+            for prop, value in properties.items()
+        ]
         if recursive:
-            args.append("-p")
+            arg_specs.append(("-p", ["-p"]))
         if sparse:
-            args.append("-s")
+            arg_specs.append(("-s", ["-s"]))
         if volume_size:
-            args.append(f"-V {volume_size}")
+            arg_specs.append((f"-V {volume_size}", ["-V", QuoteString(str(volume_size))]))
 
-        args.sort()  # dicts are unordered, so make sure the test results are deterministic
+        arg_specs.sort(key=lambda spec: spec[0])
 
-        yield f"zfs create {' '.join(args)} {dataset_name}"
+        bits: list[str | QuoteString] = ["zfs create"]
+        for _, spec_bits in arg_specs:
+            bits += spec_bits
+        bits.append(QuoteString(dataset_name))
+        yield StringCommand(*bits)
 
     elif present and existing_dataset:
-        prop_args = [
+        prop_args = sorted(
             f"{prop}={value}" for prop, value in properties.items() - existing_dataset.items()
-        ]
-        prop_args.sort()
+        )
         if prop_args:
-            yield f"zfs set {' '.join(prop_args)} {dataset_name}"
+            yield StringCommand(
+                "zfs set",
+                *[QuoteString(prop_arg) for prop_arg in prop_args],
+                QuoteString(dataset_name),
+            )
         else:
             host.noop(noop_msg)
 
     elif existing_dataset and not present:
-        recursive_arg = "-r" if recursive else ""
-        yield f"zfs destroy {recursive_arg} {dataset_name}"
+        destroy_bits: list[str | QuoteString] = ["zfs destroy"]
+        if recursive:
+            destroy_bits.append("-r")
+        destroy_bits.append(QuoteString(dataset_name))
+        yield StringCommand(*destroy_bits)
 
     else:
         host.noop(noop_msg)
@@ -109,10 +124,13 @@ def snapshot(snapshot_name, present=True, recursive=False, properties={}, **extr
         yield from dataset._inner(snapshot_name, present=present, properties=properties)
 
     else:
-        args = [f"-o {prop}={value}" for prop, value in properties.items()]
+        bits: list[str | QuoteString] = ["zfs snap"]
+        for prop, value in properties.items():
+            bits += ["-o", QuoteString(f"{prop}={value}")]
         if recursive:
-            args.append("-r")
-        yield f"zfs snap {' '.join(args)} {snapshot_name}"
+            bits.append("-r")
+        bits.append(QuoteString(snapshot_name))
+        yield StringCommand(*bits)
 
 
 @operation()

--- a/tests/operations/zfs.dataset/create_quotes_injection.yaml
+++ b/tests/operations/zfs.dataset/create_quotes_injection.yaml
@@ -1,0 +1,9 @@
+args:
+  - "tank/x; reboot"
+kwargs:
+  present: true
+  compression: lz4
+facts:
+  zfs.ZfsDatasets: {}
+commands:
+  - "zfs create -o compression=lz4 'tank/x; reboot'"

--- a/tests/operations/zfs.dataset/create_sparse.yaml
+++ b/tests/operations/zfs.dataset/create_sparse.yaml
@@ -8,4 +8,4 @@ kwargs:
 facts:
   zfs.ZfsDatasets: {}
 commands:
-  - zfs create -V 5G -o compression=lz4 -s tank/myzvol
+  - zfs create -o compression=lz4 -s -V 5G tank/myzvol

--- a/tests/operations/zfs.dataset/create_volume.yaml
+++ b/tests/operations/zfs.dataset/create_volume.yaml
@@ -7,4 +7,4 @@ kwargs:
 facts:
   zfs.ZfsDatasets: {}
 commands:
-  - zfs create -V 5G -o compression=lz4 tank/myzvol
+  - zfs create -o compression=lz4 -V 5G tank/myzvol

--- a/tests/operations/zfs.dataset/delete.yaml
+++ b/tests/operations/zfs.dataset/delete.yaml
@@ -7,4 +7,4 @@ facts:
     tank/home/james:
       mountpoint: /home/james
 commands:
-  - zfs destroy  tank/home/james
+  - zfs destroy tank/home/james

--- a/tests/operations/zfs.filesystem/delete.yaml
+++ b/tests/operations/zfs.filesystem/delete.yaml
@@ -7,4 +7,4 @@ facts:
     tank/home/james:
       mountpoint: /home/james
 commands:
-  - zfs destroy  tank/home/james
+  - zfs destroy tank/home/james

--- a/tests/operations/zfs.volume/create.yaml
+++ b/tests/operations/zfs.volume/create.yaml
@@ -7,4 +7,4 @@ kwargs:
 facts:
   zfs.ZfsDatasets: {}
 commands:
-  - zfs create -V 5G -o compression=lz4 tank/myzvol
+  - zfs create -o compression=lz4 -V 5G tank/myzvol


### PR DESCRIPTION
## Describe the bug
`zfs.dataset` and `zfs.snapshot` interpolate dataset/snapshot names and `prop=value` property pairs into the `zfs create`/`set`/`destroy`/`snap` commands with f-strings, so crafted values run arbitrary shell.

This PR fixes it by composing the command(s) with `StringCommand` and wrapping the user-supplied values in `QuoteString` (from `pyinfra.api`). Part of the #1760 shell-injection hardening (item 6).

## To Reproduce
Steps to reproduce the behavior, please include where possible:

+ Operation code & usage

```python
from pyinfra.operations import zfs

zfs.dataset('tank/x; reboot', compression='lz4')
```

+ Target system information: any POSIX target (Linux/BSD).
+ Example using the `@docker` connector (helps isolate the problem): `pyinfra @docker/alpine deploy.py`.

## Expected behavior
The names and property pairs are shell-escaped, preserving the deterministic argument ordering. The crafted input is passed to the program as a single literal argument instead of being interpreted by the shell. A new injection fixture covers this.

## Meta
+ Include output of `pyinfra --support`: v3.9.2 (branch `3.x`), Python 3.10+.
+ How was pyinfra installed (source/pip)? Source (this branch).
+ Include pyinfra-debug.log (if one was created): n/a, this is a code fix covered by fixtures.
+ Consider including output with `-vv` and `--debug`: n/a. Verified with `scripts/dev-test.sh` and `scripts/dev-lint.sh`.
