### PR TITLE
fix(api): omit variadic kwargs from auto labels

### DIFF
--- a/src/pyinfra/api/operation.py
+++ b/src/pyinfra/api/operation.py
@@ -8,7 +8,7 @@ to the deploy state. This is then run later by pyinfra's ``__main__`` or the
 from __future__ import annotations
 
 from functools import wraps
-from inspect import signature
+from inspect import Parameter, signature
 from io import StringIO
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, cast
@@ -300,7 +300,7 @@ def _wrap_operation(func: Callable[P, Generator], _set_in_op: bool = True) -> Py
 
         # Attach normal args, if we're auto-naming this operation
         if add_args:
-            op_meta = attach_args(op_meta, args, kwargs)
+            op_meta = attach_args(op_meta, func, args, kwargs)
 
         # Check if we're actually running the operation on this host
         # Run once and we've already added meta for this op? Stop here.
@@ -488,13 +488,21 @@ def _get_arg_value(arg):
     return arg
 
 
-def attach_args(op_meta, args, kwargs):
+def attach_args(op_meta, func, args, kwargs):
     for arg in args:
         if arg not in op_meta.args:
             op_meta.args.append(str(_get_arg_value(arg)))
 
     # Attach keyword args
+    named_parameters = {
+        key
+        for key, parameter in signature(func).parameters.items()
+        if parameter.kind is not Parameter.VAR_KEYWORD
+    }
     for key, value in kwargs.items():
+        if key not in named_parameters:
+            continue
+
         arg = "=".join((str(key), str(_get_arg_value(value))))
         if arg not in op_meta.args:
             op_meta.args.append(arg)

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from io import StringIO
 from os import path
 from unittest import TestCase
 from unittest.mock import mock_open, patch
@@ -115,6 +116,29 @@ class TestOperationsApi(PatchSSHTestCase):
         # And w/o errors
         assert state.results[somehost].error_ops == 0
         assert state.results[anotherhost].error_ops == 0
+
+        disconnect_all(state)
+
+    def test_template_op_auto_name_does_not_include_data_kwargs(self):
+        inventory = make_inventory()
+        state = State(inventory, Config())
+        state.current_stage = StateStage.Prepare
+        connect_all(state)
+
+        add_op(
+            state,
+            files.template,
+            StringIO("password={{ password }}"),
+            "/etc/config.toml",
+            password="!CLEARTEXTPASSWORD",
+        )
+
+        [op_hash] = state.get_op_order()
+        op_args = state.op_meta[op_hash].args
+
+        assert any(arg.startswith("StringIO(hash=") for arg in op_args)
+        assert "/etc/config.toml" in op_args
+        assert "password=!CLEARTEXTPASSWORD" not in op_args
 
         disconnect_all(state)
 


### PR DESCRIPTION
## Summary

Fixes #1896.

Automatic operation labels are generated from the call signature when `name=` is omitted. For operations such as `files.template`, arbitrary `**data` values can include template secrets and were being copied into the generated label metadata.

This changes auto-label argument capture to keep positional arguments and declared keyword parameters, while skipping extra variadic `**kwargs` values. The operation still receives the data and renders templates normally; only the generated label metadata changes.

## Validation

- `uv run pytest tests/test_api/test_api_operations.py -k template_op_auto_name_does_not_include_data_kwargs -q`
- `uv run pytest tests/test_api/test_api_operations.py -q`
- `uv run pytest tests/test_api -q`
- `uv run ruff format --check src/pyinfra/api/operation.py tests/test_api/test_api_operations.py`
- `uv run ruff check src/pyinfra/api/operation.py tests/test_api/test_api_operations.py`
- `uv run mypy src/pyinfra/api/operation.py`
- `git diff --check`

## Risk

Low. This only changes pyinfra-generated labels when an operation accepts arbitrary `**kwargs`; explicitly declared parameters and explicit `name=` labels are preserved.