### PR TITLE
fix(operations.bsdinit): enable OpenBSD services with rcctl

### DIFF
--- a/src/pyinfra/facts/bsdinit.py
+++ b/src/pyinfra/facts/bsdinit.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing_extensions import override
 
+from pyinfra.api import FactBase
+
 from .sysvinit import InitdStatus
 
 
@@ -21,3 +23,23 @@ class RcdStatus(InitdStatus):
         """
 
     default = dict
+
+
+class RcdEnabled(FactBase):
+    """
+    Returns a dict of OpenBSD rc.d services enabled at boot.
+    """
+
+    default = dict
+
+    @override
+    def requires_command(self) -> str:
+        return "rcctl"
+
+    @override
+    def command(self) -> str:
+        return "rcctl ls on"
+
+    @override
+    def process(self, output: list[str]) -> dict[str, bool]:
+        return {line: True for line in output}

--- a/src/pyinfra/operations/bsdinit.py
+++ b/src/pyinfra/operations/bsdinit.py
@@ -5,12 +5,31 @@ Manage BSD init services (``/etc/rc.d``, ``/usr/local/etc/rc.d``).
 from __future__ import annotations
 
 from pyinfra import host
-from pyinfra.api import operation
-from pyinfra.facts.bsdinit import RcdStatus
+from pyinfra.api import QuoteString, StringCommand, operation
+from pyinfra.facts.bsdinit import RcdEnabled, RcdStatus
 from pyinfra.facts.server import Os
 
 from . import files
 from .util.service import handle_service_control
+
+
+def _handle_openbsd_enabled(service: str, enabled: bool):
+    enabled_services = host.get_fact(RcdEnabled)
+    is_enabled = enabled_services.get(service, False)
+
+    if enabled is True:
+        if not is_enabled:
+            yield StringCommand("rcctl enable", QuoteString(service))
+            enabled_services[service] = True
+        else:
+            host.noop(f"service {service} is enabled")
+
+    if enabled is False:
+        if is_enabled:
+            yield StringCommand("rcctl disable", QuoteString(service))
+            enabled_services[service] = False
+        else:
+            host.noop(f"service {service} is disabled")
 
 
 @operation()
@@ -33,21 +52,32 @@ def service(
     + enabled: whether this service should be enabled/disabled on boot
     """
 
+    os = host.get_fact(Os)
     status_argument = "status"
-    if host.get_fact(Os) == "OpenBSD":
+    command_formatter = "test -e /etc/rc.d/{0} && /etc/rc.d/{0} {1} || /usr/local/etc/rc.d/{0} {1}"
+    if os == "OpenBSD":
         status_argument = "check"
+        command_formatter = "rcctl {1} {0}"
+
+        if enabled is True:
+            yield from _handle_openbsd_enabled(service, enabled)
 
     yield from handle_service_control(
         host,
         service,
         host.get_fact(RcdStatus),
-        "test -e /etc/rc.d/{0} && /etc/rc.d/{0} {1} || /usr/local/etc/rc.d/{0} {1}",
+        command_formatter,
         running,
         restarted,
         reloaded,
         command,
         status_argument=status_argument,
     )
+
+    if os == "OpenBSD":
+        if enabled is False:
+            yield from _handle_openbsd_enabled(service, enabled)
+        return
 
     # BSD init is simple, just add/remove <service>_enabled="YES"
     if isinstance(enabled, bool):

--- a/tests/facts/bsdinit.RcdEnabled/services.yaml
+++ b/tests/facts/bsdinit.RcdEnabled/services.yaml
@@ -1,0 +1,8 @@
+command: rcctl ls on
+requires_command: rcctl
+output: |
+  cron
+  rad
+fact:
+  cron: true
+  rad: true

--- a/tests/operations/bsdinit.service/openbsd_disabled.yaml
+++ b/tests/operations/bsdinit.service/openbsd_disabled.yaml
@@ -1,0 +1,12 @@
+args:
+  - rad
+kwargs:
+  enabled: false
+facts:
+  server.Os: OpenBSD
+  bsdinit.RcdStatus:
+    rad: true
+  bsdinit.RcdEnabled:
+    rad: true
+commands:
+  - rcctl disable rad

--- a/tests/operations/bsdinit.service/openbsd_disabled_noop.yaml
+++ b/tests/operations/bsdinit.service/openbsd_disabled_noop.yaml
@@ -1,0 +1,12 @@
+args:
+  - rad
+kwargs:
+  enabled: false
+  running: false
+facts:
+  server.Os: OpenBSD
+  bsdinit.RcdStatus:
+    rad: false
+  bsdinit.RcdEnabled: {}
+commands: []
+noop_description: service rad is disabled

--- a/tests/operations/bsdinit.service/openbsd_enabled_noop.yaml
+++ b/tests/operations/bsdinit.service/openbsd_enabled_noop.yaml
@@ -1,0 +1,13 @@
+args:
+  - rad
+kwargs:
+  enabled: true
+facts:
+  server.Os: OpenBSD
+  bsdinit.RcdStatus:
+    rad: false
+  bsdinit.RcdEnabled:
+    rad: true
+commands:
+  - rcctl start rad
+noop_description: service rad is enabled

--- a/tests/operations/bsdinit.service/openbsd_enabled_start.yaml
+++ b/tests/operations/bsdinit.service/openbsd_enabled_start.yaml
@@ -1,0 +1,12 @@
+args:
+  - rad
+kwargs:
+  enabled: true
+facts:
+  server.Os: OpenBSD
+  bsdinit.RcdStatus:
+    rad: false
+  bsdinit.RcdEnabled: {}
+commands:
+  - rcctl enable rad
+  - rcctl start rad


### PR DESCRIPTION
## Summary

Fixes #1906 by making `bsdinit.service(enabled=...)` use OpenBSD's `rcctl` service interface when the target OS is OpenBSD.

## What changed

- Added an `RcdEnabled` fact backed by `rcctl ls on`.
- Uses `rcctl enable <service>` before start/restart/reload when `enabled=True` on OpenBSD.
- Uses `rcctl disable <service>` for `enabled=False` on OpenBSD.
- Uses `rcctl <command> <service>` for OpenBSD service control, avoiding the old `A && A cmd || B cmd` fallback that hid real `/etc/rc.d` failures behind `/usr/local/etc/rc.d` exit 127.
- Preserves the existing `rc.conf.local` `*_enable="YES"` behavior for non-OpenBSD BSD targets.

## Validation

- `uv run pytest tests/test_operations.py` -> 1058 passed, 1 existing noop-description warning
- `uv run pytest tests/test_facts.py -k "bsdinit"` -> 1 passed
- `uv run ruff format --check src/pyinfra/operations/bsdinit.py src/pyinfra/facts/bsdinit.py`
- `uv run ruff check src/pyinfra/operations/bsdinit.py src/pyinfra/facts/bsdinit.py`
- `uv run mypy src/pyinfra/operations/bsdinit.py src/pyinfra/facts/bsdinit.py`
- `git diff --check`

## Risk

The behavior change is scoped to OpenBSD targets. FreeBSD/other BSD service enablement still goes through the existing `/etc/rc.conf.local` line handling.
