### PR TITLE
docs: clarify commit message format and PR linting

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -27,6 +27,7 @@ jobs:
           scopes: |
             api
             cli
+            deps
             operations(\.[A-Za-z0-9.\-]+)?
             facts(\.[A-Za-z0-9.\-]+)?
             connectors(\.[A-Za-z0-9.\-]+)?

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,9 +66,12 @@ scripts/dev-format.sh
 Commit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 standard. PRs that follow this will be rebased, PRs that do not will be squashed.
 
-The following scopes are allowed: `api`, `cli`, `operations`, `facts`, `connectors`. With the last 
-three an optional sub-scope can be added, ie `operations.docker` or `facts.apt`.
+The following scopes are (optionally) allowed: `api`, `cli`, `deps`, `operations`, `facts`, `connectors`. 
+With the last three an optional sub-scope can be added, ie `operations.docker` or `facts.apt`.
 
+When creating a PR, the last commit message is typically used as the PR title. When merging PRs, 
+we typically squash all commits into a single commit, and use the PR title as the commit message.
+For this reason, PR titles are linted to check if they follow our commit message conventions.
 
 ### Tests
 


### PR DESCRIPTION
 `deps` is added as an optionally allowed scope

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
