### PR TITLE
fix(facts.sysvinit): allow underscores in service names

### DIFF
--- a/src/pyinfra/facts/sysvinit.py
+++ b/src/pyinfra/facts/sysvinit.py
@@ -32,7 +32,7 @@ class InitdStatus(FactBase):
         done
     """
 
-    regex = r"([a-zA-Z0-9\-]+)=([0-9]+)"
+    regex = r"([a-zA-Z0-9_\-.]+)=([0-9]+)"
     default = dict
 
     @override

--- a/tests/facts/bsdinit.RcdStatus/services.yaml
+++ b/tests/facts/bsdinit.RcdStatus/services.yaml
@@ -1,0 +1,11 @@
+command: "\n            for SERVICE in `find /etc/rc.d /usr/local/etc/rc.d -type f`; do\n                $SERVICE status 2> /dev/null || $SERVICE check 2> /dev/null\n                echo \"`basename $SERVICE`=$?\"\n            done\n        "
+output: |
+  node_exporter=0
+  unbound=0
+  isc_dhcpd=1
+  sshd=0
+fact:
+  node_exporter: true
+  unbound: true
+  isc_dhcpd: false
+  sshd: true

--- a/tests/facts/sysvinit.InitdStatus/services.json
+++ b/tests/facts/sysvinit.InitdStatus/services.json
@@ -3,11 +3,13 @@
     "output": [
         "rpcsvcgssd=0",
         "rsyslog=4",
-        "saslauthd=3"
+        "saslauthd=3",
+        "node_exporter=0"
     ],
     "fact": {
         "rpcsvcgssd": true,
         "rsyslog": null,
-        "saslauthd": false
+        "saslauthd": false,
+        "node_exporter": true
     }
 }


### PR DESCRIPTION
Fixes #1844.

`InitdStatus.regex` was `([a-zA-Z0-9\-]+)=([0-9]+)`, which has no underscore in the character class. Because `re.match` anchors at the start of the line, a line like `node_exporter=0` does not match at all, so the service is dropped from the dict the fact returns. `bsdinit.RcdStatus` inherits the regex, so `bsdinit.service(running=True)` found no entry for the service, treated it as stopped, and issued a start command on every run. Underscores are common in rc.d and init.d script names, for example `node_exporter` and `isc_dhcpd`.

This widens the character class to `([a-zA-Z0-9_\-.]+)`, which also covers dots, another character these script names use. I added a fact fixture for `bsdinit.RcdStatus` with underscored service names, and added one underscored service to the existing `sysvinit.InitdStatus` fixture so the Linux path is covered too. Both fixtures fail before the change and pass after it.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

*AI disclosure (per `AI_POLICY.md`):* prepared with Claude Code, which traced the regex and drafted the test fixtures, and I reviewed the change and ran the tests before submitting.