### PR TITLE
chore: fix mypy warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ combine-as-imports = true
 [tool.mypy]
 check_untyped_defs = true
 ignore_missing_imports = true
-enable_incomplete_feature = "Unpack"
 enable_error_code = "explicit-override"
 files = "src/pyinfra,src/pyinfra_cli"
 


### PR DESCRIPTION
mypy produced the following warning: "Warning: Unpack is already enabled by default"

Context: The "Unpack" feature has been enabled quite a while ago: https://github.com/python/mypy/pull/16354
