### PR TITLE
fix: add target, slice and device substates to systemd status check

### DIFF
--- a/src/pyinfra/facts/systemd.py
+++ b/src/pyinfra/facts/systemd.py
@@ -64,7 +64,7 @@ class SystemdStatus(FactBase[dict[str, bool]]):
     default = dict
 
     state_key = "SubState"
-    state_values = ["running", "waiting", "exited", "listening", "mounted"]
+    state_values = ["running", "waiting", "exited", "listening", "mounted", "active", "plugged"]
 
     @override
     def command(

--- a/tests/facts/systemd.SystemdStatus/services.json
+++ b/tests/facts/systemd.SystemdStatus/services.json
@@ -15,13 +15,25 @@
         "SubState=exited",
         "",
         "Id=mnt-foo.mount",
-        "SubState=mounted"
+        "SubState=mounted",
+        "",
+        "Id=multi-user.target",
+        "SubState=active",
+        "",
+        "Id=system.slice",
+        "SubState=active",
+        "",
+        "Id=dev-sda1.device",
+        "SubState=plugged"
     ],
     "fact":  {
         "lvm2-activation.service": false,
         "lvm2-lvmetad.service": true,
         "lvm2-lvmpolld.service": false,
         "ebtables.timer": true,
-        "mnt-foo.mount": true
+        "mnt-foo.mount": true,
+        "multi-user.target": true,
+        "system.slice": true,
+        "dev-sda1.device": true
     }
 }


### PR DESCRIPTION
This continues #1367 and will be superseded by #1558. But this change is small and maybe this can be merged quicker and made available before.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
