### PR TITLE
feat(connectors): allow HiddenValue in _env

### DIFF
--- a/src/pyinfra/api/arguments.py
+++ b/src/pyinfra/api/arguments.py
@@ -16,6 +16,7 @@ from typing_extensions import TypedDict
 from pyinfra.api.exceptions import ArgumentTypeError
 from pyinfra.api.util import raise_if_bad_type
 from pyinfra.context import ctx_config
+from pyinfra.api.hiddenvalue import HiddenValue
 
 if TYPE_CHECKING:
     from pyinfra.api import Config, Host, State
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 default_sentinel = object()
 
+EnvValue = str | HiddenValue
 
 class ArgumentMeta(Generic[T]):
     description: str
@@ -62,7 +64,7 @@ class ConnectorArguments(TypedDict, total=False):
     # Shell arguments
     _shell_executable: str
     _chdir: str
-    _env: Mapping[str, str]
+    _env: Mapping[str, EnvValue]
 
     # Connector control (outside of command generation)
     _success_exit_codes: Iterable[int]
@@ -79,12 +81,16 @@ class ConnectorArguments(TypedDict, total=False):
     _temp_dir: str
 
 
-def generate_env(config: Config, value: dict) -> dict:
-    env = {key: os.environ[key] for key in config.INHERIT_ENV if key in os.environ}
+def generate_env(config: Config, value: Mapping[str, EnvValue] | None) -> dict[str, EnvValue]:
+    env: dict[str, EnvValue] = {
+        key: os.environ[key]
+        for key in config.INHERIT_ENV
+        if key in os .environ
+    }
     env.update(config.ENV)
-    env.update(value)
+    if value:
+        env.update(value)
     return env
-
 
 auth_argument_meta: dict[str, ArgumentMeta] = {
     "_sudo": ArgumentMeta(

--- a/src/pyinfra/api/arguments.py
+++ b/src/pyinfra/api/arguments.py
@@ -26,6 +26,7 @@ default_sentinel = object()
 
 EnvValue = str | HiddenValue
 
+
 class ArgumentMeta(Generic[T]):
     description: str
     default: Callable[[Config], T]
@@ -83,14 +84,13 @@ class ConnectorArguments(TypedDict, total=False):
 
 def generate_env(config: Config, value: Mapping[str, EnvValue] | None) -> dict[str, EnvValue]:
     env: dict[str, EnvValue] = {
-        key: os.environ[key]
-        for key in config.INHERIT_ENV
-        if key in os .environ
+        key: os.environ[key] for key in config.INHERIT_ENV if key in os.environ
     }
     env.update(config.ENV)
     if value:
         env.update(value)
     return env
+
 
 auth_argument_meta: dict[str, ArgumentMeta] = {
     "_sudo": ArgumentMeta(

--- a/src/pyinfra/api/arguments.py
+++ b/src/pyinfra/api/arguments.py
@@ -87,7 +87,7 @@ def generate_env(config: Config, value: Mapping[str, EnvValue] | None) -> dict[s
         key: os.environ[key] for key in config.INHERIT_ENV if key in os.environ
     }
     env.update(config.ENV)
-    if value:
+    if value is not None:
         env.update(value)
     return env
 

--- a/src/pyinfra/api/arguments_typed.py
+++ b/src/pyinfra/api/arguments_typed.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 P = ParamSpec("P")
 
+EnvValue = str | HiddenValue
+
 
 # Unfortunately we have to re-type out all of the global arguments here because
 # Python typing doesn't (yet) support merging kwargs. This acts as the operation
@@ -45,7 +47,7 @@ class PyinfraOperation(Generic[P], Protocol):
         # Shell arguments
         _shell_executable: None | str = None,
         _chdir: None | str = None,
-        _env: None | Mapping[str, str | HiddenValue] = None,
+        _env: None | Mapping[str, EnvValue] = None,
         # Connector control
         _success_exit_codes: Iterable[int] = (0,),
         _timeout: None | int = None,

--- a/src/pyinfra/api/arguments_typed.py
+++ b/src/pyinfra/api/arguments_typed.py
@@ -5,6 +5,8 @@ from collections.abc import Callable, Generator, Iterable, Mapping
 
 from typing_extensions import ParamSpec, Protocol
 
+from pyinfra.api.hiddenvalue import HiddenValue
+
 if TYPE_CHECKING:
     from pyinfra.api.operation import OperationMeta
 
@@ -43,7 +45,7 @@ class PyinfraOperation(Generic[P], Protocol):
         # Shell arguments
         _shell_executable: None | str = None,
         _chdir: None | str = None,
-        _env: None | Mapping[str, str] = None,
+        _env: None | Mapping[str, str | HiddenValue] = None,
         # Connector control
         _success_exit_codes: Iterable[int] = (0,),
         _timeout: None | int = None,

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -428,7 +428,7 @@ def make_unix_command(
             # Quote the whole `key=value` pair so arbitrary values cannot break
             # out into additional shell tokens. Invalid identifiers in `key` will
             # fail safely when the shell rejects the resulting `export` statement.
-            env_bits.append(QuoteString(f"{key}={value}"))
+            env_bits.append(QuoteString(StringCommand(key, value, _separator="=")))
         env_bits.append("&&")
         env_bits.append(command)
         command = StringCommand(*env_bits)

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -1,18 +1,17 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from pyinfra.api import Config, State
+from pyinfra.api import Config, State, HiddenValue
 from pyinfra.connectors.util import (
     CommandOutput,
     OutputLine,
     _ensure_askpass_set_for_host,
-    make_unix_command,
+    make_unix_command,  
     make_unix_command_for_host,
     remove_any_sudo_askpass_file,
 )
 
 from ..util import make_inventory
-
 
 class TestMakeUnixCommandConnectorUtil(TestCase):
     def test_command(self):
@@ -146,6 +145,40 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
             command.get_raw_value()
             == "sh -c 'export '\"'\"'KEY=value\"; id; echo \"'\"'\"' && uptime'"
         )
+
+    def test_command_env_hidden_value(self):
+        command = make_unix_command(
+            "uptime",
+            _env={
+                "KEY": HiddenValue("super-secret"),
+            },
+        )
+        
+        raw = command.get_raw_value()
+        masked = command.get_masked_value()
+        assert "super-secret" in raw
+        assert "super-secret" not in masked
+        assert "*MASKED*" in masked 
+        assert "KEY=*MASKED*" in masked
+
+    def test_command_env_hidden_value_with_shell_chars(self):
+        command = make_unix_command(
+            "uptime",
+            _env={
+                "KEY": HiddenValue("abc; id; echo bad"),
+            },
+        )
+
+        raw = command.get_raw_value()
+        masked = command.get_masked_value()
+
+        assert "abc; id; echo bad" in raw
+        assert "abc; id; echo bad" not in masked
+        assert "*MASKED*" in masked
+        assert "KEY=*MASKED*" in masked
+
+        # The raw command should still quote the assignment as one shell token.
+        assert "'\"'\"'KEY=abc; id; echo bad'\"'\"'" in raw
 
     def test_command_chdir(self):
         command = make_unix_command("uptime", _chdir="/opt/somedir")

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -6,12 +6,13 @@ from pyinfra.connectors.util import (
     CommandOutput,
     OutputLine,
     _ensure_askpass_set_for_host,
-    make_unix_command,  
+    make_unix_command,
     make_unix_command_for_host,
     remove_any_sudo_askpass_file,
 )
 
 from ..util import make_inventory
+
 
 class TestMakeUnixCommandConnectorUtil(TestCase):
     def test_command(self):
@@ -153,12 +154,12 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
                 "KEY": HiddenValue("super-secret"),
             },
         )
-        
+
         raw = command.get_raw_value()
         masked = command.get_masked_value()
         assert "super-secret" in raw
         assert "super-secret" not in masked
-        assert "*MASKED*" in masked 
+        assert "*MASKED*" in masked
         assert "KEY=*MASKED*" in masked
 
     def test_command_env_hidden_value_with_shell_chars(self):


### PR DESCRIPTION
## Summary

This PR is to allow _env values to accept the new `HiddenValue` so secret env variables can be passed into shell commands and not be exposed in the command logs.

The issue was that _env values were treated as strings when building the `export KEY=value` command. This meant that HiddenValue values would be converted into their masked representation too early, this subsequently caused the masked value to be used in the actual command instead of only the displayed command

This PR preserves the `HiddenValue` objects while constructing the env variables. Hence the raw value can be used during execution while keeping the masked value in logs. 

## Linked Issue

Fixes #1798 

## Changes

- Updates _env typing to support `HiddenValue` values:
```
EnvValue = str | HiddenValue

def generate_env(config: Config, value: Mapping[str, EnvValue] | None) -> dict[str, EnvValue]:
```

- Allow env value to be None as operation typing currently allow `_env=None` for safer handling
- Updates the environmental command construction to preserve `HiddenValue` until the command is rendered.
- Keeps the full `KEY=value` assignment quoted as one shell token.
- Adds tests covering:
  - `HiddenValue` being used as an _env value.
  - Raw command rendering using real secret
  - Masked command rendering hiding the secret
  - Shell-special characters remain safetly quoted
 

## Testing

Executed connectors tests:

`uv run pytest tests/test_connectors/test_util.py -k "env"`

Ran a tmp deploy (as shown in issues #1798) with full success:

`uv run pyinfra @local ../deploy.py -vv -y`


## Checklist

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
