### PR TITLE
docs: avoid unreleased banner on stable docs

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -80,7 +80,7 @@ accent = "pyinfra"
 
 [project.extra]
 generator = false
-docs_version = "latest"
+docs_version = "3.x"
 primary_doc_version = "3.x"
 doc_versions = ["3.x", "2.x", "1.x", "0.x", "latest"]
 docs_language = "en"


### PR DESCRIPTION
### Summary
- default `docs_version` to the stable `3.x` docs version
- keep scripted `DOCS_VERSION=latest` builds able to render the latest-docs warning

### Why
The generated `3.x` documentation should not show the banner saying it may contain unreleased features.

Fixes #1824.

### Checks
- `git diff --check`