### PR TITLE
refactor(facts): no sudo to get pacman facts

### DIFF
--- a/src/pyinfra/operations/pacman.py
+++ b/src/pyinfra/operations/pacman.py
@@ -74,9 +74,11 @@ def packages(
     yield from ensure_packages(
         host,
         packages,
-        host.get_fact(PacmanPackages),
+        host.get_fact(PacmanPackages, _sudo=False),
         present,
         install_command="pacman --noconfirm -S",
         uninstall_command="pacman --noconfirm -R",
-        expand_package_fact=lambda package: host.get_fact(PacmanUnpackGroup, package=package),
+        expand_package_fact=lambda package: host.get_fact(
+            PacmanUnpackGroup, package=package, _sudo=False
+        ),
     )


### PR DESCRIPTION
It seems that facts requested while evaluating an operation inherit the operation's `_sudo` argument.

For example, `pacman.packages(_sudo=True)` currently collects `PacmanPackages` with sudo.

However, `pacman -Q` is a read-only query and does not require elevated privileges. As a result, a package operation can require sudo authentication even when no package changes are necessary.

I wonder if this should become a convention for operations more generally.

For facts which only perform read-only, unprivileged state discovery, operations could explicitly request them with `_sudo=False`, even when the operation itself requires sudo.

This would have two benefits:

1. read-only fact collection doesn't unnecessarily require elevated privileges.
2. an operation which makes no changes should not need sudo credentials just to determine that no changes are required.

This could also be extended to `doas` and `_dzdo`


- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
