### PR TITLE
fix(operations.git.repo): pass depth argument to fetch and pull

### DIFF
--- a/src/pyinfra/operations/git.py
+++ b/src/pyinfra/operations/git.py
@@ -118,7 +118,7 @@ def repo(
     + ssh_keyscan: keyscan the remote host if not in known_hosts before clone/pull
     + update_submodules: update any git submodules
     + recursive_submodules: update git submodules recursively
-    + depth: create a shallow clone with a history truncated to the specified number of commits
+    + depth: truncate clone, fetch and pull history to the specified number of commits
     + fetch_tags: Whether all tags should be fetched prior to attempting to
       check out the specified revision.
     + force: Execute ``fetch``, ``pull`` and ``checkout`` commands with ``--force``.
@@ -156,15 +156,20 @@ def repo(
     git_dir = unix_path_join(dest, ".git")
     is_repo = host.get_fact(Directory, path=git_dir)
 
+    # The depth argument can be passed to clone, fetch and pull operations.
+    # We prepare the argument list to reuse it later on
+    depth_options: list[str | QuoteString] = []
+    if depth is not None:
+        depth_options.extend(["--depth", QuoteString(str(depth))])
+
     # Cloning new repo?
     if not is_repo:
-        options: list[str | QuoteString] = []
-        if depth is not None:
-            options.extend(["--depth", str(depth)])
+        clone_options: list[str | QuoteString] = []
+        clone_options.extend(depth_options)
         if branch:
-            options.extend(["--branch", QuoteString(branch)])
+            clone_options.extend(["--branch", QuoteString(branch)])
 
-        git_commands.append(StringCommand("clone", QuoteString(src), *options, "."))
+        git_commands.append(StringCommand("clone", QuoteString(src), *clone_options, "."))
 
     # Ensuring existing repo
     else:
@@ -182,10 +187,11 @@ def repo(
         current_branch = host.get_fact(GitBranch, repo=dest)
         if branch is not None and current_branch != branch:
             # fetch to ensure we have the branch/tag locally
+            fetch_options: list[str | QuoteString] = []
+            fetch_options.extend(depth_options)
             if fetch_tags:
-                git_commands.append(StringCommand("fetch", "--tags", *force_flag_list))
-            else:
-                git_commands.append(StringCommand("fetch", *force_flag_list))
+                fetch_options.append("--tags")
+            git_commands.append(StringCommand("fetch", *fetch_options, *force_flag_list))
 
             git_commands.append(StringCommand("checkout", QuoteString(branch), *force_flag_list))
         if branch and branch in (host.get_fact(GitTag, repo=dest) or []):
@@ -214,10 +220,12 @@ def repo(
                 host.noop(
                     f"git repository {dest} is already up to date",
                 )
-            elif rebase:
-                git_commands.append(StringCommand("pull", "--rebase", *force_flag_list))
             else:
-                git_commands.append(StringCommand("pull", *force_flag_list))
+                pull_options: list[str | QuoteString] = []
+                pull_options.extend(depth_options)
+                if rebase:
+                    pull_options.append("--rebase")
+                git_commands.append(StringCommand("pull", *pull_options, *force_flag_list))
 
     if update_submodules:
         if recursive_submodules:

--- a/tests/operations/git.repo/branch_pull_depth.json
+++ b/tests/operations/git.repo/branch_pull_depth.json
@@ -1,0 +1,44 @@
+{
+    "args": ["myrepo", "/home/myrepo"],
+    "kwargs": {
+        "branch": "mybranch",
+        "depth": 1,
+        "fetch_tags": true
+    },
+    "facts": {
+        "git.GitConfig": {
+            "repo=/home/myrepo, system=False": {
+                "remote.origin.url": ["myrepo"]
+            }
+        },
+        "files.Directory": {
+            "path=/home/myrepo": {},
+            "path=/home/myrepo/.git": {
+                "mode": 0
+            }
+        },
+        "git.GitBranch": {
+            "repo=/home/myrepo": "master"
+        },
+        "git.GitTag": {
+            "repo=/home/myrepo": [
+            ]
+        },
+        "git.GitLocalCommit": {
+            "ref=mybranch, repo=/home/myrepo": null
+        },
+        "git.GitRemoteBranchCommit": {
+            "branch=mybranch, remote=origin, repo=/home/myrepo": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+    },
+    "commands": [
+        "cd /home/myrepo && git fetch --depth 1 --tags",
+        "cd /home/myrepo && git checkout mybranch",
+        "cd /home/myrepo && git pull --depth 1"
+    ],
+    "second_output_commands": [
+        "cd /home/myrepo && git pull --depth 1"
+    ],
+    "idempotent": false,
+    "disable_idempotent_warning_reason": "git branch pull always executed"
+}

--- a/tests/operations/git.repo/branch_pull_depth_force_tags.yaml
+++ b/tests/operations/git.repo/branch_pull_depth_force_tags.yaml
@@ -1,0 +1,34 @@
+args:
+- myrepo
+- /home/myrepo
+kwargs:
+  branch: mybranch
+  depth: 1
+  fetch_tags: true
+  force: true
+  rebase: false
+facts:
+  git.GitConfig:
+    repo=/home/myrepo, system=False:
+      remote.origin.url:
+      - myrepo
+  files.Directory:
+    path=/home/myrepo: {}
+    path=/home/myrepo/.git:
+      mode: 0
+  git.GitBranch:
+    repo=/home/myrepo: master
+  git.GitTag:
+    repo=/home/myrepo: []
+  git.GitLocalCommit:
+    ref=mybranch, repo=/home/myrepo: null
+  git.GitRemoteBranchCommit:
+    branch=mybranch, remote=origin, repo=/home/myrepo: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+commands:
+- cd /home/myrepo && git fetch --depth 1 --tags --force
+- cd /home/myrepo && git checkout mybranch --force
+- cd /home/myrepo && git pull --depth 1 --force
+second_output_commands:
+- cd /home/myrepo && git pull --depth 1 --force
+idempotent: false
+disable_idempotent_warning_reason: git branch pull always executed

--- a/tests/operations/git.repo/clone_depth.json
+++ b/tests/operations/git.repo/clone_depth.json
@@ -1,0 +1,19 @@
+{
+    "args": ["myrepo", "/home/myrepo"],
+    "kwargs": {
+        "branch": "mybranch",
+        "user": "myuser",
+        "depth": 1,
+        "pull": false
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/home/myrepo": {},
+            "path=/home/myrepo/.git": null
+        }
+    },
+    "commands": [
+        "cd /home/myrepo && git clone myrepo --depth 1 --branch mybranch .",
+        "chown -R myuser /home/myrepo"
+    ]
+}


### PR DESCRIPTION
Previously, when cloning a repo with the `depth` keyword, if the remote directory changed, fetch and/or pull operations would unshallow the repository, given that the `depth` keyword was not being passed.

In turn, this ensures that if the value for the `depth` keyword changes, it will be updated in the deployment, though only when there is a change in the remote repository.

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [X] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
