### PR TITLE
feat(connectors.docker): add docker_user connector data option

### DIFF
--- a/src/pyinfra/connectors/docker.py
+++ b/src/pyinfra/connectors/docker.py
@@ -29,12 +29,14 @@ class ConnectorData(TypedDict):
     docker_identifier: str
     docker_platform: str
     docker_architecture: str
+    docker_user: str
 
 
 connector_data_meta: dict[str, DataMeta] = {
     "docker_identifier": DataMeta("ID of container or image to start from"),
     "docker_platform": DataMeta("Platform to use for Docker image (e.g., linux/amd64)"),
     "docker_architecture": DataMeta("Architecture to use for Docker image (e.g., amd64, arm64)"),
+    "docker_user": DataMeta("User to execute commands as inside the container"),
 }
 
 
@@ -207,9 +209,15 @@ class DockerConnector(BaseConnector):
         command = StringCommand(QuoteString(command))
 
         docker_flags = "-it" if local_arguments.get("_get_pty") else "-i"
+
+        docker_command_bits: list[str | QuoteString] = [self.docker_cmd, "exec"]
+
+        docker_user = self.data.get("docker_user")
+        if docker_user:
+            docker_command_bits.extend(["--user", QuoteString(docker_user)])
+
         docker_command = StringCommand(
-            self.docker_cmd,
-            "exec",
+            *docker_command_bits,
             docker_flags,
             container_id,
             "sh",

--- a/tests/test_connectors/test_docker.py
+++ b/tests/test_connectors/test_docker.py
@@ -106,6 +106,34 @@ class TestContainerConnector(TestCase):
             stdin=PIPE,
         )
 
+    def test_run_shell_command_with_user(self):
+        inventory = make_inventory(
+            hosts=(f"@{self.connector_name}/not-an-image",),
+            override_data={"docker_user": "myuser"},
+        )
+        State(inventory, Config())
+
+        command = "echo hi"
+        self.fake_popen_mock().returncode = 0
+
+        host = inventory.get_host(f"@{self.connector_name}/not-an-image")
+        host.connect()
+        out = host.run_shell_command(command, _get_pty=True)
+        assert out[0] is True
+
+        command = make_unix_command(command).get_raw_value()
+        command = shlex.quote(command)
+        docker_command = f"{self.cli_cmd} exec --user myuser -it containerid sh -c {command}"
+        shell_command = make_unix_command(docker_command).get_raw_value()
+
+        self.fake_popen_mock.assert_called_with(
+            shell_command,
+            shell=True,
+            stdout=PIPE,
+            stderr=PIPE,
+            stdin=PIPE,
+        )
+
     def test_run_shell_command_success_exit_codes(self):
         inventory = make_inventory(hosts=(f"@{self.connector_name}/not-an-image",))
         State(inventory, Config())


### PR DESCRIPTION
Closes #661.

Adds a `docker_user` host data option to the docker connector (inherited by the podman connector). When set, commands run as that user inside the container:

```
docker exec --user <user> -i <container> sh -c ...
```

Usage, following the existing connector data convention (docker options have no dedicated CLI flags):

```shell
pyinfra @docker/alpine:3.8 --data docker_user=someuser ...
```

```python
@docker/myimage, {"docker_user": "someuser"}
```

Notes:

- The user must exist in the image, as the issue states.
- File up/downloads use `docker cp`, which is daemon-side and unaffected by the exec user.
- Connector docs pick the option up automatically from `connector_data_meta`.

Tests: new `test_run_shell_command_with_user` in `tests/test_connectors/test_docker.py`, run for both the docker and podman test classes.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the conventional commits format
