### PR TITLE
fix(facts.files): fix tilde expansion for HashFiles (#1235)

### DIFF
--- a/src/pyinfra/facts/files.py
+++ b/src/pyinfra/facts/files.py
@@ -398,15 +398,21 @@ class HashFileFactBase(FactBaseOptionalStr):
 
     @override
     def command(self, path):
-        self.path = path
-        return make_formatted_string_command(self._raw_cmd, QuoteString(path))
+        if path.startswith("~/"):
+            # Insert .* to take into account string expansion
+            self.escaped_path = ".*" + re.escape(path.removeprefix("~"))
+            # Do not quote leading tilde to ensure that it gets properly expanded by the shell
+            path = StringCommand("~/", QuoteString(path.removeprefix("~/")), _separator="")
+        else:
+            self.escaped_path = re.escape(path)
+            path = QuoteString(path)
+        return make_formatted_string_command(self._raw_cmd, path)
 
     @override
     def process(self, output) -> str | None:
         output = output[0]
-        escaped_path = re.escape(self.path)
         for regex in self._regexes:
-            matches = re.match(regex % escaped_path, output)
+            matches = re.match(regex % self.escaped_path, output)
             if matches:
                 return matches.group(1)
         return None

--- a/tests/facts/files.Md5File/tilde.yaml
+++ b/tests/facts/files.Md5File/tilde.yaml
@@ -1,0 +1,5 @@
+"arg": "~/myfile"
+"command": "test -e ~/myfile && ( md5sum ~/myfile 2> /dev/null || md5 ~/myfile 2> /dev/null ) || true"
+"output":
+  - "c10ba97d7c9078a006d26b5db01d8ee7 /home/pyinfra/myfile"
+"fact": "c10ba97d7c9078a006d26b5db01d8ee7"

--- a/tests/facts/files.Md5File/tilde_bsd_style.yaml
+++ b/tests/facts/files.Md5File/tilde_bsd_style.yaml
@@ -1,0 +1,5 @@
+"arg": "~/myfile"
+"command": "test -e ~/myfile && ( md5sum ~/myfile 2> /dev/null || md5 ~/myfile 2> /dev/null ) || true"
+"output":
+  - "MD5 (/home/pyinfra/myfile) = c10ba97d7c9078a006d26b5db01d8ee7"
+"fact": "c10ba97d7c9078a006d26b5db01d8ee7"

--- a/tests/facts/files.Sha1File/tilde.yaml
+++ b/tests/facts/files.Sha1File/tilde.yaml
@@ -1,0 +1,5 @@
+"arg": "~/myfile"
+"command": "test -e ~/myfile && ( sha1sum ~/myfile 2> /dev/null || shasum ~/myfile 2> /dev/null || sha1 ~/myfile 2> /dev/null ) || true"
+"output":
+  - "85746ef87ddabd9fdf4836c5835e34a030d2a141 /home/pyinfra/myfile"
+"fact": "85746ef87ddabd9fdf4836c5835e34a030d2a141"

--- a/tests/facts/files.Sha1File/tilde_bsd_style.yaml
+++ b/tests/facts/files.Sha1File/tilde_bsd_style.yaml
@@ -1,0 +1,5 @@
+"arg": "~/myfile"
+"command": "test -e ~/myfile && ( sha1sum ~/myfile 2> /dev/null || shasum ~/myfile 2> /dev/null || sha1 ~/myfile 2> /dev/null ) || true"
+"output":
+  - "SHA1 (/home/pyinfra/myfile) = 85746ef87ddabd9fdf4836c5835e34a030d2a141"
+"fact": "85746ef87ddabd9fdf4836c5835e34a030d2a141"

--- a/tests/facts/files.Sha256File/tilde.yaml
+++ b/tests/facts/files.Sha256File/tilde.yaml
@@ -1,0 +1,5 @@
+"arg": "~/myfile"
+"command": "test -e ~/myfile && ( sha256sum ~/myfile 2> /dev/null || shasum -a 256 ~/myfile 2> /dev/null || sha256 ~/myfile 2> /dev/null ) || true"
+"output":
+  - "3867882e8ccc16bd6a1e3e214a46608f9cf5d21687bbb8c25751da3c47b48033 /home/pyinfra/myfile"
+"fact": "3867882e8ccc16bd6a1e3e214a46608f9cf5d21687bbb8c25751da3c47b48033"

--- a/tests/facts/files.Sha256File/tilde_bsd_style.yaml
+++ b/tests/facts/files.Sha256File/tilde_bsd_style.yaml
@@ -1,0 +1,5 @@
+"arg": "~/myfile"
+"command": "test -e ~/myfile && ( sha256sum ~/myfile 2> /dev/null || shasum -a 256 ~/myfile 2> /dev/null || sha256 ~/myfile 2> /dev/null ) || true"
+"output":
+  - SHA256 (/home/pyinfra/myfile) = 3867882e8ccc16bd6a1e3e214a46608f9cf5d21687bbb8c25751da3c47b48033
+"fact": "3867882e8ccc16bd6a1e3e214a46608f9cf5d21687bbb8c25751da3c47b48033"

--- a/tests/facts/files.Sha384File/tilde.yaml
+++ b/tests/facts/files.Sha384File/tilde.yaml
@@ -1,0 +1,5 @@
+"arg": "~/myfile"
+"command": "test -e ~/myfile && ( sha384sum ~/myfile 2> /dev/null || shasum -a 384 ~/myfile 2> /dev/null || sha384 ~/myfile 2> /dev/null ) || true"
+"output":
+  - "1dd2e448df7c4dc19848a37fdf25c86660b19d06a4cd6987ca2c4071f80e9dd3061e4b01ddb982dc56ed7a2ed2294699 /home/pyinfra/myfile"
+"fact": "1dd2e448df7c4dc19848a37fdf25c86660b19d06a4cd6987ca2c4071f80e9dd3061e4b01ddb982dc56ed7a2ed2294699"

--- a/tests/facts/files.Sha384File/tilde_bsd_style.yaml
+++ b/tests/facts/files.Sha384File/tilde_bsd_style.yaml
@@ -1,0 +1,5 @@
+"arg": "~/myfile"
+"command": "test -e ~/myfile && ( sha384sum ~/myfile 2> /dev/null || shasum -a 384 ~/myfile 2> /dev/null || sha384 ~/myfile 2> /dev/null ) || true"
+"output":
+  - "SHA384 (/home/pyinfra/myfile) = 1dd2e448df7c4dc19848a37fdf25c86660b19d06a4cd6987ca2c4071f80e9dd3061e4b01ddb982dc56ed7a2ed2294699"
+"fact": "1dd2e448df7c4dc19848a37fdf25c86660b19d06a4cd6987ca2c4071f80e9dd3061e4b01ddb982dc56ed7a2ed2294699"


### PR DESCRIPTION
Fixes #1235
Heavily inspired by #1175 

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

Edit:

Tested from my branch.
Now with:

```python
from pyinfra.operations import files

files.put(
    src="files/editors.conf",
    dest= "~/.config/environment.d/editors.conf"
)
```

Running `pyinfra @local deploy.py --dry --diff` correctly returns no change (assuming the file is already there)