### PR TITLE
fix(connectors.docker): strip sha256 prefix instead of slicing image ID

### DIFF
--- a/src/pyinfra/connectors/docker.py
+++ b/src/pyinfra/connectors/docker.py
@@ -174,9 +174,13 @@ class DockerConnector(BaseConnector):
         quoted_container_id = shlex.quote(container_id)
 
         with progress_spinner({f"{self.docker_cmd} commit"}):
-            image_id = local.shell(
-                f"{self.docker_cmd} commit {quoted_container_id}", splitlines=True
-            )[-1][7:19]  # last line is the image ID, get sha256:[XXXXXXXXXX]...
+            # last line is the image ID, optionally prefixed with the digest algorithm
+            # (docker prints "sha256:XXXX...", podman prints the bare digest)
+            image_id = (
+                local.shell(f"{self.docker_cmd} commit {quoted_container_id}", splitlines=True)[-1]
+                .strip()
+                .removeprefix("sha256:")[:12]
+            )
 
         with progress_spinner({f"{self.docker_cmd} rm"}):
             local.shell(

--- a/tests/test_connectors/test_docker.py
+++ b/tests/test_connectors/test_docker.py
@@ -10,6 +10,10 @@ from pyinfra.connectors.util import make_unix_command
 
 from ..util import make_inventory
 
+# Digest of the committed image, as printed by `docker commit` / `podman commit`. Docker
+# prefixes it with the algorithm, podman prints it bare.
+FAKE_IMAGE_DIGEST = "0d05fac3b9bc6d8d5fc7b323a35a23daf0ab61fc38685de569ce69f6feb7fbe6"
+
 
 class TestContainerConnector(TestCase):
     # we use this class as a template to prevent the decorators from being invoked twice on
@@ -58,6 +62,18 @@ class TestContainerConnector(TestCase):
         host.connect(reason=True)
         assert len(state.active_hosts) == 0
         host.disconnect()
+
+    def test_disconnect_host_logs_short_image_id(self):
+        inventory = make_inventory(hosts=(f"@{self.connector_name}/not-an-image",))
+        State(inventory, Config())
+        host = inventory.get_host(f"@{self.connector_name}/not-an-image")
+        host.connect(reason=True)
+
+        with patch("pyinfra.connectors.docker.logger") as fake_logger:
+            host.disconnect()
+
+        message = fake_logger.info.call_args[0][0]
+        assert message.endswith(f"image ID: {FAKE_IMAGE_DIGEST[:12]}")
 
     def test_run_shell_command(self):
         inventory = make_inventory(hosts=(f"@{self.connector_name}/not-an-image",))
@@ -233,7 +249,7 @@ def fake_docker_shell(command, splitlines=None):
         return ["containerid"]
 
     if command == "docker commit containerid":
-        return ["sha256:blahsomerandomstringdata"]
+        return [f"sha256:{FAKE_IMAGE_DIGEST}"]
 
     if command == "docker rm -f containerid":
         return []
@@ -264,7 +280,7 @@ def fake_podman_shell(command, splitlines=None):
         return ["containerid"]
 
     if command == "podman commit containerid":
-        return ["sha256:blahsomerandomstringdata"]
+        return [FAKE_IMAGE_DIGEST]
 
     if command == "podman rm -f containerid":
         return []


### PR DESCRIPTION
Fixes #1905.

`docker commit` prints the new image ID as `sha256:<digest>`, so `disconnect()` took a fixed `[7:19]` slice to log the short ID. `podman commit` prints the bare digest with no prefix, so that same slice cut characters 7 to 19 out of the digest itself. The podman connector then reported a short image ID that does not match any real image.

The fix removes the `sha256:` prefix when it is there and takes the first 12 characters of what is left, which is correct for both tools. The `run -d` path is untouched, since the container ID it returns was never sliced.

On the test side, the podman fake shell now returns a bare 64 character digest like podman really does, the docker fake keeps the prefixed form, and a new test asserts the logged ID is the first 12 characters of the digest. It runs for both connectors through the shared base class.

I used Claude Code to write this patch and its test. I reviewed the change, ran the tests, and understand what it does.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format