### PR TITLE
docs(operations.server): mention shell executable

### DIFF
--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -186,7 +186,9 @@ def shell(commands: str | list[str]):
     """
     Run raw shell code on server during a deploy. If the command would
     modify data that would be in a fact, the fact would not be updated
-    since facts are only run at the start of a deploy.
+    since facts are only run at the start of a deploy. Commands run via the
+    configured shell, which defaults to ``sh``; use the ``_shell_executable``
+    global argument when a command needs Bash or another shell.
 
     + commands: command or list of commands to execute on the remote server
 
@@ -197,6 +199,12 @@ def shell(commands: str | list[str]):
         server.shell(
             name="Run lxd auto init",
             commands=["lxd init --auto"],
+        )
+
+        server.shell(
+            name="Source a Bash environment before building",
+            commands=["source /opt/example/setupvars.sh && make"],
+            _shell_executable="bash",
         )
     """
 


### PR DESCRIPTION
## Summary

Closes #1935.

This updates the generated `server.shell` operation reference so users know raw commands run through the configured shell, which defaults to `sh`, and that `_shell_executable` can be used when a command needs Bash or another shell.

## Rationale

The general operations guide already documents `_shell_executable`, but the issue showed users naturally look at `server.shell` first when troubleshooting `source`/environment setup commands. Adding the note to the operation docstring keeps the generated operation reference discoverable without changing runtime behavior.

## Validation

- `uv run python - <<'PY' ...` confirmed the docstring now mentions `_shell_executable` and `sh`
- `uv run python scripts/generate_operations_docs.py`
- `rg -n "_shell_executable|Source a Bash" docs/operations/server.md`
- `uv run pytest tests/test_operations.py -k "server.shell"`
- `uv run ruff check src/pyinfra/operations/server.py`
- `uv run ruff format --check src/pyinfra/operations/server.py`
- `uv run python scripts/lint_arguments_sync.py`
- `git diff --check`
