### PR TITLE
fix(connectors.ssh): prompt for encrypted ssh_config IdentityFile passphrase (#1917)

### DIFF
--- a/src/pyinfra/connectors/ssh_util.py
+++ b/src/pyinfra/connectors/ssh_util.py
@@ -133,8 +133,8 @@ def load_key_with_certificate(
       ``<key>-cert.pub`` is used if present, falling back to ``<key>.pub``.
     + cwd: optional working directory used to resolve relative key paths.
     + allow_prompt: when False, an encrypted key with no known passphrase raises
-      instead of prompting. Used by non-interactive callers like the ssh_config
-      identity path so they fall through rather than block (issue #1852).
+      instead of prompting. Only for callers that must never block on input;
+      prompting is already limited to CLI runs, so API mode always raises.
     """
 
     resolved_path: str | None = None

--- a/src/pyinfra/connectors/sshuserclient/client.py
+++ b/src/pyinfra/connectors/sshuserclient/client.py
@@ -104,9 +104,9 @@ def _attach_identity_with_certificate(cfg: dict, host_config: dict) -> None:
     falls back to the implicit ``<key>-cert.pub`` lookup so OpenSSH-style CA
     auth works without explicit pyinfra ``ssh_key`` configuration (issue #1569).
     Silent fall-through when no identity exists keeps the legacy paramiko
-    ``key_filename`` flow for missing or otherwise unloadable files. The load is
-    non-interactive (``allow_prompt=False``): an encrypted identity with no known
-    passphrase falls through instead of blocking on a prompt (issue #1852).
+    ``key_filename`` flow for missing or otherwise unloadable files. An encrypted
+    identity prompts for its passphrase under the CLI and raises in API mode,
+    both handled inside :func:`load_key_with_certificate` (issue #1917).
     """
 
     identity_files = host_config.get("identityfile") or []
@@ -126,7 +126,6 @@ def _attach_identity_with_certificate(cfg: dict, host_config: dict) -> None:
             cfg["pkey"] = load_key_with_certificate(
                 key_filename=identity_file,
                 certificate_filename=certificate_filename,
-                allow_prompt=False,
             )
         except (PyinfraError, SSHException, OSError) as e:
             logger.debug("Could not load identity %s with certificate: %s", identity_file, e)

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -554,12 +554,11 @@ def test_parse_config_explicit_pkey_wins_over_encrypted_identityfile(
     assert cfg["pkey"] is sentinel
 
 
-def test_parse_config_encrypted_identityfile_does_not_prompt(
+def test_parse_config_encrypted_identityfile_prompts_in_cli(
     ssh_encrypted_key, tmp_path, _clear_ssh_config_cache
 ):
-    # Regression for #1852: an encrypted ssh_config IdentityFile with no known
-    # passphrase must fall through to the legacy key_filename flow instead of
-    # blocking on an interactive passphrase prompt.
+    # Regression for #1917: under the CLI an encrypted ssh_config IdentityFile
+    # must prompt for its passphrase, the way it did before 3.10.0.
     config_path = tmp_path / "ssh_config"
     _write_ssh_config(
         config_path,
@@ -568,11 +567,35 @@ def test_parse_config_encrypted_identityfile_does_not_prompt(
     )
 
     client = SSHClient()
-    with patch("pyinfra.connectors.ssh_util.getpass", return_value="wrong") as fake_getpass:
+    with patch(
+        "pyinfra.connectors.ssh_util.getpass",
+        return_value=ssh_encrypted_key["passphrase"],
+    ) as fake_getpass:
         with patch("pyinfra.is_cli", True):
             _, cfg, *_ = client.parse_config("myhost", ssh_config_file=str(config_path))
 
-    fake_getpass.assert_not_called()
+    fake_getpass.assert_called_once()
+    assert isinstance(cfg["pkey"], PKey)
+    assert "key_filename" not in cfg
+
+
+def test_parse_config_encrypted_identityfile_wrong_passphrase_falls_through(
+    ssh_encrypted_key, tmp_path, _clear_ssh_config_cache
+):
+    # A wrong passphrase must not blow up parse_config: fall back to the legacy
+    # key_filename flow and let paramiko report the failure.
+    config_path = tmp_path / "ssh_config"
+    _write_ssh_config(
+        config_path,
+        host="myhost",
+        IdentityFile=str(ssh_encrypted_key["key"]),
+    )
+
+    client = SSHClient()
+    with patch("pyinfra.connectors.ssh_util.getpass", return_value="wrong"):
+        with patch("pyinfra.is_cli", True):
+            _, cfg, *_ = client.parse_config("myhost", ssh_config_file=str(config_path))
+
     assert "pkey" not in cfg
     assert cfg["key_filename"] == [str(ssh_encrypted_key["key"])]
 


### PR DESCRIPTION
Closes #1917

## Description

Since 3.10.0 pyinfra no longer asks for the passphrase of an encrypted private key that comes from an `IdentityFile` in ssh_config. 3.9.2 prompted for it, 3.10.0 just fails with "Authentication error () (Private key file is encrypted)".

The cause is #1855. That change did two things to fix #1852: it added a `"pkey" not in cfg` guard in `parse_config` so an explicit pyinfra `ssh_key` wins over the ssh_config `IdentityFile`, and it passed `allow_prompt=False` to `load_key_with_certificate` in `_attach_identity_with_certificate`. The guard on its own is what fixes #1852, because with an explicit `ssh_key` the config identity is never loaded and so can never prompt. The `allow_prompt=False` was not needed for that, and it is what broke everyone else: any encrypted `IdentityFile` now falls through to the old `key_filename` path without asking for the passphrase, and paramiko cannot do anything useful with it. I checked the 3.9.2 source and `_attach_identity_with_certificate` was already there, just without that argument.

So I dropped `allow_prompt=False` from that one call. The prompt inside `_load_private_key_file` is already gated on `pyinfra.is_cli`, so API mode keeps raising the "set ssh_key_password" error instead of blocking on stdin. The `allow_prompt` keyword stays on both helpers with its default of `True`, and I fixed its docstring, which claimed the ssh_config path had to be non-interactive because of #1852. On the test side, `test_parse_config_explicit_pkey_wins_over_encrypted_identityfile` is untouched and still passes, which is the proof that #1852 stays fixed. I turned `test_parse_config_encrypted_identityfile_does_not_prompt` around into a regression test for this issue, and added one more checking that a wrong passphrase still falls back to `key_filename` rather than raising out of `parse_config`.

One case I left alone on purpose: if `ssh_password` is set and ssh_config also names an encrypted `IdentityFile`, you get asked for a key passphrase you do not need. That was true in 3.9.2 as well, so it is not part of this regression and felt better as a separate change.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts (no operation or fact changed, the two affected docstrings are updated)
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

## AI usage disclosure

Per the project's [AI policy](../blob/3.x/AI_POLICY.md): I wrote this with AI assistance (Claude Code), which drafted the one line source change, the docstring edits and the two tests. I have reviewed all of it and I can explain how `parse_config`, `_attach_identity_with_certificate` and `_load_private_key_file` fit together, and why removing `allow_prompt=False` does not undo the #1852 fix.