### PR TITLE
fix(cli): avoid local path validation for exec args

### DIFF
--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -61,7 +61,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument("inventory", nargs=1, type=click.Path(exists=False))
-@click.argument("operations", nargs=-1, required=True, type=click.Path(exists=False))
+@click.argument("operations", nargs=-1, required=True)
 @click.option(
     "verbosity",
     "-v",

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -1,5 +1,7 @@
 import json
+import os
 from os import path
+import tempfile
 from unittest import TestCase
 
 from pyinfra.api import Host, Inventory
@@ -150,6 +152,23 @@ class TestExecCli(PatchSSHTestCase):
             "--",
             "echo hi",
         )
+        assert result.exit_code == 0, result.stderr
+
+    def test_exec_command_does_not_validate_local_path_arguments(self):
+        with tempfile.NamedTemporaryFile() as file:
+            os.chmod(file.name, 0o000)
+            try:
+                result = run_cli(
+                    path.join("tests", "test_cli", "deploy", "inventories", "inventory.py"),
+                    "exec",
+                    "--debug-operations",
+                    "--",
+                    "ls",
+                    file.name,
+                )
+            finally:
+                os.chmod(file.name, 0o600)
+
         assert result.exit_code == 0, result.stderr
 
 


### PR DESCRIPTION
## Summary

- stop Click from treating variadic operation arguments as local filesystem paths
- add a CLI regression test for `exec` with an unreadable local path argument

## Rationale

`pyinfra INVENTORY exec ...` sends the remaining arguments to the remote shell command. Those arguments may look like local paths, but local readability is irrelevant for `exec`. The existing `click.Path(exists=False)` type still rejected an argument when that path existed locally but was unreadable, before pyinfra could prepare the exec operation.

Deploy-file validation is still handled later in `_validate_operations`, so deploy files keep the existing explicit pyinfra checks.

Fixes pyinfra-dev/pyinfra#1883.

## Test plan

- `uv run pytest tests/test_cli/test_cli.py::TestExecCli::test_exec_command_does_not_validate_local_path_arguments -q`
- `uv run pytest tests/test_cli/test_cli.py::TestExecCli tests/test_cli/test_cli.py::TestOperationCli -q`
- `uv run ruff format --check src/pyinfra_cli/cli.py tests/test_cli/test_cli.py`
- `uv run ruff check src/pyinfra_cli/cli.py tests/test_cli/test_cli.py`
- `uv run mypy src/pyinfra_cli/cli.py`
- `git diff --check`