### PR TITLE
feat(facts.server): Add OpenBSD support to server.Mounts

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -6,8 +6,6 @@ import re
 import shutil
 from datetime import datetime
 from tempfile import mkdtemp
-from operator import methodcaller
-from itertools import takewhile
 from typing import Optional, Union
 from collections.abc import Iterable
 
@@ -336,13 +334,7 @@ class Mounts(FactBase[dict[str, MountsDict]]):
                     path = m[2]
                     device = m[1]
                     type_ = m[3]
-                    # assumes ctime flag is always last and drops it
-                    options = list(
-                        map(
-                            methodcaller("lstrip", " "),
-                            takewhile(lambda f: "ctime=" not in f, m[4].split(",")),
-                        )
-                    )
+                    options = [opt.strip(" ") for opt in m[4].split(",") if "ctime=" not in opt]
 
                     devices[path] = {"device": device, "type": type_, "options": options}
 

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -6,6 +6,8 @@ import re
 import shutil
 from datetime import datetime
 from tempfile import mkdtemp
+from operator import methodcaller
+from itertools import takewhile
 from typing import Optional, Union
 from collections.abc import Iterable
 
@@ -286,6 +288,8 @@ class Mounts(FactBase[dict[str, MountsDict]]):
 
         if self._kernel.strip() == "FreeBSD":
             return "mount -p --libxo json"
+        if self._kernel.strip() == "OpenBSD":
+            return "mount -v"
         else:
             return "cat /proc/self/mountinfo"
 
@@ -315,6 +319,32 @@ class Mounts(FactBase[dict[str, MountsDict]]):
                 options = [option.strip() for option in entry["opts"].split(",")]
 
                 devices[path] = {"device": device, "type": type_, "options": options}
+
+            return devices
+
+        if self._kernel == "OpenBSD":
+            p = re.compile(
+                r"""
+                    (/dev/[^ ]+) (?:\ \(.*\))?\                                  # the (diskname.label) isn't always there
+                    on\ (/.*)\                                                   # *, not +, since root path "/" will be mounted
+                    type\ (ffs|mfs|nfs|nfts|tmpfs|udf|vnd|ext2fs|msdos|cd9660)\  # taken from /sbin/mount_*
+                    \((.+)\)                                                     # flags are in this group""",
+                flags=re.VERBOSE,
+            )
+            for line in output:
+                if m := re.fullmatch(p, line):
+                    path = m[2]
+                    device = m[1]
+                    type = m[3]
+                    # assumes ctime flag is always last and drops it
+                    options = list(
+                        map(
+                            methodcaller("lstrip", " "),
+                            takewhile(lambda f: "ctime=" not in f, m[4].split(",")),
+                        )
+                    )
+
+                    devices[path] = {"device": device, "type": type, "options": options}
 
             return devices
 

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -327,7 +327,7 @@ class Mounts(FactBase[dict[str, MountsDict]]):
                 r"""
                     (/dev/[^ ]+) (?:\ \(.*\))?\                                  # the (diskname.label) isn't always there
                     on\ (/.*)\                                                   # *, not +, since root path "/" will be mounted
-                    type\ (ffs|mfs|nfs|nfts|tmpfs|udf|vnd|ext2fs|msdos|cd9660)\  # taken from /sbin/mount_*
+                    type\ (ffs|mfs|nfs|ntfs|tmpfs|udf|vnd|ext2fs|msdos|cd9660)\  # taken from /sbin/mount_*
                     \((.+)\)                                                     # flags are in this group""",
                 flags=re.VERBOSE,
             )

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -26,10 +26,10 @@ ISO_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 _SAFE_USERNAME_RE = re.compile(r"^[a-zA-Z0-9._][a-zA-Z0-9._-]*$")
 _OPENBSD_MOUNT_V_RE = re.compile(
     r"""
-        (/dev/[^ ]+) (?:\ \(.*\))?\                                  # the (diskname.label) isn't always there
-        on\ (/.*)\                                                   # *, not +, since root path "/" will be mounted
-        type\ (ffs|mfs|nfs|ntfs|tmpfs|udf|vnd|ext2fs|msdos|cd9660)\  # taken from /sbin/mount_*
-        \((.+)\)                                                     # flags are in this group""",
+        (\S+) (?:\ \(.*\))?\  # the (diskname.label) part isn't always there, hence optional group
+        on\ (/.*)\            # *, not +, since root path "/" will be mounted
+        type\ (\w+)\          # types from /sbin/mount_*
+        \((.+)\)              # flags are in this group""",
     flags=re.VERBOSE,
 )
 

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -290,11 +290,11 @@ class Mounts(FactBase[dict[str, MountsDict]]):
 
     @override
     def command(self) -> str:
-        self._kernel = host.get_fact(Kernel)
+        self._kernel = host.get_fact(Kernel).strip()
 
-        if self._kernel.strip() == "FreeBSD":
+        if self._kernel == "FreeBSD":
             return "mount -p --libxo json"
-        if self._kernel.strip() == "OpenBSD":
+        if self._kernel == "OpenBSD":
             return "mount -v"
         else:
             return "cat /proc/self/mountinfo"

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -26,6 +26,14 @@ ISO_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 # Usernames used in shell tilde expansion (``~user``) cannot be quoted without
 # disabling the expansion, so the value must be a plain, shell-safe word.
 _SAFE_USERNAME_RE = re.compile(r"^[a-zA-Z0-9._][a-zA-Z0-9._-]*$")
+_OPENBSD_MOUNT_V_RE = re.compile(
+    r"""
+        (/dev/[^ ]+) (?:\ \(.*\))?\                                  # the (diskname.label) isn't always there
+        on\ (/.*)\                                                   # *, not +, since root path "/" will be mounted
+        type\ (ffs|mfs|nfs|ntfs|tmpfs|udf|vnd|ext2fs|msdos|cd9660)\  # taken from /sbin/mount_*
+        \((.+)\)                                                     # flags are in this group""",
+    flags=re.VERBOSE,
+)
 
 
 def _check_tilde_username(user: str) -> None:
@@ -323,16 +331,8 @@ class Mounts(FactBase[dict[str, MountsDict]]):
             return devices
 
         if self._kernel == "OpenBSD":
-            p = re.compile(
-                r"""
-                    (/dev/[^ ]+) (?:\ \(.*\))?\                                  # the (diskname.label) isn't always there
-                    on\ (/.*)\                                                   # *, not +, since root path "/" will be mounted
-                    type\ (ffs|mfs|nfs|ntfs|tmpfs|udf|vnd|ext2fs|msdos|cd9660)\  # taken from /sbin/mount_*
-                    \((.+)\)                                                     # flags are in this group""",
-                flags=re.VERBOSE,
-            )
             for line in output:
-                if m := re.fullmatch(p, line):
+                if m := _OPENBSD_MOUNT_V_RE.fullmatch(line):
                     path = m[2]
                     device = m[1]
                     type = m[3]

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -335,7 +335,7 @@ class Mounts(FactBase[dict[str, MountsDict]]):
                 if m := _OPENBSD_MOUNT_V_RE.fullmatch(line):
                     path = m[2]
                     device = m[1]
-                    type = m[3]
+                    type_ = m[3]
                     # assumes ctime flag is always last and drops it
                     options = list(
                         map(
@@ -344,7 +344,7 @@ class Mounts(FactBase[dict[str, MountsDict]]):
                         )
                     )
 
-                    devices[path] = {"device": device, "type": type, "options": options}
+                    devices[path] = {"device": device, "type": type_, "options": options}
 
             return devices
 

--- a/tests/facts/server.Mounts/openbsd.json
+++ b/tests/facts/server.Mounts/openbsd.json
@@ -9,7 +9,9 @@
         "/dev/sd0h (b486026f5c43e172.h) on /usr/local type ffs (rw, local, nodev, wxallowed, ctime=Thu Jan  1 12:00:00 1970)",
         "/dev/sd0j (b486026f5c43e172.j) on /usr/obj type ffs (rw, local, nodev, nosuid, ctime=Thu Jan  1 12:00:00 1970)",
         "/dev/sd0i (b486026f5c43e172.i) on /usr/src type ffs (rw, local, nodev, nosuid, ctime=Thu Jan  1 12:00:00 1970)",
-        "/dev/sd0e on /var type ffs (rw, local, nosuid, ctime=Thu Jan  1 12:00:00 1970)"
+        "/dev/sd0e on /var type ffs (rw, local, nosuid, ctime=Thu Jan  1 12:00:00 1970)",
+        "skynet:/sys on /sys type nfs (rw, nodev, nosuid, ctime=Mon Aug  4 16:21:19 1997, tcp, soft, intr)",
+        "mfs:75 on /run type mfs (rw, noexec, nosuid, ctime=Thu Jan  1 12:00:00 1970)"
     ],
     "facts": {
         "server.Kernel": "OpenBSD"
@@ -59,6 +61,16 @@
             "device": "/dev/sd0e",
             "type": "ffs",
             "options": ["rw", "local", "nosuid"]
+        },
+        "/sys": {
+            "device": "skynet:/sys",
+            "type": "nfs",
+            "options": ["rw", "nodev", "nosuid", "tcp", "soft", "intr"]
+        },
+        "/run": {
+            "device": "mfs:75",
+            "type": "mfs",
+            "options": ["rw", "noexec", "nosuid"]
         }
     }
 }

--- a/tests/facts/server.Mounts/openbsd.json
+++ b/tests/facts/server.Mounts/openbsd.json
@@ -1,0 +1,64 @@
+{
+    "command": "mount -v",
+    "output": [
+        "/dev/sd0a (b486026f5c43e172.a) on / type ffs (rw, local, ctime=Thu Jan  1 12:00:00 1970)",
+        "/dev/sd0k (b486026f5c43e172.k) on /home type ffs (rw, local, nodev, nosuid, ctime=Thu Jan  1 12:00:00 1970)",
+        "/dev/sd0d (b486026f5c43e172.d) on /tmp type ffs (rw, local, nodev, nosuid, ctime=Thu Jan  1 12:00:00 1970)",
+        "/dev/sd0f (b486026f5c43e172.f) on /usr type ffs (rw, local, nodev, ctime=Thu Jan  1 12:00:00 1970)",
+        "/dev/sd0g (b486026f5c43e172.g) on /usr/X11R6 type ffs (rw, local, nodev, ctime=Thu Jan  1 12:00:00 1970)",
+        "/dev/sd0h (b486026f5c43e172.h) on /usr/local type ffs (rw, local, nodev, wxallowed, ctime=Thu Jan  1 12:00:00 1970)",
+        "/dev/sd0j (b486026f5c43e172.j) on /usr/obj type ffs (rw, local, nodev, nosuid, ctime=Thu Jan  1 12:00:00 1970)",
+        "/dev/sd0i (b486026f5c43e172.i) on /usr/src type ffs (rw, local, nodev, nosuid, ctime=Thu Jan  1 12:00:00 1970)",
+        "/dev/sd0e on /var type ffs (rw, local, nosuid, ctime=Thu Jan  1 12:00:00 1970)"
+    ],
+    "facts": {
+        "server.Kernel": "OpenBSD"
+    },
+    "fact": {
+        "/": {
+            "device": "/dev/sd0a",
+            "type": "ffs",
+            "options": ["rw", "local"]
+        },
+        "/home": {
+            "device": "/dev/sd0k",
+            "type": "ffs",
+            "options": ["rw", "local", "nodev", "nosuid"]
+        },
+        "/tmp": {
+            "device": "/dev/sd0d",
+            "type": "ffs",
+            "options": ["rw", "local", "nodev", "nosuid"]
+        },
+        "/usr": {
+            "device": "/dev/sd0f",
+            "type": "ffs",
+            "options": ["rw", "local", "nodev"]
+        },
+        "/usr/X11R6": {
+            "device": "/dev/sd0g",
+            "type": "ffs",
+            "options": ["rw", "local", "nodev"]
+        },
+        "/usr/local": {
+            "device": "/dev/sd0h",
+            "type": "ffs",
+            "options": ["rw", "local", "nodev", "wxallowed"]
+        },
+        "/usr/obj": {
+            "device": "/dev/sd0j",
+            "type": "ffs",
+            "options": ["rw", "local", "nodev", "nosuid"]
+        },
+        "/usr/src": {
+            "device": "/dev/sd0i",
+            "type": "ffs",
+            "options": ["rw", "local", "nodev", "nosuid"]
+        },
+        "/var": {
+            "device": "/dev/sd0e",
+            "type": "ffs",
+            "options": ["rw", "local", "nosuid"]
+        }
+    }
+}


### PR DESCRIPTION
`server.Mounts` handles Linux and FreeBSD, however, the fact fails on OpenBSD due to missing `/proc` (and it has different commandline options for `mount`). This PR adds a parser for OpenBSD's [`mount -v`](https://man.openbsd.org/mount#v).

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
