### PR TITLE
feat(connectors): add @fake no-op execution connector

### DIFF
--- a/docs/examples/dynamic_inventories_data.md
+++ b/docs/examples/dynamic_inventories_data.md
@@ -46,3 +46,56 @@ master_db_server = inventory.db_servers[0].name
 
 db_user = 'username'
 ```
+
+## Test Inventories with Fake Data
+
+For tests, demos and screenshots you often want a whole inventory of hosts
+without any real target to connect to. The built-in [`@fake` connector](../connectors/fake.md)
+simulates command execution locally without running anything, and pairs nicely
+with a [function-based inventory](../inventory-data.md#function-based-inventories-alpha)
+to generate any number of fake hosts and data in plain Python:
+
+```py
+# inventory.py
+
+def make_test(web_count=2, db_count=1):
+    web_hosts = [f'@fake/web-{i}' for i in range(1, web_count + 1)]
+    db_hosts = [f'@fake/db-{i}' for i in range(1, db_count + 1)]
+
+    # Any host can script specific command results (including failures) via
+    # `fake_responses`; anything unmatched just succeeds with no output.
+    web_hosts[0] = (
+        '@fake/web-1',
+        {
+            'fake_responses': {
+                'git --version': 'git version 2.40.0',
+                'pip install': {
+                    'success': False,
+                    'stderr': 'error: externally-managed-environment',
+                },
+            },
+        },
+    )
+
+    return {
+        'web': (web_hosts, {'role': 'web', 'port': 80}),
+        'db': (db_hosts, {'role': 'db', 'port': 5432}),
+    }
+```
+
+Point pyinfra at the function on the command line as `module.attribute`:
+
+```sh
+# Inspect the generated hosts and data
+pyinfra inventory:make_test debug-inventory
+
+# Run any command or operation against the fake hosts
+pyinfra inventory:make_test exec -- echo "hello world"
+
+# `@fake/web-1` reports the scripted failure, the rest succeed
+pyinfra inventory:make_test server.shell "pip install requests"
+```
+
+See the [`@fake` connector](../connectors/fake.md) documentation for the full
+`fake_responses` format (substring and regular-expression matchers), simulated
+command timing and other available data.

--- a/docs/inventory-data.md
+++ b/docs/inventory-data.md
@@ -95,6 +95,8 @@ def make_prod():
 
     Provide per-group data via the `(hosts, data)` tuple in the function's return value, or compose the data inside the function itself (e.g. by reading files, calling APIs, or importing Python modules). The function-based inventory loader is also still in alpha and will log a warning at startup.
 
+See [Dynamic Inventories & Data](examples/dynamic_inventories_data.md) for a worked example, including building a fake-data test inventory against the `@fake` connector.
+
 ## Project Layout
 
 There is no enforced project structure — pyinfra works with anything from a single `deploy.py` file to a multi-directory tree. The CLI only auto-loads two things by convention:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ local = "pyinfra.connectors.local:LocalConnector"
 ssh = "pyinfra.connectors.ssh:SSHConnector"
 dockerssh = "pyinfra.connectors.dockerssh:DockerSSHConnector"
 podmanssh = "pyinfra.connectors.dockerssh:PodmanSSHConnector"
+# Testing / development connector (no-op simulation)
+fake = "pyinfra.connectors.fake:FakeConnector"
 # Inventory only connectors
 terraform = "pyinfra.connectors.terraform:TerraformInventoryConnector"
 vagrant = "pyinfra.connectors.vagrant:VagrantInventoryConnector"

--- a/src/pyinfra/connectors/fake.py
+++ b/src/pyinfra/connectors/fake.py
@@ -1,0 +1,271 @@
+"""
+A fake execution connector that simulates command execution without touching a
+real target. Both fact-gathering and operation execution funnel through
+``run_shell_command``, so a single interception point drives both.
+
+Responses are configurable via inventory data (the ``fake_responses`` key), which
+maps a command matcher to a canned result. Anything not matched succeeds with
+empty output by default.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import re
+from typing import TYPE_CHECKING, Any
+
+import gevent
+from typing_extensions import Unpack, override
+
+from pyinfra import logger
+from pyinfra.api.output import echo
+from pyinfra.connectors.base import BaseConnector, ConnectorData, DataMeta
+from pyinfra.connectors.util import CommandOutput, OutputLine
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from io import IOBase
+
+    from pyinfra.api.arguments import ConnectorArguments
+    from pyinfra.api.command import StringCommand
+
+# Default simulated command duration (seconds), so progress bars behave like a
+# real deploy rather than completing instantly. Override via env vars or per-host
+# ``fake_delay`` / ``fake_delay_jitter`` inventory data.
+DEFAULT_DELAY = float(os.environ.get("PYINFRA_FAKE_DELAY", "0.5"))
+DEFAULT_DELAY_JITTER = float(os.environ.get("PYINFRA_FAKE_DELAY_JITTER", "0.4"))
+
+
+class FakeConnectorData(ConnectorData, total=False):
+    fake_responses: dict[str | re.Pattern, Any]
+    fake_delay: float
+    fake_delay_jitter: float
+
+
+class FakeConnector(BaseConnector):
+    """
+    The ``@fake`` connector simulates execution locally without running anything,
+    which is handy for demos, screenshots, documentation examples and tests.
+
+    Every command "succeeds" (exit code 0) with empty output by default. Specific
+    responses can be scripted via the host ``fake_responses`` data, a mapping of a
+    command matcher to a canned response.
+
+    The matcher (mapping key) is either:
+
+    + a ``str`` — matched as a **substring** of the command, or
+    + a compiled ``re.Pattern`` (``re.compile(...)``) — matched with
+      ``pattern.search(command)``, so regular expressions are supported.
+
+    The response (mapping value) is either:
+
+    + a ``str`` / ``list[str]`` of stdout lines, or
+    + a ``dict`` with optional ``stdout`` (``str``/``list``), ``stderr``
+      (``str``/``list``) and ``success`` (``bool``) keys.
+
+    Matchers are tried in insertion order; the first match wins.
+
+    Each simulated command/transfer also takes a short, slightly randomised
+    amount of time (so progress bars behave like a real deploy rather than
+    finishing instantly). Tune this with the ``fake_delay`` /
+    ``fake_delay_jitter`` host data, or the ``PYINFRA_FAKE_DELAY`` /
+    ``PYINFRA_FAKE_DELAY_JITTER`` environment variables. Set the delay to
+    ``0`` for instant execution (e.g. in tests).
+    """
+
+    __examples_doc__ = """
+    Run any command or operation against one or more fake hosts, with no real
+    target:
+
+    .. code:: shell
+
+        # A single fake host
+        pyinfra @fake exec -- echo "hello world"
+
+        # Multiple named fake hosts (comma separated)
+        pyinfra @fake/web-1,@fake/web-2 server.shell "echo hi"
+
+    Script what specific commands return with the ``fake_responses`` host data in
+    an inventory file (``inventory.py``). Each key is a matcher, each value the
+    canned response:
+
+    .. code:: python
+
+        import re
+
+        hosts = [
+            (
+                "@fake/web-1",
+                {
+                    "fake_responses": {
+                        # substring match
+                        "command -v git": {"success": False},
+                        "git --version": "git version 2.40.0",
+                        # regexp match (re.Pattern keys use pattern.search())
+                        re.compile(r"^apt-get .*install"): {
+                            "success": False,
+                            "stderr": "E: locked",
+                        },
+                    },
+                    # instant execution for this host
+                    "fake_delay": 0,
+                },
+            ),
+        ]
+
+    A response value is either a ``str`` / ``list[str]`` of stdout lines, or a
+    ``dict`` with optional ``stdout``, ``stderr`` and ``success`` keys. Matchers
+    are tried in insertion order; the first match wins, and unmatched commands
+    succeed with no output.
+    """
+
+    handles_execution = True
+
+    data_cls = FakeConnectorData
+    data_meta = {
+        "fake_responses": DataMeta(
+            "Mapping of command matcher (substring str or re.Pattern) to a canned response.",
+            default={},
+        ),
+        "fake_delay": DataMeta(
+            "Base duration (seconds) to simulate for each command/transfer.",
+            default=DEFAULT_DELAY,
+        ),
+        "fake_delay_jitter": DataMeta(
+            "Extra random duration (seconds, 0..jitter) added to each delay.",
+            default=DEFAULT_DELAY_JITTER,
+        ),
+    }
+
+    #: Commands executed against this connector instance, recorded for tests/debug.
+    executed_commands: list[str]
+
+    def __init__(self, state, host) -> None:
+        super().__init__(state, host)
+        self.executed_commands = []
+
+    @override
+    @staticmethod
+    def make_names_data(name: str | None = None) -> Iterator[tuple[str, dict, list[str]]]:
+        if not name:
+            yield "@fake", {}, ["@fake"]
+            return
+
+        for sub_name in name.split(","):
+            sub_name = sub_name.strip()
+            if not sub_name:
+                continue
+            yield f"@fake/{sub_name}", {}, ["@fake"]
+
+    def _lookup_response(self, command_str: str) -> tuple[bool, CommandOutput]:
+        fake_responses = self.data.get("fake_responses") or {}
+
+        for matcher, response in fake_responses.items():
+            if isinstance(matcher, re.Pattern):
+                if not matcher.search(command_str):
+                    continue
+            elif matcher not in command_str:
+                continue
+
+            success = True
+            stdout: list[str] = []
+            stderr: list[str] = []
+
+            if isinstance(response, dict):
+                success = bool(response.get("success", True))
+                stdout = _as_lines(response.get("stdout"))
+                stderr = _as_lines(response.get("stderr"))
+            else:
+                stdout = _as_lines(response)
+
+            lines = [OutputLine("stdout", line) for line in stdout]
+            lines += [OutputLine("stderr", line) for line in stderr]
+            return success, CommandOutput(lines)
+
+        # Default: succeed with no output.
+        return True, CommandOutput([])
+
+    def _sleep(self) -> None:
+        """Simulate a realistic, non-instant task duration.
+
+        Uses ``gevent.sleep`` so other host greenlets and the progress bar
+        continue to run cooperatively while this "command" is in flight.
+        """
+        delay = self.data.get("fake_delay")
+        if delay is None:
+            delay = DEFAULT_DELAY
+        jitter = self.data.get("fake_delay_jitter")
+        if jitter is None:
+            jitter = DEFAULT_DELAY_JITTER
+
+        duration = float(delay) + random.uniform(0, max(0.0, float(jitter)))
+        if duration > 0:
+            gevent.sleep(duration)
+
+    @override
+    def run_shell_command(
+        self,
+        command: str | StringCommand,
+        print_output: bool = False,
+        print_input: bool = False,
+        **arguments: Unpack[ConnectorArguments],
+    ) -> tuple[bool, CommandOutput]:
+        if isinstance(command, str):
+            command_str = command
+        else:
+            command_str = command.get_masked_value()
+        self.executed_commands.append(command_str)
+
+        logger.debug("[fake] simulating command on %s: %s", self.host.name, command_str)
+
+        if print_input:
+            echo(f"{self.host.print_prefix}>>> {command_str}", err=True)
+
+        self._sleep()
+
+        status, output = self._lookup_response(command_str)
+
+        if print_output:
+            for line in output.output_lines:
+                echo(f"{self.host.print_prefix}{line}", err=True)
+
+        return status, output
+
+    @override
+    def put_file(
+        self,
+        filename_or_io: str | IOBase,
+        remote_filename: str,
+        remote_temp_filename: str | None = None,
+        print_output: bool = False,
+        print_input: bool = False,
+        **arguments: Unpack[ConnectorArguments],
+    ) -> bool:
+        logger.debug("[fake] simulating put_file on %s: %s", self.host.name, remote_filename)
+        self._sleep()
+        return True
+
+    @override
+    def get_file(
+        self,
+        remote_filename: str,
+        filename_or_io: str | IOBase,
+        remote_temp_filename: str | None = None,
+        print_output: bool = False,
+        print_input: bool = False,
+        **arguments: Unpack[ConnectorArguments],
+    ) -> bool:
+        logger.debug("[fake] simulating get_file on %s: %s", self.host.name, remote_filename)
+        self._sleep()
+        return True
+
+
+def _as_lines(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return value.splitlines()
+    if isinstance(value, (list, tuple)):
+        return [str(line) for line in value]
+    return [str(value)]

--- a/tests/test_connectors/test_fake.py
+++ b/tests/test_connectors/test_fake.py
@@ -1,0 +1,190 @@
+import re
+from unittest import TestCase
+from unittest.mock import patch
+
+from pyinfra.api import Config, HiddenValue, State, StringCommand
+from pyinfra.api.connect import connect_all
+from pyinfra.connectors.fake import FakeConnector
+
+from ..util import make_inventory
+
+# Instant execution everywhere so tests never call gevent.sleep.
+NO_DELAY = {"fake_delay": 0, "fake_delay_jitter": 0}
+
+
+def make_fake_inventory(hosts=("@fake",), **data):
+    host_data = {**NO_DELAY, **data}
+    return make_inventory(hosts=tuple((host, host_data) for host in hosts))
+
+
+class TestFakeConnectorNamesData(TestCase):
+    def test_make_names_data_no_name(self):
+        assert list(FakeConnector.make_names_data()) == [("@fake", {}, ["@fake"])]
+
+    def test_make_names_data_single_name(self):
+        assert list(FakeConnector.make_names_data("web-1")) == [
+            ("@fake/web-1", {}, ["@fake"]),
+        ]
+
+    def test_make_names_data_comma_separated(self):
+        assert list(FakeConnector.make_names_data("web-1, web-2 ,web-3")) == [
+            ("@fake/web-1", {}, ["@fake"]),
+            ("@fake/web-2", {}, ["@fake"]),
+            ("@fake/web-3", {}, ["@fake"]),
+        ]
+
+    def test_make_names_data_ignores_empty_segments(self):
+        assert list(FakeConnector.make_names_data("web-1,,")) == [
+            ("@fake/web-1", {}, ["@fake"]),
+        ]
+
+
+class TestFakeConnector(TestCase):
+    def test_connect_all(self):
+        inventory = make_fake_inventory(hosts=("@fake",))
+        state = State(inventory, Config())
+        connect_all(state)
+        assert len(state.active_hosts) == 1
+
+    def test_connect_multiple_named_hosts(self):
+        inventory = make_inventory(
+            hosts=(("@fake/web-1", NO_DELAY), ("@fake/web-2", NO_DELAY)),
+        )
+        state = State(inventory, Config())
+        connect_all(state)
+        assert len(state.active_hosts) == 2
+
+    def test_default_command_succeeds_with_empty_output(self):
+        inventory = make_fake_inventory()
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        status, output = host.run_shell_command("echo hi")
+
+        assert status is True
+        assert output.output_lines == []
+
+    def test_executed_commands_recorded(self):
+        inventory = make_fake_inventory()
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        host.run_shell_command("echo one")
+        host.run_shell_command("echo two")
+
+        assert host.connector.executed_commands == ["echo one", "echo two"]
+
+    def test_response_substring_match(self):
+        inventory = make_fake_inventory(
+            fake_responses={"git --version": "git version 2.40.0"},
+        )
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        status, output = host.run_shell_command("git --version")
+
+        assert status is True
+        assert output.stdout_lines == ["git version 2.40.0"]
+
+    def test_response_regexp_match(self):
+        inventory = make_fake_inventory(
+            fake_responses={
+                re.compile(r"^apt-get .*install"): {
+                    "success": False,
+                    "stderr": "E: locked",
+                },
+            },
+        )
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        status, output = host.run_shell_command("apt-get -y install nginx")
+
+        assert status is False
+        assert output.stderr_lines == ["E: locked"]
+
+    def test_response_dict_stdout_stderr_success(self):
+        inventory = make_fake_inventory(
+            fake_responses={
+                "check": {
+                    "stdout": ["line 1", "line 2"],
+                    "stderr": "a warning",
+                    "success": False,
+                },
+            },
+        )
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        status, output = host.run_shell_command("run check now")
+
+        assert status is False
+        assert output.stdout_lines == ["line 1", "line 2"]
+        assert output.stderr_lines == ["a warning"]
+
+    def test_response_first_match_wins(self):
+        inventory = make_fake_inventory(
+            fake_responses={
+                "git": "first",
+                "git --version": "second",
+            },
+        )
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        _, output = host.run_shell_command("git --version")
+
+        assert output.stdout_lines == ["first"]
+
+    def test_unmatched_command_succeeds_empty(self):
+        inventory = make_fake_inventory(
+            fake_responses={"never-matched": "nope"},
+        )
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        status, output = host.run_shell_command("something else")
+
+        assert status is True
+        assert output.output_lines == []
+
+    def test_put_file(self):
+        inventory = make_fake_inventory()
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        assert host.put_file("local", "remote") is True
+
+    def test_get_file(self):
+        inventory = make_fake_inventory()
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        assert host.get_file("remote", "local") is True
+
+    @patch("pyinfra.api.output._echo")
+    def test_run_shell_command_masked(self, fake_echo):
+        inventory = make_fake_inventory()
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        command = StringCommand("echo", HiddenValue("top-secret-stuff"))
+        status, _ = host.run_shell_command(command, print_input=True)
+
+        assert status is True
+        # The masked value is echoed and recorded, never the secret.
+        fake_echo.assert_called_with(
+            f"{host.print_prefix}>>> echo *MASKED*",
+            err=True,
+        )
+        assert host.connector.executed_commands == ["echo *MASKED*"]
+
+    def test_delay_is_invoked(self):
+        inventory = make_inventory(hosts=(("@fake", {"fake_delay": 2, "fake_delay_jitter": 0}),))
+        State(inventory, Config())
+        host = inventory.get_host("@fake")
+
+        with patch("pyinfra.connectors.fake.gevent.sleep") as fake_sleep:
+            host.run_shell_command("echo hi")
+
+        fake_sleep.assert_called_once_with(2.0)


### PR DESCRIPTION
Adds a built-in `@fake` execution connector that simulates command execution locally without touching a real target — useful for tests, demos, screenshots and documentation examples.

Every command succeeds with empty output by default. Per-host `fake_responses` data lets you script specific results: a matcher (a substring or a compiled `re.Pattern`) maps to a canned response (stdout/stderr lines and a success flag), with matchers tried in insertion order. Each simulated command also takes a short, slightly randomised duration (via `gevent.sleep`, cooperative with other host greenlets) so progress output behaves like a real deploy; timing is tunable via `fake_delay` / `fake_delay_jitter` host data or the `PYINFRA_FAKE_DELAY` / `PYINFRA_FAKE_DELAY_JITTER` environment variables (set to `0` for instant runs).

The connector is registered like the other built-ins through the `pyinfra.connectors` entry point, so no special install or import is needed (`pyinfra @fake ...`). Its documentation page is auto-generated from the class docstring, and a worked "test inventories with fake data" example is added under `docs/examples/`, linked from the function-based inventories docs.

Includes unit tests covering host naming, response matching (substring/regex, dict form, insertion order, unmatched default) and file transfers.

See https://github.com/pyinfra-dev/pyinfra/discussions/1885 for context