### PR TITLE
fix(operations.brew): use enum value strings in brew.trust fixtures

### DIFF
--- a/tests/operations/brew.trust/trust_already_trusted.json
+++ b/tests/operations/brew.trust/trust_already_trusted.json
@@ -1,5 +1,5 @@
 {
-    "args": [["foo", "bar", "baz"], "enum:BrewItemKind:casks", true],
+    "args": [["foo", "bar", "baz"], "casks", true],
     "facts": {
         "brew.BrewTrusted": {
             "casks": ["foo", "bar", "baz"],

--- a/tests/operations/brew.trust/trust_item_names_trusted_different_kind.json
+++ b/tests/operations/brew.trust/trust_item_names_trusted_different_kind.json
@@ -1,5 +1,5 @@
 {
-    "args": [["foo", "bar", "baz"], "enum:BrewItemKind:casks", true],
+    "args": [["foo", "bar", "baz"], "casks", true],
     "facts": {
         "brew.BrewTrusted": {
             "casks": [],

--- a/tests/operations/brew.trust/trust_needs_trust.json
+++ b/tests/operations/brew.trust/trust_needs_trust.json
@@ -1,5 +1,5 @@
 {
-    "args": [["foo", "bar", "baz"], "enum:BrewItemKind:commands", true],
+    "args": [["foo", "bar", "baz"], "commands", true],
     "facts": {"brew.BrewTrusted": {"casks": [], "commands": ["bar"], "formulae": [], "taps": []}},
     "commands": ["brew trust --command baz", "brew trust --command foo"],
     "noop_description": "bar commands already trusted"

--- a/tests/operations/brew.trust/untrust_already_untrusted.json
+++ b/tests/operations/brew.trust/untrust_already_untrusted.json
@@ -1,5 +1,5 @@
 {
-    "args": [["foo", "bar", "baz"], "enum:BrewItemKind:formulae", false],
+    "args": [["foo", "bar", "baz"], "formulae", false],
     "facts": {"brew.BrewTrusted": {"casks": [], "commands": [], "formulae": [], "taps": []}},
     "commands": [],
     "noop_description": "bar, baz, foo formulae already untrusted"

--- a/tests/operations/brew.trust/untrust_currently_trusted.json
+++ b/tests/operations/brew.trust/untrust_currently_trusted.json
@@ -1,5 +1,5 @@
 {
-    "args": [["foo", "bar", "baz"], "enum:BrewItemKind:taps", false],
+    "args": [["foo", "bar", "baz"], "taps", false],
     "facts": {
         "brew.BrewTrusted": {"casks": [], "commands": [], "formulae": [], "taps": ["foo", "baz"]}
     },

--- a/tests/operations/brew.trust/zero_length_item_name.json
+++ b/tests/operations/brew.trust/zero_length_item_name.json
@@ -1,5 +1,5 @@
 {
-    "args": ["", "enum:BrewItemKind:taps", true],
+    "args": ["", "taps", true],
     "facts": {"brew.BrewTrusted": {"casks": [], "commands": [], "formulae": [], "taps": []}},
     "commands": [],
     "exception": {

--- a/tests/operations/brew.trust/zero_length_name_in_list_of_names.json
+++ b/tests/operations/brew.trust/zero_length_name_in_list_of_names.json
@@ -1,5 +1,5 @@
 {
-    "args": [["a", "", "c"], "enum:BrewItemKind:taps", true],
+    "args": [["a", "", "c"], "taps", true],
     "facts": {"brew.BrewTrusted": {"casks": [], "commands": [], "formulae": [], "taps": []}},
     "commands": [],
     "exception": {


### PR DESCRIPTION
Fixes the failing unit-test job shown in https://github.com/pyinfra-dev/pyinfra/actions/runs/29364159319/job/87191537358.

The `brew.trust` operation tests passed `enum:BrewItemKind:<member>` strings for the `kind` argument. `pyinfra_testing` coerces operation arguments to enum members by their value, not by a typed `enum:...` string, so `kind` arrived as a plain `str` and the operation failed with:

```
AttributeError: 'str' object has no attribute 'value'
```

Update the fixtures to use the enum value strings (`casks`, `commands`, `formulae`, `taps`) directly, consistent with how `selinux` operation fixtures pass enum values.
