### PR TITLE
fix(operations.dnf): install pinned package versions

### DIFF
--- a/src/pyinfra/operations/util/packaging.py
+++ b/src/pyinfra/operations/util/packaging.py
@@ -119,11 +119,8 @@ def _has_package(
         return any(version in value for version in pkg_versions)
 
     packages_to_check: list[str | list[str]] = [package]
-    if expand_package_fact:
-        if isinstance(package, list):
-            packages_to_check = expand_package_fact(package[0]) or packages_to_check
-        else:
-            packages_to_check = expand_package_fact(package) or packages_to_check
+    if expand_package_fact and not isinstance(package, list):
+        packages_to_check = expand_package_fact(package) or packages_to_check
 
     package_name_to_versions = defaultdict(set)
     for pkg in packages_to_check:

--- a/tests/operations/dnf.packages/install_pinned_package_when_different_version_installed.json
+++ b/tests/operations/dnf.packages/install_pinned_package_when_different_version_installed.json
@@ -1,0 +1,29 @@
+{
+    "args": [
+        [
+            "kernel-devel=4.18.0-240.el8"
+        ]
+    ],
+    "facts": {
+        "rpm.RpmPackages": {
+            "kernel-devel": [
+                "4.18.0-553.150.1.el8_10"
+            ]
+        },
+        "rpm.RpmPackageProvides": {
+            "package=kernel-devel": [
+                [
+                    "kernel-devel",
+                    "4.18.0-240.el8"
+                ],
+                [
+                    "kernel-devel",
+                    "4.18.0-553.150.1.el8_10"
+                ]
+            ]
+        }
+    },
+    "commands": [
+        "dnf install -y kernel-devel=4.18.0-240.el8"
+    ]
+}


### PR DESCRIPTION
## Summary
- Fix `dnf.packages` so `name=version` requests check the exact installed package version instead of being satisfied by any provider version returned by repoquery.
- Add a dnf operation fixture covering `kernel-devel=<old-version>` when another `kernel-devel` version is already installed.

Fixes #1910.

## Validation
- `uv run pytest tests/test_operations.py -k "dnf.packages or yum.packages"`
- `uv run pytest tests/test_operations_utils.py -k "EnsurePackages"`
- `uv run pytest tests/test_operations.py`
- `uv run ruff check src/pyinfra/operations/util/packaging.py`
- `uv run ruff format --check src/pyinfra/operations/util/packaging.py`
- `git diff --check`

## Risk
Low: version-pinned package checks now skip provider expansion, while unpinned package alias/provider behavior keeps using the existing expansion path.