### PR TITLE
docs: fix links to connector and fact guides

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -8,7 +8,7 @@ Connectors enable pyinfra to integrate with other tools out of the box. Connecto
 
 Each connector page is listed below and contains examples as well as a list of available data that can be used to configure the connector.
 
-**Want a new connector?** Check out [the writing connectors guide](../api/connectors.md).
+**Want a new connector?** Check out [the writing connectors guide](api/connectors.md).
 
 ### Popular connectors
 

--- a/docs/facts.md
+++ b/docs/facts.md
@@ -22,7 +22,7 @@ Multiple facts with arguments may be called like so:
 pyinfra @local fact files.File path=setup.py files.File path=anotherfile.txt
 ```
 
-You can leverage facts within [operations](../using-operations.md) like this:
+You can leverage facts within [operations](using-operations.md) like this:
 
 ```python
 from pyinfra import host
@@ -32,6 +32,6 @@ if host.get_fact(LinuxName) == 'Ubuntu':
     apt.packages(...)
 ```
 
-**Want a new fact?** Check out [the writing facts guide](../api/facts.md).
+**Want a new fact?** Check out [the writing facts guide](api/facts.md).
 
 --8<-- "facts-cards.html"


### PR DESCRIPTION
## Summary

- fix the connector overview link to the writing-connectors guide
- fix the facts overview links to operations and the writing-facts guide

Closes #1889

## Validation

- generated the documentation site successfully
- verified all seven local link targets in the modified pages

## AI disclosure

OpenAI Codex was used to help investigate the broken links, prepare the patch, and run validation. I manually reviewed and approved the final diff before committing it.