### PR TITLE
fix(connectors.ssh): don't truncate local file when download fails (#1440)

### DIFF
--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import os
 from random import uniform
-from shutil import which
+from shutil import copyfileobj, which
 from socket import gaierror
+from tempfile import SpooledTemporaryFile
 from time import sleep
 from typing import IO, TYPE_CHECKING, Any, Protocol
 from collections.abc import Iterable
@@ -33,6 +34,10 @@ from .util import (
 
 if TYPE_CHECKING:
     from pyinfra.api.arguments import ConnectorArguments
+
+# Downloads are buffered in memory up to this size before spilling over onto disk, so that
+# the local destination is only written once the remote file has arrived in full.
+GET_FILE_BUFFER_MAX_SIZE = 1024 * 1024  # 1MB
 
 
 class ConnectorData(TypedDict):
@@ -467,10 +472,15 @@ class SSHConnector(BaseConnector):
                 ),
             ) from e
 
-    def _get_file(self, remote_filename: str, filename_or_io: str | IO):
-        with get_file_io(filename_or_io, "wb") as file_io:
-            sftp = self.get_file_transfer_connection()
-            sftp.getfo(remote_filename, file_io)
+    def _get_file(self, remote_filename: str, filename_or_io: str | IO) -> None:
+        # Download into a temporary buffer first - opening the destination truncates it, so
+        # writing into it directly would destroy the local file if the transfer then failed.
+        transfer_client = self.get_file_transfer_connection()
+        with SpooledTemporaryFile(max_size=GET_FILE_BUFFER_MAX_SIZE, mode="w+b") as buff:
+            transfer_client.getfo(remote_filename, buff)
+            buff.seek(0)
+            with get_file_io(filename_or_io, "wb") as file_io:
+                copyfileobj(buff, file_io)
 
     @override
     def get_file(

--- a/tests/test_connectors/test_ssh.py
+++ b/tests/test_connectors/test_ssh.py
@@ -1,5 +1,7 @@
 import importlib
+from pathlib import Path
 from socket import error as socket_error, gaierror
+from tempfile import TemporaryDirectory
 from unittest import TestCase, mock
 
 from paramiko import AuthenticationException, PasswordRequiredException, SSHException
@@ -1138,6 +1140,29 @@ class TestSSHConnector(TestCase):
         #     "not-a-file",
         #     fake_open(),
         # )
+
+    @mock.patch("pyinfra.connectors.ssh.SSHClient")
+    @mock.patch("pyinfra.connectors.ssh.SFTPClient")
+    def test_get_file_failure_leaves_local_file_alone(self, fake_sftp_client, fake_ssh_client):
+        inventory = make_inventory(hosts=("somehost",))
+        state = State(inventory, Config())
+        host = inventory.get_host("somehost")
+        host.connect()
+
+        fake_sftp_client.from_transport().getfo.side_effect = PermissionError(
+            13,
+            "Permission denied",
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            local_file = Path(temp_dir) / "existing-file"
+            local_file.write_bytes(b"do not truncate me")
+
+            with ctx_state.use(state):
+                with self.assertRaises(PermissionError):
+                    host.get_file("not-a-file", str(local_file))
+
+            assert local_file.read_bytes() == b"do not truncate me"
 
     @mock.patch("pyinfra.connectors.ssh.SSHClient")
     @mock.patch("pyinfra.connectors.ssh.SFTPClient")


### PR DESCRIPTION
Part of #1440, not a full fix.

`SSHConnector._get_file` opened the local destination with `get_file_io(..., "wb")`, which truncates it, and only then started the transfer. If the transfer failed, the user was left with an empty local file and no way back to the original contents. In #1440 the download fails with `PermissionError`, so `files.get` with `_sudo=True` wipes the local copy.

The download now goes through a `SpooledTemporaryFile` first, and the destination is only opened once the remote file has arrived in full. Spooling keeps small downloads in memory and spills larger ones to disk, so this does not pull whole files into RAM. Both transfer backends write into the file object they are given, so `sftp` and `scp` behave the same.

This addresses the truncation half of #1440 that @Fizzadar flagged. The sudo temp dir resolution is left open, so please don't auto-close the issue on merge. `docker.py` and `chroot.py` have the same shape in their download paths and are untouched here, they belong in a separate PR.

New test `test_get_file_failure_leaves_local_file_alone` writes a real file to a temp dir, makes the mocked `getfo` raise `PermissionError`, and asserts the bytes on disk are unchanged. It fails on `3.x` (reads `b''`) and passes with the fix.

## Checklist

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts (no operation, fact or argument changed, so nothing to document)
- [x] Tests pass (`scripts/dev-test.sh`, 1943 passed / 1 skipped)
- [x] Type checking & code style passes (`scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

## AI usage disclosure

Per [AI_POLICY.md](../blob/3.x/AI_POLICY.md): written with AI assistance using Claude Code, which located the truncating write, drafted the buffered version and the regression test, and ran the tests and linters. I reviewed and understand the change, including why the spooled buffer keeps the `sftp` and `scp` paths identical and why the sudo temp dir half of the issue is out of scope here.