### PR TITLE
feat(operations.docker.volume): allow options to be passed when creating docker volumes

### DIFF
--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -415,13 +415,20 @@ def build(
 
 
 @operation()
-def volume(volume: str, driver: str = "", labels: list[str] | None = None, present: bool = True):
+def volume(
+    volume: str,
+    driver: str = "",
+    labels: list[str] | None = None,
+    options: list[str] | None = None,
+    present: bool = True,
+):
     """
     Manage Docker volumes
 
     + volume: Volume name
     + driver: Docker volume storage driver
     + labels: Label list to attach in the volume
+    + options: Driver-specific options
     + present: whether the Docker volume should exist
 
     **Examples:**
@@ -449,6 +456,7 @@ def volume(volume: str, driver: str = "", labels: list[str] | None = None, prese
             volume=volume,
             driver=driver,
             labels=labels,
+            options=options,
             present=present,
         )
 

--- a/src/pyinfra/operations/util/docker.py
+++ b/src/pyinfra/operations/util/docker.py
@@ -311,6 +311,7 @@ def _prune_command(**kwargs) -> StringCommand:
 
 def _create_volume(**kwargs) -> StringCommand:
     labels = kwargs["labels"] if kwargs["labels"] else []
+    options = kwargs["options"] if kwargs["options"] else []
 
     command: list[str | QuoteString] = ["docker volume create", QuoteString(kwargs["volume"])]
 
@@ -319,6 +320,9 @@ def _create_volume(**kwargs) -> StringCommand:
 
     for label in labels:
         command += ["--label", QuoteString(label)]
+
+    for option in options:
+        command += ["--opt", QuoteString(option)]
 
     return StringCommand(*command)
 

--- a/tests/operations/docker.volume/add_volume_with_options.json
+++ b/tests/operations/docker.volume/add_volume_with_options.json
@@ -1,0 +1,16 @@
+{
+    "kwargs": {
+        "volume": "my_volume",
+        "driver": "local",
+        "options": ["type=nfs", "o=addr=192.168.1.100,rw,nfsvers=4.1", "device=:/exported/path"],
+        "present": true
+    },
+    "facts": {
+        "docker.DockerVolume": {
+            "object_id=my_volume": []
+        }
+    },
+    "commands": [
+        "docker volume create my_volume -d local --opt type=nfs --opt o=addr=192.168.1.100,rw,nfsvers=4.1 --opt device=:/exported/path"
+    ]
+}


### PR DESCRIPTION
Options (`--opt`) are required when creating NFS volumes and other types of volumes. We make no attempt at modelling all possible options, because that would brittle in light of future Docker updates. Instead, a list of strings can be passed. Not all options are kv pairs, so we don't use a dict.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
