### PR TITLE
ci: add shellcheck workflow and fix scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,26 @@
+name: Shellcheck
+
+on:
+  push:
+    branches:
+      - 3.x
+      - 2.x
+      - 1.x
+      - 0.x
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Check shell scripts
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: |
+          git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' -- ':!*.py' \
+            | xargs shellcheck

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,7 +49,9 @@ uv add --editable ./pyinfra
 ### Code Style & Type Checking
 
 Code style is enforced via [ruff](https://docs.astral.sh/ruff/). Types are checked with mypy currently, and pyright is
-recommended for local development though currently optional. There is a script to run the linting & type-checking:
+recommended for local development though currently optional. Shell scripts are checked with
+[shellcheck](https://www.shellcheck.net/), so install it before running the lint script (eg `apt-get install shellcheck`
+or `brew install shellcheck`). There is a script to run the linting & type-checking:
 
 ```sh
 # Check formatting & types

--- a/scripts/dev-lint.sh
+++ b/scripts/dev-lint.sh
@@ -12,4 +12,12 @@ uv run mypy
 echo "Execute arguments type check..."
 uv run python scripts/lint_arguments_sync.py
 
+echo "Execute shellcheck..."
+if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "shellcheck is not installed, see docs/contributing.md for instructions." >&2
+    exit 1
+fi
+git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' -- ':!*.py' \
+    | xargs shellcheck
+
 echo "Linting complete!"

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 echo "Execute pytest..."
-uv run pytest $@
+uv run pytest "$@"
 
 echo "Tests complete!"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 
-VERSION=`uv run python scripts/generate_next_version.py`
-MAJOR_BRANCH="`uv run python scripts/generate_next_version.py | cut -d'.' -f1`.x"
+VERSION=$(uv run python scripts/generate_next_version.py)
+MAJOR_BRANCH="$(uv run python scripts/generate_next_version.py | cut -d'.' -f1).x"
 
 echo "# Releasing pyinfra v${VERSION} (branch ${MAJOR_BRANCH})"
 


### PR DESCRIPTION
## What this does

Adds a Shellcheck CI workflow and fixes the shell scripts so the tree passes it.

This revives #1431 by @yarikoptic, which went stale against `3.x`. The scripts have drifted since then, so the changes are re-derived against the current tree rather than a replay of the old diff.

## Changes

- `.github/workflows/shellcheck.yml`: installs shellcheck and runs it on every tracked file that starts with a shell shebang or a shellcheck directive. Matches the repo conventions (`actions/checkout@v5`, `ubuntu-24.04`, same branch triggers as `test.yml`), with `permissions: contents: read`.
- `scripts/dev-test.sh`: `uv run pytest $@` to `"$@"` (SC2068, real argument re-splitting bug).
- `scripts/release.sh`: shebang `#!/bin/sh` to `#!/bin/bash` (SC3040, `pipefail` is undefined in POSIX sh) and legacy backticks to `$(...)` (SC2006).

## Note on the file selection

The original detection also matched `src/pyinfra/connectors/util.py`, a Python file that embeds a `#!/bin/sh` heredoc as a string. Shellcheck cannot parse that file as shell and errors out, which would fail CI. The workflow grep now excludes Python files (`':!*.py'`), so only real shell scripts are checked. The earlier `build-public-docs.sh` SC2086 fix from the original PR is no longer needed: that script was rewritten upstream and is already clean.

## Verification

- `git grep -l '...' -- ':!*.py' | xargs shellcheck` exits 0 over all matched files.
- Workflow YAML parses, and both edited scripts pass `bash -n`.
