### PR TITLE
fix(connectors.ssh): skip unparsable known_hosts lines instead of dropping the file

### DIFF
--- a/src/pyinfra/connectors/sshuserclient/client.py
+++ b/src/pyinfra/connectors/sshuserclient/client.py
@@ -161,6 +161,38 @@ def get_ssh_config(user_config_file=None):
             return ssh_config
 
 
+def _load_host_keys_file(host_keys: HostKeys, filename: str) -> None:
+    """
+    Load a single known_hosts file, skipping any line paramiko cannot parse.
+
+    ``HostKeys.load`` only ignores lines that raise ``SSHException``, so a line
+    it fails on for any other reason (``@cert-authority``/``@revoked`` markers,
+    a truncated key) aborts the whole file and drops every valid key in it. That
+    makes pyinfra treat known hosts as unknown and append them again (issue
+    #1339). See: https://github.com/paramiko/paramiko/pull/1990
+    """
+
+    with open(filename) as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            try:
+                entry = HostKeyEntry.from_line(line, lineno)
+            # Broad by necessity: paramiko raises a bare ``Exception`` subclass
+            # (``InvalidHostKey``) for undecodable key data.
+            except Exception as e:
+                logger.warning("Skipping bad host keys line %s:%i: %s", filename, lineno, e)
+                continue
+
+            if entry is None:
+                continue
+
+            for hostname in entry.hostnames:
+                host_keys.add(hostname, entry.key.get_name(), entry.key)
+
+
 @memoize
 def get_host_keys(filenames):
     """
@@ -174,10 +206,9 @@ def get_host_keys(filenames):
 
         for filename in filenames:
             try:
-                host_keys.load(filename)
-            # When paramiko encounters a bad host keys line it sometimes bails the
-            # entire load incorrectly.
-            # See: https://github.com/paramiko/paramiko/pull/1990
+                _load_host_keys_file(host_keys, filename)
+            # A missing or unreadable known_hosts file is not fatal, the keys
+            # from any other files should still be used.
             except Exception as e:
                 logger.warning("Failed to load host keys from %s: %s", filename, e)
 

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -6,7 +6,7 @@ import pytest
 from paramiko import PKey, ProxyCommand, SSHException
 
 from pyinfra.connectors.sshuserclient import SSHClient
-from pyinfra.connectors.sshuserclient.client import AskPolicy, get_ssh_config
+from pyinfra.connectors.sshuserclient.client import AskPolicy, get_host_keys, get_ssh_config
 
 CERT_KEY_TYPE = "ssh-ed25519-cert-v01@openssh.com"
 
@@ -575,6 +575,36 @@ def test_parse_config_encrypted_identityfile_does_not_prompt(
     fake_getpass.assert_not_called()
     assert "pkey" not in cfg
     assert cfg["key_filename"] == [str(ssh_encrypted_key["key"])]
+
+
+def test_get_host_keys_skips_unparsable_lines(tmp_path):
+    # Regression for #1339: a line paramiko can't parse (here a @cert-authority
+    # marker) must not throw away the rest of the file, otherwise known hosts
+    # look unknown and get appended to known_hosts again on every run.
+    example_hostname = "192.168.1.222"
+    example_keytype = "ecdsa-sha2-nistp256"
+    example_key = (
+        "AAAAE2VjZHNhLXNoYTItbmlzdHAyNT"
+        "YAAAAIbmlzdHAyNTYAAABBBHNp1NM"
+        "ZjxPBuuKwIPfkVJqWaH3oUtW137kIW"
+        "P4PlCyACt8zVIIimFhIpwRUidcf7jw"
+        "VWPAJvfBjEPqewDApnZQ="
+    )
+
+    known_hosts = tmp_path / "known_hosts"
+    known_hosts.write_text(
+        "# a comment\n"
+        "\n"
+        f"@cert-authority *.example.com ssh-rsa {EXAMPLE_KEY_1}\n"
+        f"{example_hostname} {example_keytype} {example_key}\n"
+    )
+
+    get_host_keys.cache = {}
+    host_keys = get_host_keys((str(known_hosts),))
+
+    keys = host_keys.lookup(example_hostname)
+    assert keys is not None
+    assert keys[example_keytype].get_base64() == example_key
 
 
 def test_parse_config_keeps_key_filename_when_no_real_identityfile(


### PR DESCRIPTION
Fixes #1339.

`get_host_keys` calls paramiko's `HostKeys.load`, which only skips lines that raise `SSHException`. A `@cert-authority` line raises `InvalidHostKey`, which is a plain `Exception`, so the load stops there and the rest of the file is thrown away. pyinfra then sees no known hosts, treats hosts it already knows as new, and with `StrictHostKeyChecking accept-new` writes their keys to `known_hosts` again on every run. That is where the duplicate entries come from.

This reads the file line by line, skips blank lines and comments the same way paramiko does, and drops only the lines that fail to parse, logging a warning with the file name and line number. Keys after a bad line are kept.

The test writes a `known_hosts` whose first entry is an unparsable `@cert-authority` line followed by a valid ecdsa key, then checks that key still resolves. It fails before the change and passes after.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

*AI disclosure (per `AI_POLICY.md`):* the patch and test were written with Claude Code, then reviewed and tested by me before submitting.