### PR TITLE
fix(api): strip su password prompt from fact output

### DIFF
--- a/src/pyinfra/api/facts.py
+++ b/src/pyinfra/api/facts.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
 # Sentinel output line emitted when skip_unless_command binary is absent on the remote host.
 _MISSING_COMMAND_MARKER = "##PYINFRA_NOCMD##"
+_SU_PASSWORD_PROMPT = "Password:"
 
 SUDO_REGEX = r"^sudo: unknown user"
 SU_REGEXES = (
@@ -333,6 +334,15 @@ def _get_fact(
         )
 
     stdout_lines, stderr_lines = output.stdout_lines, output.stderr_lines
+    if (
+        executor_kwargs["_su_user"]
+        and stdout_lines
+        and stdout_lines[0].startswith(_SU_PASSWORD_PROMPT)
+    ):
+        stdout_lines = stdout_lines.copy()
+        stdout_lines[0] = stdout_lines[0][len(_SU_PASSWORD_PROMPT) :]
+        if stdout_lines[0] == "":
+            stdout_lines.pop(0)
 
     # Detect the "binary absent" sentinel from the if/then/else shell guard.
     if status and stdout_lines == [_MISSING_COMMAND_MARKER]:

--- a/src/pyinfra/api/facts.py
+++ b/src/pyinfra/api/facts.py
@@ -22,7 +22,7 @@ from typing_extensions import override
 
 from pyinfra import logger
 from pyinfra.api.output import format_text
-from pyinfra.api import StringCommand
+from pyinfra.api import QuoteString, StringCommand
 from pyinfra.api.arguments import all_global_arguments, pop_global_arguments
 from pyinfra.api.exceptions import FactPreconditionError, FactProcessError, MissingCommandError
 from pyinfra.api.util import (
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
 # Sentinel output line emitted when skip_unless_command binary is absent on the remote host.
 _MISSING_COMMAND_MARKER = "##PYINFRA_NOCMD##"
-_SU_PASSWORD_PROMPT = "Password:"
+_SU_OUTPUT_MARKER = "##PYINFRA_SU_READY##"
 
 SUDO_REGEX = r"^sudo: unknown user"
 SU_REGEXES = (
@@ -319,6 +319,9 @@ def _get_fact(
         key: value for key, value in global_kwargs.items() if key in CONNECTOR_ARGUMENT_KEYS
     }
 
+    if executor_kwargs["_su_user"]:
+        command = StringCommand("printf", QuoteString(_SU_OUTPUT_MARKER), "&&", command)
+
     try:
         status, output = host.run_shell_command(
             command,
@@ -334,15 +337,12 @@ def _get_fact(
         )
 
     stdout_lines, stderr_lines = output.stdout_lines, output.stderr_lines
-    if (
-        executor_kwargs["_su_user"]
-        and stdout_lines
-        and stdout_lines[0].startswith(_SU_PASSWORD_PROMPT)
-    ):
-        stdout_lines = stdout_lines.copy()
-        stdout_lines[0] = stdout_lines[0][len(_SU_PASSWORD_PROMPT) :]
-        if stdout_lines[0] == "":
-            stdout_lines.pop(0)
+    if executor_kwargs["_su_user"]:
+        for index, line in enumerate(stdout_lines):
+            if _SU_OUTPUT_MARKER in line:
+                stdout_lines = stdout_lines[index:].copy()
+                stdout_lines[0] = line.split(_SU_OUTPUT_MARKER, 1)[1]
+                break
 
     # Detect the "binary absent" sentinel from the if/then/else shell guard.
     if status and stdout_lines == [_MISSING_COMMAND_MARKER]:

--- a/tests/test_api/test_api_facts.py
+++ b/tests/test_api/test_api_facts.py
@@ -104,6 +104,28 @@ class TestFactsApi(PatchSSHTestCase):
             **defaults,
         )
 
+    def test_get_fact_strips_freebsd_su_password_prompt_from_stdout(self):
+        inventory = make_inventory(hosts=("anotherhost",))
+        state = State(inventory, Config())
+
+        anotherhost = inventory.get_host("anotherhost")
+        anotherhost.data._su_user = "root"
+
+        connect_all(state)
+
+        with patch("pyinfra.connectors.ssh.SSHConnector.run_shell_command") as fake_run_command:
+            fake_run_command.return_value = (
+                True,
+                CommandOutput(
+                    [
+                        OutputLine("stdout", "Password:some-output"),
+                    ],
+                ),
+            )
+            fact_data = get_facts(state, Command, ("echo some-output",))
+
+        assert fact_data == {anotherhost: "some-output"}
+
     def test_get_fact_error(self):
         inventory = make_inventory(hosts=("anotherhost",))
         state = State(inventory, Config())

--- a/tests/test_api/test_api_facts.py
+++ b/tests/test_api/test_api_facts.py
@@ -97,8 +97,10 @@ class TestFactsApi(PatchSSHTestCase):
         defaults = _get_executor_defaults(state, anotherhost)
         defaults.update(anotherhost.current_op_global_arguments)
 
+        command = fake_run_command.call_args.args[0]
+        assert str(command) == "printf '##PYINFRA_SU_READY##' && yes"
         fake_run_command.assert_called_with(
-            "yes",
+            command,
             print_input=False,
             print_output=False,
             **defaults,
@@ -118,13 +120,55 @@ class TestFactsApi(PatchSSHTestCase):
                 True,
                 CommandOutput(
                     [
-                        OutputLine("stdout", "Password:some-output"),
+                        OutputLine("stdout", "Password:##PYINFRA_SU_READY##some-output"),
                     ],
                 ),
             )
             fact_data = get_facts(state, Command, ("echo some-output",))
 
         assert fact_data == {anotherhost: "some-output"}
+        assert "##PYINFRA_SU_READY##" in str(fake_run_command.call_args.args[0])
+
+    def test_get_fact_preserves_real_output_starting_with_password(self):
+        inventory = make_inventory(hosts=("anotherhost",))
+        state = State(inventory, Config())
+
+        anotherhost = inventory.get_host("anotherhost")
+        anotherhost.data._su_user = "root"
+
+        connect_all(state)
+
+        with patch("pyinfra.connectors.ssh.SSHConnector.run_shell_command") as fake_run_command:
+            fake_run_command.return_value = (
+                True,
+                CommandOutput([OutputLine("stdout", "Password:some-output")]),
+            )
+            fact_data = get_facts(state, Command, ("echo Password:some-output",))
+
+        assert fact_data == {anotherhost: "Password:some-output"}
+
+    def test_get_fact_preserves_leading_newline_after_su_password_prompt(self):
+        inventory = make_inventory(hosts=("anotherhost",))
+        state = State(inventory, Config())
+
+        anotherhost = inventory.get_host("anotherhost")
+        anotherhost.data._su_user = "root"
+
+        connect_all(state)
+
+        with patch("pyinfra.connectors.ssh.SSHConnector.run_shell_command") as fake_run_command:
+            fake_run_command.return_value = (
+                True,
+                CommandOutput(
+                    [
+                        OutputLine("stdout", "Password:##PYINFRA_SU_READY##"),
+                        OutputLine("stdout", "some-output"),
+                    ],
+                ),
+            )
+            fact_data = get_facts(state, Command, ("printf '\\nsome-output\\n'",))
+
+        assert fact_data == {anotherhost: "\nsome-output"}
 
     def test_get_fact_error(self):
         inventory = make_inventory(hosts=("anotherhost",))
@@ -269,8 +313,10 @@ class TestFactsApi(PatchSSHTestCase):
         defaults["_sudo_user"] = "override-sudo-user"
         defaults["_su_user"] = "override-su-user"
 
+        command = fake_run_command.call_args.args[0]
+        assert str(command) == "printf '##PYINFRA_SU_READY##' && yes"
         fake_run_command.assert_called_with(
-            "yes",
+            command,
             print_input=False,
             print_output=False,
             **defaults,


### PR DESCRIPTION
## Summary
- strip a leading `Password:` prompt from fact stdout when facts run through `su`
- keep normal fact stdout unchanged unless `_su_user` is active
- add regression coverage for the FreeBSD `su` prompt leaking into fact output

Fixes #1947

## Validation
- `uv run pytest tests/test_api/test_api_facts.py tests/test_connectors/test_util.py -q`
- `uv run ruff check src/pyinfra/api/facts.py tests/test_api/test_api_facts.py`
- `uv run ruff format --check src/pyinfra/api/facts.py tests/test_api/test_api_facts.py`
- `uv run mypy src/pyinfra/api/facts.py`
- `git diff --check`

## Risk
Low. The change only adjusts the first stdout line for fact commands executed with `_su_user`, and only when that line starts with the standard `Password:` prompt.