### PR TITLE
fix(operations.files): clear error for file-like src with directory dest (#1144)

### DIFF
--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -1135,7 +1135,14 @@ def put(
     remote_file = host.get_fact(File, path=dest)
 
     if not remote_file and bool(host.get_fact(Directory, path=dest)):
-        assert isinstance(src, str)
+        # A file-like ``src`` has no filename to append to the directory, so the
+        # destination is ambiguous. Raise a clear error rather than a bare
+        # ``AssertionError`` from the ``isinstance`` check below (#1144).
+        if hasattr(src, "read"):
+            raise OperationTypeError(
+                "When `src` is a file-like object, `dest` must be a full file "
+                "path, not a directory",
+            )
         dest = unix_path_join(dest, os.path.basename(src))
         remote_file = host.get_fact(File, path=dest)
 

--- a/tests/operations/files.put/io_src_to_directory.json
+++ b/tests/operations/files.put/io_src_to_directory.json
@@ -1,0 +1,15 @@
+{
+    "args": ["io:file contents", "/home"],
+    "facts": {
+        "files.File": {
+            "path=/home": false
+        },
+        "files.Directory": {
+            "path=/home": true
+        }
+    },
+    "exception": {
+        "name": "OperationTypeError",
+        "message": "When `src` is a file-like object, `dest` must be a full file path, not a directory"
+    }
+}

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,6 +4,7 @@ import os
 import re
 from datetime import datetime, timezone
 from inspect import getcallargs, getfullargspec
+from io import StringIO
 from os import path
 from pathlib import Path
 from unittest.mock import patch
@@ -68,6 +69,8 @@ def parse_value(value):
             return datetime.fromisoformat(value[9:])
         if value.startswith("path:"):
             return Path(value[5:])
+        if value.startswith("io:"):
+            return StringIO(value[3:])
         return value
 
     if isinstance(value, list):


### PR DESCRIPTION
## What / why

`files.put()` raised a bare, unhelpful `AssertionError` when `src` is a file-like object (e.g. `StringIO`) and `dest` is an existing remote directory. From #1144:

```pytb
  File ".../pyinfra/operations/files.py", line 938, in put
    dest = unix_path_join(dest, os.path.basename(src))
  File "<frozen posixpath>", line 142, in basename
TypeError: expected str, bytes or os.PathLike object, not StringIO
```

On `3.x` this code path now hits `assert isinstance(src, str)`, so the user just gets a bare `AssertionError` with no indication of the cause.

When `dest` is a directory, `put()` derives the destination filename from `src`. A file-like object has no filename, so the destination is genuinely ambiguous — but the user deserves to be told that, not handed an assertion failure.

Closes #1144.

## Fix

Replace the bare assertion with a clear `OperationTypeError` (a `TypeError` subclass, already imported) when `src` is file-like:

```python
if not remote_file and bool(host.get_fact(Directory, path=dest)):
    if hasattr(src, "read"):
        raise OperationTypeError(
            "When `src` is a file-like object, `dest` must be a full file "
            "path, not a directory",
        )
    dest = unix_path_join(dest, os.path.basename(src))
    ...
```

Using `hasattr(src, "read")` (consistent with how `put()` already detects IO objects higher up) means `str` **and** `Path` sources are unaffected — `os.path.basename` handles both, and the previous `isinstance(src, str)` assertion would actually have rejected valid `Path` sources too.

This addresses request 1 in the issue (a better error message). Request 2 (auto-deriving the filename for `files.template()` with a directory dest, stripping `.j2`/`.jinja`) is a separate behavioural enhancement and is intentionally left out of this minimal fix.

## Tests

The operation-fixture harness couldn't express a file-like `src`, so I added a small `io:` prefix to `tests/util.py::parse_value` (alongside the existing `path:`/`datetime:` prefixes) that builds a `StringIO`. The new regression fixture `tests/operations/files.put/io_src_to_directory.json` then exercises the directory-dest + file-like-src case and asserts the `OperationTypeError`.

- **Before:** the fixture raised `AssertionError` at `files.py:1138` → harness reported "Wrong exception raised!" (fails).
- **After:** the expected `OperationTypeError` is raised (passes).

```
$ scripts/dev-test.sh  (pytest tests/test_operations.py)
1023 passed

$ ruff check / ruff format --diff   -> clean
$ mypy src/pyinfra/operations/files.py -> Success: no issues found
```

## Checklist

- [x] Pull request is based on the default branch (`3.x`)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Documentation — N/A (error-handling fix, no new operation/argument; the `StringIO` example in the `put()` docstring is unchanged)
- [x] Tests pass (`scripts/dev-test.sh`)
- [x] Type checking & code style passes (`scripts/dev-lint.sh`)
- [x] Pull request title follows conventional commits

---

*AI disclosure (per `AI_POLICY.md`):* prepared with AI assistance using **Claude Code**. The assistant located the failing code path, drafted the fix and the test, and ran the suite/linters. I reviewed and understand the change in full — it swaps a bare `assert` for a typed, actionable `OperationTypeError`, keeps `str`/`Path` sources working via `hasattr(src, "read")`, and adds a minimal `io:` test-fixture helper plus a regression fixture. No behavioural change beyond the error type/message.