### PR TITLE
fix(connectors.ssh): treat ProxyJump none as no jump host (#1445)

### DIFF
--- a/src/pyinfra/connectors/sshuserclient/client.py
+++ b/src/pyinfra/connectors/sshuserclient/client.py
@@ -347,11 +347,15 @@ class SSHClient(ParamikoClient):
             if agent_path.lower() != "none":
                 identity_agent = os.path.expanduser(agent_path)
 
+        proxyjump = host_config.get("proxyjump")
+
         if "proxycommand" in host_config:
             cfg["sock"] = ProxyCommand(host_config["proxycommand"])
 
-        elif "proxyjump" in host_config:
-            hops = host_config["proxyjump"].split(",")
+        # ``ProxyJump none`` disables jumping entirely (issue #1445), the same as
+        # OpenSSH - without this we'd jump via a host literally called "none".
+        elif proxyjump and proxyjump.strip().lower() != "none":
+            hops = proxyjump.split(",")
             sock = None
             # Propagate the target's timeout down so hop connections and the
             # direct-tcpip channel don't hang forever when the network misbehaves

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -44,6 +44,16 @@ Host 192.168.1.2
     ForwardAgent yes
 """
 
+SSH_CONFIG_PROXYJUMP_NONE = """
+Host 192.168.1.4
+    User otheruser
+    ProxyJump none
+
+Host 192.168.1.5
+    User otheruser
+    ProxyJump NONE
+"""
+
 SSH_CONFIG_PROXYJUMP_CONNECTTIMEOUT = """
 Host jump
     HostName jump.example.com
@@ -361,6 +371,31 @@ class TestSSHUserConfig(TestCase):
             username="nottestuser",
         )
         fake_gateway.assert_called_once_with("192.168.1.2", 1022, "192.168.1.2", 1022, timeout=None)
+
+    @patch(
+        "pyinfra.connectors.sshuserclient.client.open",
+        mock_open(read_data=SSH_CONFIG_PROXYJUMP_NONE),
+        create=True,
+    )
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.connect")
+    @patch("pyinfra.connectors.sshuserclient.SSHClient.gateway")
+    def test_load_ssh_config_proxyjump_none(self, fake_gateway, fake_ssh_connect):
+        """Regression test for #1445: ``ProxyJump none`` disables jumping rather
+        than jumping via a host literally called "none"."""
+        client = SSHClient()
+
+        _, config, *_ = client.parse_config("192.168.1.4")
+
+        assert "sock" not in config
+        fake_ssh_connect.assert_not_called()
+        fake_gateway.assert_not_called()
+
+        # OpenSSH compares the value case insensitively.
+        _, config, *_ = client.parse_config("192.168.1.5")
+
+        assert "sock" not in config
+        fake_ssh_connect.assert_not_called()
+        fake_gateway.assert_not_called()
 
     @patch(
         "pyinfra.connectors.sshuserclient.client.open",


### PR DESCRIPTION
Closes #1445

## Description

OpenSSH reads `ProxyJump none` as switching the option off. pyinfra instead split the value on commas and used the result as a list of hops, so a host with `ProxyJump none` in its ssh_config made pyinfra try to connect to a machine literally called "none" and fail on name resolution. Paramiko has a special case for `ProxyCommand none` but not for this one, so it needs handling here.

The fix skips the jump when the value is `none`, compared without case. `sock` is then never set and pyinfra connects straight to the target, which is what ssh does. The check is against the whole value on purpose, since OpenSSH only accepts `none` on its own and never as one entry in a comma separated hop list. It reads the same way as the `IdentityAgent none` check a few lines above.

New test `test_load_ssh_config_proxyjump_none` covers both `none` and `NONE`, and asserts no hop connection is made and no `sock` ends up in the config. It fails before the change and passes after.

## Checklist

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts (no new operations or facts, this only changes ssh_config handling)
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

## AI usage disclosure

Per the project's [AI policy](../blob/3.x/AI_POLICY.md): I wrote this with AI assistance (Claude Code), which drafted the two line source change and the new test, and I have read the diff and understand how `parse_config` builds the ProxyJump chain and why skipping it leaves a plain direct connection.