### PR TITLE
fix(facts.git): GitLocalCommit fact failing on nonlocal ref

### DIFF
--- a/src/pyinfra/facts/git.py
+++ b/src/pyinfra/facts/git.py
@@ -83,7 +83,7 @@ class GitLocalCommit(GitFactBase):
 
     @override
     def command(self, repo: str, ref: str = "HEAD") -> str:
-        return f"! test -d {repo} || (cd {repo} && git rev-parse {ref} 2>/dev/null)"
+        return f"! test -d {repo} || (cd {repo} && git rev-parse {ref} 2>/dev/null) || true"
 
     @override
     def process(self, output: list[str]):

--- a/tests/facts/git.GitLocalCommit/branch_ref.json
+++ b/tests/facts/git.GitLocalCommit/branch_ref.json
@@ -3,7 +3,7 @@
         "repo": "myrepo",
         "ref": "mybranch"
     },
-    "command": "! test -d myrepo || (cd myrepo && git rev-parse mybranch 2>/dev/null)",
+    "command": "! test -d myrepo || (cd myrepo && git rev-parse mybranch 2>/dev/null) || true",
     "requires_command": "git",
     "output": [
         "1a2b3c4d5e6f7890abcdef1234567890abcdef12"

--- a/tests/facts/git.GitLocalCommit/head.json
+++ b/tests/facts/git.GitLocalCommit/head.json
@@ -1,6 +1,6 @@
 {
     "arg": "myrepo",
-    "command": "! test -d myrepo || (cd myrepo && git rev-parse HEAD 2>/dev/null)",
+    "command": "! test -d myrepo || (cd myrepo && git rev-parse HEAD 2>/dev/null) || true",
     "requires_command": "git",
     "output": [
         "1a2b3c4d5e6f7890abcdef1234567890abcdef12"

--- a/tests/facts/git.GitLocalCommit/no_repo.json
+++ b/tests/facts/git.GitLocalCommit/no_repo.json
@@ -1,6 +1,6 @@
 {
     "arg": "myrepo",
-    "command": "! test -d myrepo || (cd myrepo && git rev-parse HEAD 2>/dev/null)",
+    "command": "! test -d myrepo || (cd myrepo && git rev-parse HEAD 2>/dev/null) || true",
     "requires_command": "git",
     "output": [],
     "fact": null

--- a/tests/facts/git.GitLocalCommit/unknown_ref.json
+++ b/tests/facts/git.GitLocalCommit/unknown_ref.json
@@ -1,0 +1,12 @@
+{
+    "arg": {
+        "repo": "myrepo",
+        "ref": "v34.0.1"
+    },
+    "command": "! test -d myrepo || (cd myrepo && git rev-parse v34.0.1 2>/dev/null) || true",
+    "requires_command": "git",
+    "output": [
+        "v34.0.1"
+    ],
+    "fact": null
+}

--- a/tests/facts/git.GitLocalCommit/unknown_ref.json
+++ b/tests/facts/git.GitLocalCommit/unknown_ref.json
@@ -5,8 +5,6 @@
     },
     "command": "! test -d myrepo || (cd myrepo && git rev-parse v34.0.1 2>/dev/null) || true",
     "requires_command": "git",
-    "output": [
-        "v34.0.1"
-    ],
+    "output": [],
     "fact": null
 }


### PR DESCRIPTION
Fixes: #1880 

---

Its docstring explicitly promises: "returns None when the repository does not exist, the ref is unknown, or the command fails." And the `process()` method is written for that — it validates the output against a SHA regex and returns None otherwise.

But the shell command doesn't hold up its end. When the directory exists and the ref is unknown, `git rev-parse` exits with code 128. The `2>/dev/null` hides the error text but does nothing about the exit code, so the whole fact command exits non-zero. pyinfra treats a failed fact command as fatal — `Error: could not load fact` — kicks the host out, and you get `No hosts remaining!`.

-------

As per AI policy I disclose that test were created with assistance of LLM. I have read and tested them manually so its human verified.

----



- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format