### PR TITLE
docs: clarify server.shell shell usage

### DIFF
--- a/docs/using-operations.md
+++ b/docs/using-operations.md
@@ -77,6 +77,20 @@ apt.update(
 )
 ```
 
+Command operations, including `server.shell`, run through the configured shell.
+The default shell is `sh`, so raw shell commands should either use POSIX `sh`
+syntax or choose a shell explicitly with `_shell_executable`:
+
+```python
+from pyinfra.operations import server
+
+server.shell(
+    name="Run a Bash login shell command",
+    commands=["my-command"],
+    _shell_executable="bash -l",
+)
+```
+
 ## The `host` Object
 
 pyinfra provides a global `host` object that can be used to retrieve information and metadata about the current host target. At all times the `host` variable represents the current host context, so you can think about the deploy code executing on individual hosts at a time.


### PR DESCRIPTION
Closes #1275

## Summary
- Clarify that command operations such as `server.shell` run through the configured shell
- Mention the default `sh` shell and show how to choose Bash explicitly with `_shell_executable`

## Checks
- `git diff --check`
- Targeted Markdown render of `docs/using-operations.md`