### PR TITLE
fix: scripts/,docs/: With with virtual environments other than `uv`

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Run shellcheck
         run: |
           git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' -- ':!*.py' \
-            | xargs shellcheck
+            | xargs shellcheck -x -P scripts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,16 +10,21 @@ instead of YAML, and much faster. It supports SSH, local machine, Docker, and mo
 
 ## Development Setup
 
-```bash
-uv sync  # Install all dependencies into managed venv
-```
+If you use `uv`, you may:
+
+    uv sync  # Install all dependencies into managed venv
+
+Or you can set up your own virtualenv (or even use your top-level
+environment), and ensure everything you need is installed with
+
+    pip install --group=dev -e .
 
 ## Common Commands
 
 ```bash
 # Run tests
 scripts/dev-test.sh
-# or directly:
+# or directly (leave off `uv run` if you've set up your own virtualenv):
 uv run pytest --cov --disable-warnings -m 'not end_to_end'
 
 # Run fixtures for a single operation or fact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Operations/facts:
 - facts.server.LinuxDistribution: resolve `major`/`minor` from the most precise release source available, not just `/etc/os-release`. Fact output changes on hosts where `VERSION_ID` only exposes the major version — e.g. CentOS 7 now reports `minor: 9` instead of `minor: null` (#1859) (@wlix13)
 - facts.server.LinuxDistribution: report `minor: 0` instead of `null` for X.0 releases (e.g. RED OS 8.0) (#1859) (@wlix13)
 
+Docs/meta:
+
+- docs,scripts/: No longer require `uv`, but just use the current
+  (typically virtual) environment if `uv` is not available. (@0cjs)
+
 # v3.9.2
 
 - Fix documentation recursive copy mess

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -82,10 +82,10 @@ To limit the pytests to a specific fact or operation:
 
 ```sh
 # Only run fact tests for facts.efibootmgr.EFIBootMGR
-uv run pytest tests/test_facts.py -k "efibootmgr.EFIBootMGR"
+scripts/dev-test.sh tests/test_facts.py -k "efibootmgr.EFIBootMGR"
 
 # Only run operation tests for operations.selinux
-uv run pytest tests/test_operations.py -k "selinux."
+scripts/dev-test.sh tests/test_operations.py -k "selinux."
 ```
 
 #### End-to-End Tests
@@ -97,11 +97,11 @@ The end-to-end tests are also executed via `pytest` but not selected by default,
 scripts/dev-test-e2e.sh
 
 # Run local e2e tests (works on Linux / MacOS, no Windows yet)
-uv run pytest -m end_to_end_local
+scripts/dev-test.sh -m end_to_end_local
 
 # Run Docker and SSH e2e tests (Linux / MacOS with Docker installed)
-uv run pytest -m end_to_end_ssh
-uv run pytest -m end_to_end_docker
+scripts/dev-test.sh -m end_to_end_ssh
+scripts/dev-test.sh -m end_to_end_docker
 ```
 
 ## Documentation

--- a/docs/install.md
+++ b/docs/install.md
@@ -83,10 +83,10 @@ First install [pipx](https://pipx.pypa.io/stable/installation/) if you haven't a
    env\Scripts\activate
    ```
 
-#### Install pyinfra via pip
+#### Install development dependencies and pyinfra in edit mode into the virtual environment
 
    ```sh
-   pip install pyinfra
+   pip install --group=dev -e .
    ```
 
 #### Verify pip Installation

--- a/scripts/build-public-docs.sh
+++ b/scripts/build-public-docs.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -euo pipefail
+source "$(dirname "$0")/common.bash"    # setup $uvrun, etc.
 
 NEXT_BRANCH="3.x"
 LATEST_BRANCH="3.x"
@@ -20,7 +19,7 @@ build_docs() {
 
     echo "Building zensical site for version: ${docs_version}"
     rm -rf "$build_dir"
-    uv run zensical build --clean
+    $uvrun zensical build --clean
     mkdir -p "$(dirname "$build_dir")"
     mv build/docs "$build_dir"
 }
@@ -55,7 +54,7 @@ if [ -n "${TAG_NAME}" ] && [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+([\.a-z0-9]+)?$ ]];
     if [ "${BRANCH_NAME}" = "${LATEST_BRANCH}" ]; then
         echo "Generating /page redirects"
         mkdir -p "docs-public/page/"
-        DOCS_VERSION=$BRANCH_NAME uv run python scripts/generate_redirect_pages.py
+        DOCS_VERSION=$BRANCH_NAME $uvrun python scripts/generate_redirect_pages.py
     fi
 fi
 
@@ -64,5 +63,5 @@ if [[ -z "${TAG_NAME}" ]] && [[ "${BRANCH_NAME}" != "${LATEST_BRANCH}" && "${BRA
     echo "Performing local build for branch: ${BRANCH_NAME}"
     build_docs "$BRANCH_NAME" "build/local"
     echo "Docs built to build/local/"
-    echo "Preview with: uv run zensical serve"
+    echo "Preview with: $uvrun zensical serve"
 fi

--- a/scripts/common.bash
+++ b/scripts/common.bash
@@ -1,0 +1,16 @@
+#   This file should be `source`d.
+
+set -Eeuo pipefail
+
+#   If uv is available, we will always use it. But if uv is not present, we
+#   assume that the developer has set up her own virtualenv configuration
+#   and run:
+#       pip install --group=dev -e .
+uvrun=
+if uv --version >/dev/null 2>&1; then
+    uvrun='uv run'
+else
+    [[ -z ${VIRTUAL_ENV:-} ]] && echo 1>&2 \
+        "WARNING: no 'uv' and no \$VIRTUAL_ENV; trying in current environment."
+fi
+true

--- a/scripts/dev-format.sh
+++ b/scripts/dev-format.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-
-set -euo pipefail
+source "$(dirname "$0")/common.bash"    # setup $uvrun, etc.
 
 echo "Execute ruff format..."
-uv run ruff format
+$uvrun ruff format

--- a/scripts/dev-lint.sh
+++ b/scripts/dev-lint.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
-
-set -euo pipefail
+source "$(dirname "$0")/common.bash"    # setup $uvrun, etc.
 
 echo "Execute ruff check..."
-uv run ruff check --diff --unsafe-fixes
-uv run ruff format --diff
+$uvrun ruff check --diff --unsafe-fixes
+$uvrun ruff format --diff
 
 echo "Execute mypy..."
-uv run mypy
+$uvrun mypy
 
 echo "Execute arguments type check..."
-uv run python scripts/lint_arguments_sync.py
+$uvrun python scripts/lint_arguments_sync.py
 
 echo "Execute shellcheck..."
 if ! command -v shellcheck >/dev/null 2>&1; then
     echo "shellcheck is not installed, see docs/contributing.md for instructions." >&2
     exit 1
 fi
+
 git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' -- ':!*.py' \
-    | xargs shellcheck
+    | xargs shellcheck -x -P scripts/
 
 echo "Linting complete!"

--- a/scripts/dev-test-e2e.sh
+++ b/scripts/dev-test-e2e.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
-
-set -euo pipefail
+source "$(dirname "$0")/common.bash"    # setup $uvrun, etc.
 
 echo "Execute local end to end tests..."
-uv run pytest -m end_to_end_local
+$uvrun pytest -m end_to_end_local
 
 echo "Execute SSH end to end tests..."
-uv run pytest -m end_to_end_ssh
+$uvrun pytest -m end_to_end_ssh
 
 echo "Execute Docker end to end tests..."
-uv run pytest -m end_to_end_docker
+$uvrun pytest -m end_to_end_docker
 
 echo "Tests complete!"

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-
-set -euo pipefail
+source "$(dirname "$0")/common.bash"    # setup $uvrun, etc.
 
 echo "Execute pytest..."
-uv run pytest "$@"
+$uvrun pytest "$@"
 
 echo "Tests complete!"

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -3,7 +3,7 @@
 # emit Markdown pages + card snippets into docs/. Must run before `zensical
 # build` — zensical has no build-time hooks.
 
-set -euo pipefail
+source "$(dirname "$0")/common.bash"    # setup $uvrun, etc.
 
 cd "$(dirname "$0")/.."
 
@@ -12,16 +12,16 @@ mkdir -p docs/operations docs/facts docs/connectors snippets
 find docs/operations docs/facts docs/connectors -maxdepth 1 -type f -name '*.md' ! -name 'index.md' -delete
 
 echo "### Generating operations docs"
-uv run python scripts/generate_operations_docs.py
+$uvrun python scripts/generate_operations_docs.py
 
 echo "### Generating facts docs"
-uv run python scripts/generate_facts_docs.py
+$uvrun python scripts/generate_facts_docs.py
 
 echo "### Generating connectors docs"
-uv run python scripts/generate_connectors_docs.py
+$uvrun python scripts/generate_connectors_docs.py
 
 echo "### Generating arguments snippet"
-uv run python scripts/generate_arguments_doc.py
+$uvrun python scripts/generate_arguments_doc.py
 
 echo "### Generating llms.txt"
-uv run python scripts/generate_llms_txt.py
+$uvrun python scripts/generate_llms_txt.py

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
+source "$(dirname "$0")/common.bash"    # setup $uvrun, etc.
 
-set -euo pipefail
-
-VERSION=$(uv run python scripts/generate_next_version.py)
-MAJOR_BRANCH="$(uv run python scripts/generate_next_version.py | cut -d'.' -f1).x"
+VERSION=$($uvrun python scripts/generate_next_version.py)
+MAJOR_BRANCH="$($uvrun python scripts/generate_next_version.py | cut -d'.' -f1).x"
 
 echo "# Releasing pyinfra v${VERSION} (branch ${MAJOR_BRANCH})"
 
 echo "# Running tests..."
-uv run pytest
+$uvrun pytest
 
 echo "# Git tag & push..."
 git tag -a "v$VERSION" -m "v$VERSION"
@@ -22,6 +21,6 @@ echo "Publishing to PyPI..."
 uv publish
 
 echo "Making GitHub release..."
-uv run python scripts/make_github_release.py
+$uvrun python scripts/make_github_release.py
 
 echo "# All done!"

--- a/scripts/spellcheck.sh
+++ b/scripts/spellcheck.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+source "$(dirname "$0")/common.bash"    # setup $uvrun, etc.
 
-uv run typos
+$uvrun typos


### PR DESCRIPTION
If `uv` is available, the scripts/* programs will still use it directly, but if not it assumes that the developer has set up a virtual environment in her own way and just runs pytest etc. directly. (If $VIRTUAL_ENV is not set, probably a virtual environment has not been set up and a warning will be printed, but things will still work if you have the necessary programs and libraries installed.)

Note that this does not check for $CONDA_DEFAULT_ENV or similar.

The documentation has also been updated to make this clear, and add the `pip` command that does the equivalent install into the current environment of what `uv` sets up.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [ ] Type checking & code style passes (see `scripts/dev-lint.sh`)
       - 2872 ruff errors and a mypy, but I believe that none of these are from this commit. Shellcheck passes.
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
