### PR TITLE
chore: deduplicate shellcheck lint command

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -21,6 +21,4 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck
-        run: |
-          git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' -- ':!*.py' \
-            | xargs shellcheck
+        run: scripts/dev-shellcheck.sh

--- a/scripts/dev-lint.sh
+++ b/scripts/dev-lint.sh
@@ -13,11 +13,6 @@ echo "Execute arguments type check..."
 uv run python scripts/lint_arguments_sync.py
 
 echo "Execute shellcheck..."
-if ! command -v shellcheck >/dev/null 2>&1; then
-    echo "shellcheck is not installed, see docs/contributing.md for instructions." >&2
-    exit 1
-fi
-git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' -- ':!*.py' \
-    | xargs shellcheck
+scripts/dev-shellcheck.sh
 
 echo "Linting complete!"

--- a/scripts/dev-shellcheck.sh
+++ b/scripts/dev-shellcheck.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "shellcheck is not installed, see docs/contributing.md for instructions." >&2
+    exit 1
+fi
+
+git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' -- ':!*.py' \
+    | xargs shellcheck


### PR DESCRIPTION
## Summary

- add `scripts/dev-shellcheck.sh` as the single shellcheck entrypoint
- have `scripts/dev-lint.sh` and the Shellcheck GitHub Actions workflow call that script

## Why

The shellcheck command and file-selection regex were duplicated between the local developer lint script and CI. Keeping the logic in one executable script keeps local and CI shell linting behavior aligned while preserving the existing fail-fast handling when shellcheck is missing.

Fixes #1877.

## Validation

- `scripts/dev-shellcheck.sh`
- `shellcheck scripts/dev-shellcheck.sh scripts/dev-lint.sh`
- `git diff --check`
- `scripts/dev-lint.sh`
