### PR TITLE
style: fix ruff lint errors (PEP 585/604, f-strings, imports)

### DIFF
--- a/src/pyinfra/api/__init__.py
+++ b/src/pyinfra/api/__init__.py
@@ -7,7 +7,7 @@ from .command import (  # noqa: F401
     StringCommand,
     MaskString,
 )
-from .hiddenvalue import HiddenValue
+from .hiddenvalue import HiddenValue  # noqa: F401 # pragma: no cover
 from .config import Config  # noqa: F401 # pragma: no cover
 from .deploy import deploy  # noqa: F401 # pragma: no cover
 from .exceptions import (  # noqa: F401

--- a/src/pyinfra/connectors/scp/client.py
+++ b/src/pyinfra/connectors/scp/client.py
@@ -117,7 +117,7 @@ class SCPClient:
         # Quote them as the control sequence \^J for now,
         # which is how openssh handles it.
         self.channel.sendall(
-            ("C%s %d " % (mode, size)).encode("ascii") + basename.replace(b"\n", b"\\^J") + b"\n"
+            f"C{mode} {size} ".encode("ascii") + basename.replace(b"\n", b"\\^J") + b"\n"
         )
         self._recv_confirm()
         file_pos = 0

--- a/src/pyinfra/facts/efibootmgr.py
+++ b/src/pyinfra/facts/efibootmgr.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, TypedDict
+from typing import Any, TypedDict
 from collections.abc import Iterable
 
 from typing_extensions import override
@@ -18,7 +18,7 @@ class EFIBootMgrInfoDict(TypedDict):
     Entries: dict[int, BootEntry]
 
 
-class EFIBootMgr(FactBase[Optional[EFIBootMgrInfoDict]]):
+class EFIBootMgr(FactBase[EFIBootMgrInfoDict | None]):
     """
     Returns information about the UEFI boot variables:
 

--- a/src/pyinfra/facts/files.py
+++ b/src/pyinfra/facts/files.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import re
 import stat
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from typing_extensions import NotRequired, TypedDict, override
 from typing import Literal
@@ -220,7 +220,7 @@ class FileDict(TypedDict):
     link_target: NotRequired[str]
 
 
-class File(FactBase[Union[FileDict, Literal[False], None]]):
+class File(FactBase[FileDict | Literal[False] | None]):
     """
     Returns information about a file on the remote system:
 
@@ -370,7 +370,7 @@ class Socket(File):
 
 
 if TYPE_CHECKING:
-    FactBaseOptionalStr = FactBase[Optional[str]]
+    FactBaseOptionalStr = FactBase[str | None]
 else:
     FactBaseOptionalStr = FactBase
 
@@ -390,10 +390,10 @@ class HashFileFactBase(FactBaseOptionalStr):
         assert cls.__name__.endswith("File")
         hash_name = cls.__name__[:-4].upper()
         cls._regexes = (
-            # GNU coreutils style:
-            r"^([a-fA-F0-9]{%d})\s+%%s$" % digits,
+            # GNU coreutils style (two-stage template: %%s stays a literal %s placeholder):
+            r"^([a-fA-F0-9]{%d})\s+%%s$" % digits,  # noqa: UP031
             # BSD style:
-            r"^%s\s+\(%%s\)\s+=\s+([a-fA-F0-9]{%d})$" % (hash_name, digits),
+            r"^%s\s+\(%%s\)\s+=\s+([a-fA-F0-9]{%d})$" % (hash_name, digits),  # noqa: UP031
         )
 
     @override

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -6,7 +6,6 @@ import re
 import shutil
 from datetime import datetime
 from tempfile import mkdtemp
-from typing import Optional, Union
 from collections.abc import Iterable
 
 from dateutil.parser import parse as parse_date
@@ -41,7 +40,7 @@ class User(FactBase):
         return "echo $USER"
 
 
-class Home(FactBase[Optional[str]]):
+class Home(FactBase[str | None]):
     """
     Returns the home directory of the given user, or the current user if no user is given.
     """
@@ -205,7 +204,7 @@ class Timezone(FactBase[str]):
         return output[0]
 
 
-class Which(FactBase[Optional[str]]):
+class Which(FactBase[str | None]):
     """
     Returns the path of a given command according to `command -v`, if available.
     """
@@ -354,7 +353,7 @@ class Mounts(FactBase[dict[str, MountsDict]]):
         return devices
 
 
-class Port(FactBase[Union[tuple[str, int], tuple[None, None]]]):
+class Port(FactBase[tuple[str, int] | tuple[None, None]]):
     """
     Returns the process occupying a port and its PID.
 

--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -17,9 +17,9 @@ from pyinfra.facts.docker import (
     DockerVolume,
 )
 
-DOCKER_HUB_SERVER = "https://index.docker.io/v1/"
-
 from .util.docker import ContainerSpec, handle_docker, parse_image_reference
+
+DOCKER_HUB_SERVER = "https://index.docker.io/v1/"
 
 
 @operation()

--- a/src/pyinfra/progress.py
+++ b/src/pyinfra/progress.py
@@ -101,10 +101,8 @@ def progress_spinner(items, prefix_message=None):
             if items_allowed_width > 0:
                 items_string = f"{{{', '.join(f'{i}' for i in items)}}}"
                 if len(items_string) >= items_allowed_width:
-                    items_string = "{}...}}".format(
-                        # -3 for the ...
-                        items_string[: items_allowed_width - 3],
-                    )
+                    # -3 for the ...
+                    items_string = f"{items_string[: items_allowed_width - 3]}...}}"
 
                 message_bits.append(items_string)
 

--- a/src/pyinfra_cli/inventory.py
+++ b/src/pyinfra_cli/inventory.py
@@ -2,7 +2,7 @@ import ast
 import socket
 from collections import defaultdict
 from os import listdir, path
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar
 from collections.abc import Callable
 
 from pyinfra import logger
@@ -13,7 +13,7 @@ from pyinfra.context import ctx_inventory
 from .exceptions import CliError
 from .util import exec_file, try_import_module_attribute
 
-HostType = Union[str, tuple[str, dict]]
+HostType = str | tuple[str, dict]
 
 # Hosts in an inventory can be just the hostname or a tuple (hostname, data)
 ALLOWED_HOST_TYPES = (str, tuple)

--- a/src/pyinfra_cli/virtualenv.py
+++ b/src/pyinfra_cli/virtualenv.py
@@ -68,7 +68,7 @@ def init_virtualenv() -> None:
         virtual_env = os.path.join(
             os.environ["VIRTUAL_ENV"],
             "lib",
-            "python%d.%d" % sys.version_info[:2],
+            f"python{sys.version_info[0]}.{sys.version_info[1]}",
             "site-packages",
         )
 


### PR DESCRIPTION
## What

Resolves the ruff 0.14 lint findings currently present on `3.x` (14 across 9 files), scoped to lint only with no behaviour change.

- PEP 604 unions (`X | None`, `X | Y`) in the runtime `FactBase[...]` subscripts of `facts.efibootmgr`, `facts.files` and `facts.server`, and in the `HostType` alias of `pyinfra_cli.inventory`.
- f-strings in place of `%` / `str.format` building in `connectors.scp.client`, `pyinfra_cli.virtualenv` and `progress`.
- Move the `.util.docker` import above the module-level `DOCKER_HUB_SERVER` constant in `operations.docker` (E402); the import does not depend on that constant.
- Mark the `HiddenValue` re-export in `pyinfra.api.__init__` with `# noqa: F401`, matching its sibling imports.
- Mark the two two-stage regex templates in `facts.files` with `# noqa: UP031`. There `%%s` is an intentional literal `%s` placeholder for a later substitution, and a `.format()` rewrite would need cryptic brace escaping.

## Notes

The `FactBase[...]` unions are evaluated at runtime (base-class subscripts, not annotations). They are valid because the project floor is Python 3.10 (`requires-python = ">=3.10,<4.0"`). ruff does not autofix these for that reason, so they were converted by hand and checked to construct at runtime.

## Verification

- `scripts/dev-lint.sh`: ruff check, ruff format, mypy (160 files) and the arguments sync check all pass.
- Full non-end-to-end test suite: 1855 passed.
