### PR TITLE
feat(operations.server.Mount): generalize remount to more BSDs

### DIFF
--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -325,6 +325,8 @@ def mount(
     + path: the path of the mounted filesystem
     + mounted: whether the filesystem should be mounted
     + options: the mount options
+    + device: the device behind the mount
+    + fs_type: the filesystem type
 
     Options:
         If the currently mounted filesystem does not have all of the provided
@@ -373,14 +375,14 @@ def mount(
         mounted_options = mounts[mounted_path]["options"]
         needed_options = set(options) - set(mounted_options)
         if needed_options:
-            if host.get_fact(Kernel).strip() == "FreeBSD":
+            # the -u option is common among FreeBSD, OpenBSD, NetBSD, DragonFlyBSD
+            if "BSD" in host.get_fact(Kernel).strip():
                 fs_type = mounts[mounted_path]["type"]
                 device = mounts[mounted_path]["device"]
-
                 yield StringCommand(
                     "mount",
-                    "-o",
-                    StringCommand("update,", options_string, _separator=""),
+                    "-uo",
+                    StringCommand(options_string, _separator=""),
                     "-t",
                     fs_type,
                     QuoteString(device),

--- a/tests/operations/server.mount/remount_options_bsd.json
+++ b/tests/operations/server.mount/remount_options_bsd.json
@@ -1,0 +1,19 @@
+{
+    "args": ["/data"],
+    "kwargs": {
+        "options": ["rw", "noatime"]
+    },
+    "facts": {
+        "server.Kernel": "*BSD",
+        "server.Mounts": {
+            "/data": {
+                "options": ["rw"],
+                "type": "ufs",
+                "device": "/dev/sd0a"
+            }
+        }
+    },
+    "commands": [
+        "mount -uo rw,noatime -t ufs /dev/sd0a /data"
+    ]
+}


### PR DESCRIPTION
Previous code used `mount -o` update, which is exclusive to FreeBSD and DragonFlyBSD. However, FreeBSD, OpenBSD, NetBSD, and DragonFlyBSD all support `mount -u`.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
