### PR TITLE
fix(facts.deb): DebPackage failing when file/directory with same name exists in cwd

### DIFF
--- a/src/pyinfra/facts/deb.py
+++ b/src/pyinfra/facts/deb.py
@@ -74,7 +74,7 @@ class DebPackage(FactBase):
     @override
     def command(self, package):
         return make_formatted_string_command(
-            "! test -e {0} && (dpkg -s {0} 2>/dev/null || true) || dpkg -I {0}",
+            "test -f {0} && case {0} in *.deb) dpkg -I {0} ;; *) dpkg -s {0} 2>/dev/null || true ;; esac || dpkg -s {0} 2>/dev/null || true",
             QuoteString(package),
         )
 

--- a/tests/facts/deb.DebPackage/directory_same_name.json
+++ b/tests/facts/deb.DebPackage/directory_same_name.json
@@ -1,0 +1,13 @@
+{
+    "arg": "some-directory",
+    "command": "test -f some-directory && case some-directory in *.deb) dpkg -I some-directory ;; *) dpkg -s some-directory 2>/dev/null || true ;; esac || dpkg -s some-directory 2>/dev/null || true",
+    "requires_command": "dpkg",
+    "output": [
+        "Package: some-directory",
+        "Version: 2.0"
+    ],
+    "fact": {
+        "name": "some-directory",
+        "version": "2.0"
+    }
+}

--- a/tests/facts/deb.DebPackage/non_deb_file.json
+++ b/tests/facts/deb.DebPackage/non_deb_file.json
@@ -1,0 +1,7 @@
+{
+    "arg": "random-file.txt",
+    "command": "test -f random-file.txt && case random-file.txt in *.deb) dpkg -I random-file.txt ;; *) dpkg -s random-file.txt 2>/dev/null || true ;; esac || dpkg -s random-file.txt 2>/dev/null || true",
+    "requires_command": "dpkg",
+    "output": [],
+    "fact": {}
+}

--- a/tests/facts/deb.DebPackage/package.json
+++ b/tests/facts/deb.DebPackage/package.json
@@ -1,6 +1,6 @@
 {
     "arg": "package-name",
-    "command": "! test -e package-name && (dpkg -s package-name 2>/dev/null || true) || dpkg -I package-name",
+    "command": "test -f package-name && case package-name in *.deb) dpkg -I package-name ;; *) dpkg -s package-name 2>/dev/null || true ;; esac || dpkg -s package-name 2>/dev/null || true",
     "requires_command": "dpkg",
     "output": [
         "Package: package-name",

--- a/tests/facts/deb.DebPackage/package_needs_quotes.json
+++ b/tests/facts/deb.DebPackage/package_needs_quotes.json
@@ -1,6 +1,6 @@
 {
     "arg": "/tmp/my package; whoami.deb",
-    "command": "! test -e '/tmp/my package; whoami.deb' && (dpkg -s '/tmp/my package; whoami.deb' 2>/dev/null || true) || dpkg -I '/tmp/my package; whoami.deb'",
+    "command": "test -f '/tmp/my package; whoami.deb' && case '/tmp/my package; whoami.deb' in *.deb) dpkg -I '/tmp/my package; whoami.deb' ;; *) dpkg -s '/tmp/my package; whoami.deb' 2>/dev/null || true ;; esac || dpkg -s '/tmp/my package; whoami.deb' 2>/dev/null || true",
     "requires_command": "dpkg",
     "output": [
         "Package: my-package",

--- a/tests/facts/deb.DebPackage/whitespace.json
+++ b/tests/facts/deb.DebPackage/whitespace.json
@@ -1,6 +1,6 @@
 {
     "arg": "/root/tivsm-api64.amd64.deb",
-    "command": "! test -e /root/tivsm-api64.amd64.deb && (dpkg -s /root/tivsm-api64.amd64.deb 2>/dev/null || true) || dpkg -I /root/tivsm-api64.amd64.deb",
+    "command": "test -f /root/tivsm-api64.amd64.deb && case /root/tivsm-api64.amd64.deb in *.deb) dpkg -I /root/tivsm-api64.amd64.deb ;; *) dpkg -s /root/tivsm-api64.amd64.deb 2>/dev/null || true ;; esac || dpkg -s /root/tivsm-api64.amd64.deb 2>/dev/null || true",
     "requires_command": "dpkg",
     "output": [
       " new Debian package, version 2.0.",


### PR DESCRIPTION
## Problem

`host.get_fact(deb.DebPackage, "somename")` throws an exception if a directory or regular file named `somename` exists in the current working directory.

The root cause is that `test -e` matches directories AND regular files, causing `dpkg -I` to be incorrectly invoked on non-.deb targets.

## Fix

- Changed `test -e` to `test -f` (only match regular files)
- Added `case` statement to only invoke `dpkg -I` on `*.deb` files
- Falls back to `dpkg -s` for all other cases (package name lookup)

## Tests Added

- `directory_same_name.json` — package name matches a directory in cwd
- `non_deb_file.json` — regular non-.deb file as argument

All 15 deb-related tests pass (7 DebPackage + 8 DebPackages).