### PR TITLE
fix(connectors.ssh): respect ssh_key_password over ssh_config IdentityFile

### DIFF
--- a/src/pyinfra/connectors/ssh_util.py
+++ b/src/pyinfra/connectors/ssh_util.py
@@ -24,7 +24,12 @@ def raise_connect_error(host: "Host", message, data):
     raise ConnectError(message)
 
 
-def _load_private_key_file(filename: str, key_filename: str, key_password: str):
+def _load_private_key_file(
+    filename: str,
+    key_filename: str,
+    key_password: str,
+    allow_prompt: bool = True,
+):
     exception: PyinfraError | SSHException = PyinfraError(f"Invalid key: {filename}")
 
     key_cls: type[RSAKey] | type[ECDSAKey] | type[Ed25519Key]
@@ -40,12 +45,13 @@ def _load_private_key_file(filename: str, key_filename: str, key_password: str):
                 # If password is not provided, but we're in CLI mode, ask for it. I'm not a
                 # huge fan of having CLI specific code in here, but it doesn't really fit
                 # anywhere else without duplicating lots of key related code into cli.py.
-                if pyinfra.is_cli:
+                if pyinfra.is_cli and allow_prompt:
                     key_password = getpass(
                         f"Enter password for private key: {key_filename}: ",
                     )
 
-                # API mode and no password? We can't continue!
+                # No password and no prompt (API mode, or a non-interactive caller
+                # such as the ssh_config identity path)? We can't continue.
                 else:
                     raise PyinfraError(
                         f"Private key file ({key_filename}) is encrypted, set ssh_key_password to "
@@ -76,6 +82,7 @@ def load_key_with_certificate(
     key_password: str | None = None,
     certificate_filename: str | None = None,
     cwd: str | None = None,
+    allow_prompt: bool = True,
 ) -> PKey:
     """
     Load a paramiko ``PKey`` from disk and attach an OpenSSH certificate when one
@@ -89,6 +96,9 @@ def load_key_with_certificate(
       ``CertificateFile`` directive). When unset, the adjacent
       ``<key>-cert.pub`` is used if present, falling back to ``<key>.pub``.
     + cwd: optional working directory used to resolve relative key paths.
+    + allow_prompt: when False, an encrypted key with no known passphrase raises
+      instead of prompting. Used by non-interactive callers like the ssh_config
+      identity path so they fall through rather than block (issue #1852).
     """
 
     resolved_path: str | None = None
@@ -100,7 +110,12 @@ def load_key_with_certificate(
             continue
         key_file_exists = True
         try:
-            key = _load_private_key_file(candidate, key_filename, key_password or "")
+            key = _load_private_key_file(
+                candidate,
+                key_filename,
+                key_password or "",
+                allow_prompt=allow_prompt,
+            )
             resolved_path = candidate
             break
         except SSHException:

--- a/src/pyinfra/connectors/sshuserclient/client.py
+++ b/src/pyinfra/connectors/sshuserclient/client.py
@@ -101,7 +101,9 @@ def _attach_identity_with_certificate(cfg: dict, host_config: dict) -> None:
     falls back to the implicit ``<key>-cert.pub`` lookup so OpenSSH-style CA
     auth works without explicit pyinfra ``ssh_key`` configuration (issue #1569).
     Silent fall-through when no identity exists keeps the legacy paramiko
-    ``key_filename`` flow for missing or otherwise unloadable files.
+    ``key_filename`` flow for missing or otherwise unloadable files. The load is
+    non-interactive (``allow_prompt=False``): an encrypted identity with no known
+    passphrase falls through instead of blocking on a prompt (issue #1852).
     """
 
     identity_files = host_config.get("identityfile") or []
@@ -121,6 +123,7 @@ def _attach_identity_with_certificate(cfg: dict, host_config: dict) -> None:
             cfg["pkey"] = load_key_with_certificate(
                 key_filename=identity_file,
                 certificate_filename=certificate_filename,
+                allow_prompt=False,
             )
         except (PyinfraError, SSHException, OSError) as e:
             logger.debug("Could not load identity %s with certificate: %s", identity_file, e)
@@ -314,7 +317,11 @@ class SSHClient(ParamikoClient):
         if "user" in host_config:
             cfg["username"] = host_config["user"]
 
-        if "identityfile" in host_config:
+        # An explicit pyinfra ``ssh_key`` (already loaded into ``pkey`` using
+        # ``ssh_key_password``) wins over any ssh_config ``IdentityFile``, the
+        # same way ``ssh -i`` overrides the config (issue #1852). Loading the
+        # config identity here would otherwise prompt for its passphrase.
+        if "identityfile" in host_config and "pkey" not in cfg:
             cfg["key_filename"] = host_config["identityfile"]
             _attach_identity_with_certificate(cfg, host_config)
 

--- a/tests/test_connectors/conftest.py
+++ b/tests/test_connectors/conftest.py
@@ -52,3 +52,21 @@ def ssh_ca_keypair(tmp_path_factory) -> dict[str, Path]:
         "user_cert": user_cert,
         "ssh_dir": ssh_dir,
     }
+
+
+@pytest.fixture(scope="session")
+def ssh_encrypted_key(tmp_path_factory) -> dict[str, object]:
+    if shutil.which("ssh-keygen") is None:
+        pytest.skip("ssh-keygen not available on PATH")
+
+    ssh_dir = tmp_path_factory.mktemp("ssh_encrypted")
+    key = ssh_dir / "encrypted_ed25519"
+    passphrase = "correct horse battery staple"
+
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-N", passphrase, "-f", str(key), "-C", "encrypted-test"],
+        check=True,
+        capture_output=True,
+    )
+
+    return {"key": key, "passphrase": passphrase}

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -527,6 +527,56 @@ def test_parse_config_honours_certificatefile_directive(
     assert cfg["pkey"].public_blob.key_type == CERT_KEY_TYPE
 
 
+def test_parse_config_explicit_pkey_wins_over_encrypted_identityfile(
+    ssh_encrypted_key, tmp_path, _clear_ssh_config_cache
+):
+    # Regression for #1852: an explicit pyinfra ssh_key (already loaded into a
+    # pkey using ssh_key_password) must win over an ssh_config IdentityFile. The
+    # encrypted IdentityFile must not be loaded, so no passphrase prompt fires.
+    config_path = tmp_path / "ssh_config"
+    _write_ssh_config(
+        config_path,
+        host="myhost",
+        IdentityFile=str(ssh_encrypted_key["key"]),
+    )
+
+    sentinel = object()
+    client = SSHClient()
+    with patch("pyinfra.connectors.ssh_util.getpass", return_value="wrong") as fake_getpass:
+        with patch("pyinfra.is_cli", True):
+            _, cfg, *_ = client.parse_config(
+                "myhost",
+                {"pkey": sentinel},
+                ssh_config_file=str(config_path),
+            )
+
+    fake_getpass.assert_not_called()
+    assert cfg["pkey"] is sentinel
+
+
+def test_parse_config_encrypted_identityfile_does_not_prompt(
+    ssh_encrypted_key, tmp_path, _clear_ssh_config_cache
+):
+    # Regression for #1852: an encrypted ssh_config IdentityFile with no known
+    # passphrase must fall through to the legacy key_filename flow instead of
+    # blocking on an interactive passphrase prompt.
+    config_path = tmp_path / "ssh_config"
+    _write_ssh_config(
+        config_path,
+        host="myhost",
+        IdentityFile=str(ssh_encrypted_key["key"]),
+    )
+
+    client = SSHClient()
+    with patch("pyinfra.connectors.ssh_util.getpass", return_value="wrong") as fake_getpass:
+        with patch("pyinfra.is_cli", True):
+            _, cfg, *_ = client.parse_config("myhost", ssh_config_file=str(config_path))
+
+    fake_getpass.assert_not_called()
+    assert "pkey" not in cfg
+    assert cfg["key_filename"] == [str(ssh_encrypted_key["key"])]
+
+
 def test_parse_config_keeps_key_filename_when_no_real_identityfile(
     tmp_path, _clear_ssh_config_cache
 ):


### PR DESCRIPTION
Fixes #1852.

## Problem

The ssh_config certificate auto-load added in #1750 (shipped in 3.9.0) loads the ssh_config `IdentityFile` eagerly during `parse_config`, but without a passphrase. With an encrypted key this triggers a `getpass` prompt even when the host already sets `ssh_key` and `ssh_key_password`, so the configured password is ignored:

```
Enter password for private key: /home/user/.ssh/foo.example.com:
```

It only triggers when the user's `~/.ssh/config` has an `IdentityFile` matching the host and that key is encrypted.

## Fix

1. An explicit pyinfra `ssh_key`, already loaded into a `pkey` using `ssh_key_password`, now wins over any ssh_config `IdentityFile`, the same way `ssh -i` overrides config. The config identity is no longer loaded when a `pkey` is already present, so no prompt fires.
2. The config identity load is now non-interactive (`allow_prompt=False`). An encrypted identity with no known passphrase falls through to the legacy `key_filename` flow instead of blocking on a prompt.

## Tests

- New `ssh_encrypted_key` fixture (real passphrase-protected key via `ssh-keygen`).
- `test_parse_config_explicit_pkey_wins_over_encrypted_identityfile`: explicit pkey preserved, no prompt.
- `test_parse_config_encrypted_identityfile_does_not_prompt`: encrypted config identity falls through silently, no prompt.

Full non-e2e suite passes (1857), ruff/format/mypy clean.
