### PR TITLE
feat(operations.docker): add container_exec operation

### DIFF
--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -915,3 +915,85 @@ def compose(
             command_bits.append("--remove-orphans")
 
     yield StringCommand(*command_bits)
+
+
+@operation(is_idempotent=False)
+def container_exec(
+    container: str,
+    command: str | list[str],
+    user: str | None = None,
+    workdir: str | None = None,
+    env: dict[str, str] | None = None,
+    detach: bool = False,
+    privileged: bool = False,
+    tty: bool = False,
+):
+    """
+    Run a command inside an existing Docker container (``docker exec``).
+
+    + container: name or ID of the target container
+    + command: command to run. A string is run through the container's shell
+      (``sh -c``) so pipes/redirects work; a list is passed straight through as
+      ``argv`` with no shell
+    + user: run as this user (maps to ``--user``)
+    + workdir: working directory inside the container (maps to ``--workdir``)
+    + env: environment variables to set (maps to repeated ``--env``)
+    + detach: run in the background (maps to ``--detach``)
+    + privileged: give extended privileges to the command (maps to ``--privileged``)
+    + tty: allocate a pseudo-TTY (maps to ``--tty``)
+
+    This operation is not idempotent: it always runs the command. The target
+    container must already exist and be running.
+
+    **Examples:**
+
+    .. code:: python
+
+        from pyinfra.operations import docker
+
+        # Run a shell command (pipes/redirects work)
+        docker.container_exec(
+            name="Migrate the database",
+            container="app",
+            command="./manage.py migrate 2>&1 | tee /var/log/migrate.log",
+        )
+
+        # Pass an explicit argv (no shell)
+        docker.container_exec(
+            name="Touch a file as appuser",
+            container="app",
+            command=["touch", "/srv/ready"],
+            user="appuser",
+            workdir="/srv",
+            env={"STAGE": "prod"},
+        )
+    """
+    if not container:
+        raise OperationError("docker.container_exec requires a container")
+
+    if not command:
+        raise OperationError("docker.container_exec requires a command")
+
+    command_bits: list[str | QuoteString] = ["docker exec"]
+
+    if detach:
+        command_bits.append("--detach")
+    if privileged:
+        command_bits.append("--privileged")
+    if tty:
+        command_bits.append("--tty")
+    if user is not None:
+        command_bits.extend(["--user", QuoteString(user)])
+    if workdir is not None:
+        command_bits.extend(["--workdir", QuoteString(workdir)])
+    for key, value in (env or {}).items():
+        command_bits.extend(["--env", QuoteString(f"{key}={value}")])
+
+    command_bits.append(QuoteString(container))
+
+    if isinstance(command, list):
+        command_bits.extend(QuoteString(arg) for arg in command)
+    else:
+        command_bits.extend(["sh -c", QuoteString(command)])
+
+    yield StringCommand(*command_bits)

--- a/tests/operations/docker.container_exec/argv_with_options.yaml
+++ b/tests/operations/docker.container_exec/argv_with_options.yaml
@@ -1,0 +1,10 @@
+args:
+  - app
+  - ["touch", "/srv/ready"]
+kwargs:
+  user: appuser
+  workdir: /srv
+  env:
+    STAGE: prod
+commands:
+  - "docker exec --user appuser --workdir /srv --env STAGE=prod app touch /srv/ready"

--- a/tests/operations/docker.container_exec/flags.yaml
+++ b/tests/operations/docker.container_exec/flags.yaml
@@ -1,0 +1,9 @@
+args:
+  - app
+  - ["ls"]
+kwargs:
+  detach: true
+  privileged: true
+  tty: true
+commands:
+  - "docker exec --detach --privileged --tty app ls"

--- a/tests/operations/docker.container_exec/missing_command.yaml
+++ b/tests/operations/docker.container_exec/missing_command.yaml
@@ -1,0 +1,6 @@
+args:
+  - app
+  - ""
+exception:
+  name: OperationError
+  message: docker.container_exec requires a command

--- a/tests/operations/docker.container_exec/quotes_injection.yaml
+++ b/tests/operations/docker.container_exec/quotes_injection.yaml
@@ -1,0 +1,5 @@
+args:
+  - "x; reboot"
+  - ["id"]
+commands:
+  - "docker exec 'x; reboot' id"

--- a/tests/operations/docker.container_exec/shell_command.yaml
+++ b/tests/operations/docker.container_exec/shell_command.yaml
@@ -1,0 +1,5 @@
+args:
+  - app
+  - "./manage.py migrate 2>&1 | tee /var/log/migrate.log"
+commands:
+  - "docker exec app sh -c './manage.py migrate 2>&1 | tee /var/log/migrate.log'"


### PR DESCRIPTION
Closes #1217.

Adds `docker.container_exec` to run a command inside an existing container (`docker exec`), covering the Ansible `docker_container_exec` use case from the issue.

## Behavior

```python
from pyinfra.operations import docker

# String command: run through the container shell (sh -c), so pipes/redirects work
docker.container_exec(
    name="Migrate the database",
    container="app",
    command="./manage.py migrate 2>&1 | tee /var/log/migrate.log",
)

# List command: passed straight through as argv, no shell
docker.container_exec(
    name="Touch a file as appuser",
    container="app",
    command=["touch", "/srv/ready"],
    user="appuser",
    workdir="/srv",
    env={"STAGE": "prod"},
)
```

- Required: `container`, `command` (a string runs via `sh -c`; a list is argv with no shell).
- Options: `user` (`--user`), `workdir` (`--workdir`), `env` (repeated `--env`), `detach`, `privileged`, `tty`.
- Non-idempotent (like `docker.compose`): it always runs the command and expects the container to exist and be running.
- Composed with `StringCommand` + `QuoteString`; raises `OperationError` on missing container/command.

## Tests

YAML fixtures under `tests/operations/docker.container_exec/`: shell command, argv with options, flags, an injection-proof case, and a missing-command exception. All pass; full docker suite is green, mypy and ruff clean, and the operation renders in the generated docs.

## Checklist

- [x] Based on the default branch (`3.x`)
- [x] Tests included
- [x] Documentation included (docstring)
- [x] Tests pass
- [x] Type checking & code style passes
