### PR TITLE
fix(cli): preserve Windows paths in module errors

### DIFF
--- a/src/pyinfra_cli/util.py
+++ b/src/pyinfra_cli/util.py
@@ -153,7 +153,16 @@ def parse_cli_arg(arg):
     return arg
 
 
+def _is_windows_drive_path(path: str) -> bool:
+    return len(path) >= 3 and path[1] == ":" and path[2] in ("/", "\\")
+
+
 def try_import_module_attribute(path, prefix=None, raise_for_none=True):
+    if _is_windows_drive_path(path):
+        if raise_for_none:
+            raise CliError(f"No such module: {path}")
+        return None
+
     if ":" in path:
         # Allow a.module.name:function syntax
         mod_path, attr_name = path.rsplit(":", 1)

--- a/tests/test_cli/test_cli_util.py
+++ b/tests/test_cli/test_cli_util.py
@@ -102,3 +102,11 @@ def test_try_import_module_attribute_falls_through_when_attr_missing(monkeypatch
     result = try_import_module_attribute("pip.Pip3Packages", prefix="pyinfra.facts")
 
     assert result is Pip3Packages
+
+
+def test_try_import_module_attribute_preserves_windows_path_in_error():
+    with pytest.raises(CliError, match=r"^No such module: D:/non_existing_script\.py$"):
+        try_import_module_attribute("D:/non_existing_script.py")
+
+    with pytest.raises(CliError, match=r"^No such module: D:\\non_existing_script\.py$"):
+        try_import_module_attribute(r"D:\non_existing_script.py")


### PR DESCRIPTION
## Summary
- preserve full Windows drive paths before parsing module:attribute syntax
- add regression coverage for forward-slash and backslash Windows paths

Fixes #1861.

## Validation
- uv run pytest tests/test_cli/test_cli_util.py -q
- uv run pytest tests/test_cli -q
- uv run ruff format --check src/pyinfra_cli/util.py tests/test_cli/test_cli_util.py
- uv run ruff check src/pyinfra_cli/util.py tests/test_cli/test_cli_util.py
- uv run mypy src/pyinfra_cli/util.py
- git diff --check HEAD~1..HEAD

## Risk
Low: the change only bypasses module/attribute parsing for explicit Windows drive paths such as `D:/...` and `D:\...`; existing dotted and `module:function` imports keep the previous flow.