### PR TITLE
fix(cli): don't validate exec arguments as local paths

### DIFF
--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -4,7 +4,7 @@ import warnings
 from fnmatch import fnmatch
 from getpass import getpass
 from collections.abc import Iterable
-from os import chdir as os_chdir, environ, getcwd, path
+from os import R_OK, access, chdir as os_chdir, environ, getcwd, path
 
 import click
 
@@ -59,7 +59,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument("inventory", nargs=1, type=click.Path(exists=False))
-@click.argument("operations", nargs=-1, required=True, type=click.Path(exists=False))
+@click.argument("operations", nargs=-1, required=True, type=str)
 @click.option(
     "verbosity",
     "-v",
@@ -573,6 +573,8 @@ def _validate_operations(operations, chdir):
 
         for filename in operations[0:]:
             if path.exists(filename):
+                if not access(filename, R_OK):
+                    raise CliError(f"Deploy file is not readable: {filename}")
                 filenames.append(filename)
                 continue
             if chdir and filename.startswith(chdir):

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -1,4 +1,6 @@
 import json
+import os
+import tempfile
 from os import path
 from unittest import TestCase
 
@@ -151,6 +153,29 @@ class TestExecCli(PatchSSHTestCase):
             "echo hi",
         )
         assert result.exit_code == 0, result.stderr
+
+    def test_exec_command_with_unreadable_local_path(self):
+        # Regression test for https://github.com/pyinfra-dev/pyinfra/issues/1883
+        # exec arguments are remote shell commands and must not be validated as
+        # local paths by Click.
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            secret_path = f.name
+
+        try:
+            os.chmod(secret_path, 0o000)
+            result = run_cli(
+                path.join("tests", "test_cli", "deploy", "inventories", "inventory.py"),
+                "exec",
+                "--",
+                "ls",
+                secret_path,
+            )
+            assert result.exit_code == 0, result.stderr
+            assert "is not readable" not in result.output
+            assert "Invalid value for 'OPERATIONS" not in result.output
+        finally:
+            os.chmod(secret_path, 0o644)
+            os.unlink(secret_path)
 
 
 class TestJsonOutput(PatchSSHTestCase):


### PR DESCRIPTION
Fixes pyinfra-dev/pyinfra#1883.

## Problem

The `operations` CLI argument used `click.Path(exists=False)`, which validates readability for any argument that exists as a local file. This caused `pyinfra exec` to reject remote paths that happen to exist locally as unreadable files, before pyinfra even reached host connection.

## Change

- Change the `operations` argument type to plain `str`, removing Click's eager path validation.
- Add an explicit readability check in `_validate_operations()` only for deploy files (`.py`), preserving the useful error message for that case.
- Add a regression test that runs `exec` with an unreadable local path and verifies it is not rejected by Click.

## Verification

- `uv run pytest tests/test_cli/` — 65 passed
- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run mypy src/pyinfra_cli/cli.py` — clean