### PR TITLE
docs: add debugging guide

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -15,11 +15,11 @@ Where possible pyinfra follows [semantic versioning](https://semver.org/) rules.
 
 pyinfra works on anywhere that runs Python - Mac, Linux & Windows are all supported.
 
-### Editor Integration
+### Interactive Debuggers
 
-#### PyCharm
-
-To debug pyinfra within PyCharm, you need to [explicitly enable support for Gevent](https://blog.jetbrains.com/pycharm/2012/08/gevent-debug-support/).
+pyinfra executes work concurrently using gevent, so stepping through a deploy in an interactive
+debugger does not reliably represent the order of remote execution. See
+[Debugging Deploys](debugging.md) for supported ways to inspect deploy state and execution.
 
 
 ## Remote Systems

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,65 @@
+# Debugging Deploys
+
+pyinfra deploys are designed to be safe to run repeatedly. A useful debugging loop is to inspect
+the current host state, preview the deploy, add focused logging, and then run the deploy again.
+
+## Inspect the inputs and plan
+
+Start by checking the inventory and the facts used by the deploy:
+
+```sh
+# Show the resolved hosts, groups, and data
+pyinfra inventory.py debug-inventory
+
+# Collect a fact directly
+pyinfra inventory.py fact server.LinuxName
+```
+
+Then preview the operations without changing the hosts:
+
+```sh
+pyinfra inventory.py deploy.py --debug-operations
+pyinfra inventory.py deploy.py --dry
+```
+
+Increase verbosity to see more detail. `-v` includes collected facts and no-op information,
+`-vv` includes the commands sent to hosts, and `-vvv` includes command output in real time. Use
+`--debug` when you also need pyinfra's internal debug messages.
+
+## Log values from deploy code
+
+Use pyinfra's logger to inspect Python values while a deploy is being prepared:
+
+```python
+from pyinfra import host, logger
+from pyinfra.facts.server import LinuxDistribution
+
+distribution = host.get_fact(LinuxDistribution)
+logger.info("Distribution data: %r", distribution)
+```
+
+Logging keeps diagnostic output with pyinfra's normal output. Avoid logging secrets or other
+sensitive host data.
+
+Do not add an operation such as `server.shell` merely to print a Python value. Operations run on
+the target host and are deferred until the execution phase, so they do not behave like `print()`
+statements in deploy code.
+
+## Account for the execution model
+
+pyinfra first runs deploy code for each host to gather facts and prepare an ordered set of
+operations. It then executes those operations across the hosts. Consequently:
+
+- facts read during preparation describe the host before this deploy's operations run;
+- the output of an operation is not available immediately after calling it; and
+- execution may be concurrent across hosts, so stepping through a deploy in an interactive
+  debugger does not reliably represent the order of remote work.
+
+Use [facts](facts.md) to inspect current host state. If later Python code must consume an
+operation's output, use an execution-time callback as described in
+[Output & Callbacks](using-operations.md#output--callbacks). For conditions that depend on an
+earlier operation, use the `_if` callback described in
+[Change Detection](using-operations.md#change-detection).
+
+Keep the diagnostic change small, rerun the deploy, and remove or reduce temporary logging once
+the behavior is understood.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Welcome to the pyinfra v3 documentation. If you're new to pyinfra you should sta
 - [**Using Operations**](using-operations.md) — The guide to writing reusable, committable operations in Python files.
 - [**Inventory & Data**](inventory-data.md) — Use groups, host, and group data to control and configure operations for any environment.
 - [**Using the CLI**](cli.md) — The pyinfra CLI is extremely powerful for ad hoc command execution and management.
+- [**Debugging Deploys**](debugging.md) — Inspect inventory, facts and operations, and add focused diagnostic logging.
 - [**FAQ**](faq.md) — Quick answers to the most commonly asked questions for using pyinfra.
 
 ## Deploy Reference

--- a/zensical.toml
+++ b/zensical.toml
@@ -20,6 +20,7 @@ nav = [
         { "Using Operations" = "using-operations.md" },
         { "Inventory & Data" = "inventory-data.md" },
         { "Using the CLI" = "cli.md" },
+        { "Debugging Deploys" = "debugging.md" },
         { "FAQ" = "faq.md" },
     ] },
     { "Deploy Reference" = [


### PR DESCRIPTION
## Summary

- add a dedicated guide for inspecting inventory, facts, and planned operations
- document logging, verbosity, and pyinfra's two-phase execution model
- replace the outdated interactive-debugger guidance and add the page to navigation

Closes #1149

## Validation

- generated the documentation site successfully
- verified the new page's local links, navigation entries, and documented CLI options

## AI disclosure

OpenAI Codex was used to help research the current debugging interfaces, draft the documentation, and run validation. I manually reviewed and approved the final diff before committing it.