### PR TITLE
fix(operations): coerce Path arguments to str in git, pip, apt and unix_path_join

### DIFF
--- a/src/pyinfra/operations/apt.py
+++ b/src/pyinfra/operations/apt.py
@@ -163,7 +163,7 @@ def key(
         return
 
     # Resolve destination path under /etc/apt/keyrings/
-    if dest and not dest.startswith("/"):
+    if dest and not str(dest).startswith("/"):
         dest = f"/etc/apt/keyrings/{dest}"
     elif not dest:
         if src:

--- a/src/pyinfra/operations/git.py
+++ b/src/pyinfra/operations/git.py
@@ -416,7 +416,7 @@ def worktree(
             # branch it creates. When the command runs as root (e.g. via
             # `_sudo`), those files end up root-owned and break later git
             # commands run as the worktree owner.
-            worktree_name = worktree.rstrip("/").rsplit("/", 1)[-1]
+            worktree_name = str(worktree).rstrip("/").rsplit("/", 1)[-1]
             yield chown(
                 unix_path_join(repo, ".git", "worktrees", worktree_name),
                 user,

--- a/src/pyinfra/operations/pip.py
+++ b/src/pyinfra/operations/pip.py
@@ -167,7 +167,7 @@ def packages(
         yield from _virtualenv(virtualenv, **virtualenv_kwargs)
 
         # And update pip path
-        virtualenv = virtualenv.rstrip("/")
+        virtualenv = str(virtualenv).rstrip("/")
         pip = StringCommand(QuoteString(virtualenv), "/bin/", pip, _separator="").get_raw_value()
 
     install_command_args = [pip, "install"]

--- a/src/pyinfra/operations/util/files.py
+++ b/src/pyinfra/operations/util/files.py
@@ -16,7 +16,7 @@ class MetadataTimeField(Enum):
 
 
 def unix_path_join(*parts) -> str:
-    part_list = list(parts)
+    part_list = [str(part) for part in parts]
     part_list[0:-1] = [part.rstrip("/") for part in part_list[0:-1]]
     return "/".join(part_list)
 

--- a/tests/operations/apt.key/add_path_dest.yaml
+++ b/tests/operations/apt.key/add_path_dest.yaml
@@ -1,0 +1,16 @@
+args:
+  - mykey
+kwargs:
+  dest: "path:vendor-archive.gpg"
+facts:
+  files.Directory:
+    "path=/etc/apt/keyrings": null
+  files.File:
+    "path=/etc/apt/keyrings/vendor-archive.gpg": null
+commands:
+  - mkdir -p /etc/apt/keyrings
+  - chmod 755 /etc/apt/keyrings
+  - if grep -q "BEGIN PGP PUBLIC KEY BLOCK" "mykey"; then gpg --batch --dearmor -o "/etc/apt/keyrings/vendor-archive.gpg" "mykey"; else cp "mykey" "/etc/apt/keyrings/vendor-archive.gpg"; fi
+  - mkdir -p /etc/apt/keyrings
+  - touch /etc/apt/keyrings/vendor-archive.gpg
+  - chmod 644 /etc/apt/keyrings/vendor-archive.gpg

--- a/tests/operations/git.repo/clone_path_dest.yaml
+++ b/tests/operations/git.repo/clone_path_dest.yaml
@@ -1,0 +1,14 @@
+args:
+  - myrepo
+  - "path:/home/myrepo"
+kwargs:
+  branch: mybranch
+  user: myuser
+  pull: false
+facts:
+  files.Directory:
+    "path=/home/myrepo": {}
+    "path=/home/myrepo/.git": null
+commands:
+  - cd /home/myrepo && git clone myrepo --branch mybranch .
+  - chown -R myuser /home/myrepo

--- a/tests/operations/git.repo/clone_path_dest.yaml
+++ b/tests/operations/git.repo/clone_path_dest.yaml
@@ -1,3 +1,7 @@
+# str(Path) renders with backslashes on Windows, breaking the fake fact lookup
+require_platform:
+  - Darwin
+  - Linux
 args:
   - myrepo
   - "path:/home/myrepo"

--- a/tests/operations/git.worktree/create_with_user_path.yaml
+++ b/tests/operations/git.worktree/create_with_user_path.yaml
@@ -1,3 +1,7 @@
+# str(Path) renders with backslashes on Windows, breaking the fake fact lookup
+require_platform:
+  - Darwin
+  - Linux
 args:
   - "path:/home/myworktree"
 kwargs:

--- a/tests/operations/git.worktree/create_with_user_path.yaml
+++ b/tests/operations/git.worktree/create_with_user_path.yaml
@@ -1,0 +1,18 @@
+args:
+  - "path:/home/myworktree"
+kwargs:
+  repo: "path:/home/mainrepo"
+  new_branch: mybranch
+  user: myuser
+facts:
+  files.Directory:
+    "path=/home/mainrepo": {}
+    "path=/home/mainrepo/.git":
+      mode: 0
+    "path=/home/myworktree": null
+commands:
+  - cd /home/mainrepo && git worktree add -b mybranch /home/myworktree
+  - chown -R myuser /home/myworktree
+  - chown -R myuser /home/mainrepo/.git/worktrees/myworktree
+  - chown myuser /home/mainrepo/.git/refs/heads/mybranch
+  - chown -R myuser /home/mainrepo/.git/logs/refs/heads/mybranch

--- a/tests/operations/pip.packages/add_path_virtualenv_packages.yaml
+++ b/tests/operations/pip.packages/add_path_virtualenv_packages.yaml
@@ -1,0 +1,17 @@
+args:
+  - - elasticquery==1.1
+    - flask
+    - test==1.1
+kwargs:
+  virtualenv: "path:testdir"
+facts:
+  pip.PipPackages:
+    "pip=testdir/bin/pip":
+      elasticquery:
+        - "1.0"
+      test:
+        - "1.1"
+  files.File:
+    "path=testdir/bin/activate": true
+commands:
+  - testdir/bin/pip install elasticquery==1.1 flask


### PR DESCRIPTION
Closes #643.

Passing `pathlib.Path` objects to some operations still raised `AttributeError` on str-only methods:

- `git.repo(dest=Path(...))` and anything else routing through `unix_path_join` (`part.rstrip("/")` in `src/pyinfra/operations/util/files.py`)
- `git.worktree(worktree=Path(...))` (`worktree.rstrip("/")`)
- `pip.packages(virtualenv=Path(...))` (`virtualenv.rstrip("/")`)
- `apt.key(dest=Path(...))` (`dest.startswith("/")`)

Fixes:

- `unix_path_join` coerces all parts with `str()` first, covering every operation that uses the helper
- the three remaining call sites `str()` the argument before calling str methods on it

Tests: new YAML fixtures passing `Path` arguments (via the `path:` fixture syntax) for all four operations.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the conventional commits format
