### PR TITLE
fix(cli): parse literal list arguments

### DIFF
--- a/src/pyinfra_cli/util.py
+++ b/src/pyinfra_cli/util.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import json
 from datetime import datetime
 from importlib import import_module
@@ -150,6 +151,14 @@ def parse_cli_arg(arg):
         return json.loads(arg)
     except ValueError:
         pass
+
+    try:
+        parsed_arg = ast.literal_eval(arg)
+    except (SyntaxError, ValueError):
+        pass
+    else:
+        if isinstance(parsed_arg, (dict, list, tuple)):
+            return parsed_arg
 
     return arg
 

--- a/tests/test_cli/test_cli_util.py
+++ b/tests/test_cli/test_cli_util.py
@@ -54,6 +54,14 @@ class TestCliUtil(TestCase):
             (["one", "two"], {"hello": "world"}),
         )
 
+    def test_setup_op_and_python_literal_list_kwarg(self):
+        commands = ("server.user", "one", "groups=['wheel', 'docker']")
+
+        assert get_func_and_args(commands) == (
+            server.user,
+            (["one"], {"groups": ["wheel", "docker"]}),
+        )
+
 
 @pytest.fixture(scope="function")
 def user_sys_path():


### PR DESCRIPTION
## Summary

Fixes pyinfra-dev/pyinfra#1869.

CLI operation kwargs already accepted JSON containers, but Python-style literal containers such as `groups=['wheel', 'docker']` were left as raw strings. For list-valued operation kwargs like `server.user(..., groups=...)`, that meant the operation received a string and iterated it as characters.

This adds a safe `ast.literal_eval` fallback after the existing bool/int/JSON parsing and only returns container literals (`dict`, `list`, `tuple`). Scalar strings such as `'hello'` remain unchanged.

## Validation

- `uv run pytest tests/test_cli/test_cli_util.py -q`
- `uv run pytest tests/test_cli/test_cli.py -q`
- `uv run ruff format --check src/pyinfra_cli/util.py tests/test_cli/test_cli_util.py`
- `uv run ruff check src/pyinfra_cli/util.py tests/test_cli/test_cli_util.py`
- `uv run mypy src/pyinfra_cli/util.py`
- `git diff --check HEAD~1..HEAD`

## Risk

Low. The fallback is only reached after existing parsing fails, uses `ast.literal_eval` rather than evaluation, and only changes parsed container literals.

## AI assistance

OpenAI Codex was used to inspect the existing parsing path, implement the patch and regression tests, and run the validation commands above.