### PR TITLE
docs(facts.deb): clarify package resolution

### DIFF
--- a/src/pyinfra/facts/deb.py
+++ b/src/pyinfra/facts/deb.py
@@ -60,6 +60,19 @@ class DebPackages(FactBase):
 class DebPackage(FactBase):
     """
     Returns information on a .deb archive or installed package.
+
+    Package resolution depends on the remote current working directory and is
+    therefore not idempotent:
+
+    * Names that do not match the shell pattern ``*.deb`` query the installed
+      package database.
+    * Names that match ``*.deb`` inspect the archive only when that file exists
+      in the current working directory. Otherwise they query the installed
+      package database.
+
+    Consequently, archive names such as ``package.deb.old`` and
+    ``package.deb~`` cannot be queried as files. Older pyinfra versions tried
+    to inspect any existing path as an archive instead.
     """
 
     _regexes = {

--- a/tests/test_facts_documentation.py
+++ b/tests/test_facts_documentation.py
@@ -1,0 +1,9 @@
+from pyinfra.facts.deb import DebPackage
+
+
+def test_deb_package_documents_package_resolution():
+    docstring = " ".join((DebPackage.__doc__ or "").split())
+
+    assert "``*.deb``" in docstring
+    assert "current working directory" in docstring
+    assert "installed package database" in docstring


### PR DESCRIPTION
Closes #1860

Documents how `DebPackage` chooses between archive inspection and the installed package database, including the current-working-directory dependency and unsupported archive suffixes. Adds a focused documentation regression test.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [ ] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
