### PR TITLE
fix(connectors.ssh): support sudo passwords with rsync

### DIFF
--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -6,7 +6,7 @@ from shutil import copyfileobj, which
 from socket import gaierror
 from tempfile import SpooledTemporaryFile
 from time import sleep
-from typing import IO, TYPE_CHECKING, Any, Protocol
+from typing import IO, TYPE_CHECKING, Any, Protocol, cast
 from collections.abc import Iterable
 
 from paramiko import AuthenticationException, BadHostKeyException, SFTPClient, SSHException
@@ -682,6 +682,17 @@ class SSHConnector(BaseConnector):
     ):
         _sudo = arguments.pop("_sudo", False)
         _sudo_user = arguments.pop("_sudo_user", False)
+        sudo_arguments = cast(
+            "ConnectorArguments",
+            {
+                "_sudo": _sudo,
+                "_sudo_user": _sudo_user,
+                "_sudo_password": arguments.pop("_sudo_password", None),
+                "_shell_executable": None,
+            },
+        )
+        if "_temp_dir" in arguments:
+            sudo_arguments["_temp_dir"] = arguments.pop("_temp_dir")
 
         hostname = self.data["ssh_hostname"] or self.host.name
         user = self.data["ssh_user"]
@@ -726,34 +737,46 @@ class SSHConnector(BaseConnector):
         if ssh_key:
             ssh_flags.append(f"-i {ssh_key}")
 
-        remote_rsync_command = "rsync"
-        if _sudo:
-            remote_rsync_command = "sudo rsync"
-            if _sudo_user:
-                remote_rsync_command = f"sudo -u {_sudo_user} rsync"
+        def run_rsync() -> tuple[int, CommandOutput]:
+            remote_rsync_command = StringCommand("rsync")
+            if _sudo:
+                remote_rsync_command = make_unix_command_for_host(
+                    self.state,
+                    self.host,
+                    remote_rsync_command,
+                    **sudo_arguments,
+                )
 
-        rsync_command = (
-            "rsync {rsync_flags} "
-            '--rsh "ssh {ssh_flags}" '
-            "--rsync-path '{remote_rsync_command}' "
-            "{src} {user}{hostname}:{dest}"
-        ).format(
-            rsync_flags=" ".join(flags),
-            ssh_flags=" ".join(ssh_flags),
-            remote_rsync_command=remote_rsync_command,
-            user=user or "",
-            hostname=hostname,
-            src=src,
-            dest=dest,
-        )
+            rsync_command = (
+                "rsync {rsync_flags} "
+                '--rsh "ssh {ssh_flags}" '
+                "--rsync-path {remote_rsync_command} "
+                "{src} {user}{hostname}:{dest}"
+            ).format(
+                rsync_flags=" ".join(flags),
+                ssh_flags=" ".join(ssh_flags),
+                remote_rsync_command=StringCommand(
+                    QuoteString(remote_rsync_command)
+                ).get_raw_value(),
+                user=user or "",
+                hostname=hostname,
+                src=src,
+                dest=dest,
+            )
 
-        if print_input:
-            echo(f"{self.host.print_prefix}>>> {rsync_command}", err=True)
+            if print_input:
+                echo(f"{self.host.print_prefix}>>> {rsync_command}", err=True)
 
-        return_code, output = run_local_process(
-            rsync_command,
-            print_output=print_output,
-            print_prefix=self.host.print_prefix,
+            return run_local_process(
+                rsync_command,
+                print_output=print_output,
+                print_prefix=self.host.print_prefix,
+            )
+
+        return_code, output = execute_command_with_sudo_retry(
+            self.host,
+            sudo_arguments,
+            run_rsync,
         )
 
         status = return_code == 0

--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -825,8 +825,8 @@ def rsync(src: str, dest: str, flags: list[str] | None = None):
         StrictHostKeyChecking setting, config and known_hosts file (when specified).
 
     .. caution::
-        When using SSH, the ``files.rsync`` operation only supports the ``sudo`` and ``sudo_user``
-        global arguments.
+        When using SSH, the ``files.rsync`` operation only supports the ``sudo``, ``sudo_user``,
+        and ``sudo_password`` global arguments.
     """
 
     if flags is None:

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -318,10 +318,85 @@ class TestOperationsApi(PatchSSHTestCase):
             (
                 "rsync -ax --delete --rsh "
                 '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=accept-new\\""'
-                " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
+                " --rsync-path 'sudo -H -n -u root rsync' src vagrant@somehost:dest"
             ),
             print_output=False,
             print_prefix=inventory.get_host("somehost").print_prefix,
+        )
+
+    @patch("pyinfra.connectors.ssh.SSHConnector.check_can_rsync", lambda _: True)
+    def test_rsync_op_with_sudo_password(self):
+        inventory = make_inventory(hosts=("somehost",))
+        state = State(inventory, Config())
+        state.current_stage = StateStage.Prepare
+        connect_all(state)
+
+        host = inventory.get_host("somehost")
+        host.connector_data["sudo_askpass_path__/tmp"] = "/tmp/pyinfra-sudo-askpass"
+
+        add_op(
+            state,
+            files.rsync,
+            "src",
+            "dest",
+            _sudo=True,
+            _sudo_user="root",
+            _sudo_password="PASSWORD",
+        )
+
+        assert len(state.get_op_order()) == 1
+
+        with patch("pyinfra.connectors.ssh.run_local_process") as fake_run_local_process:
+            fake_run_local_process.return_value = 0, []
+            run_ops(state)
+
+        fake_run_local_process.assert_called_with(
+            (
+                "rsync -ax --delete --rsh "
+                '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=accept-new\\""'
+                " --rsync-path 'env SUDO_ASKPASS=/tmp/pyinfra-sudo-askpass "
+                "PYINFRA_SUDO_PASSWORD=PASSWORD sudo -H -A -k -u root rsync' "
+                "src vagrant@somehost:dest"
+            ),
+            print_output=False,
+            print_prefix=host.print_prefix,
+        )
+
+    @patch("pyinfra.connectors.ssh.SSHConnector.check_can_rsync", lambda _: True)
+    def test_rsync_op_retries_with_prompted_sudo_password(self):
+        inventory = make_inventory(hosts=("somehost",))
+        state = State(inventory, Config())
+        state.current_stage = StateStage.Prepare
+        connect_all(state)
+
+        host = inventory.get_host("somehost")
+        host.connector_data["sudo_askpass_path__/tmp"] = "/tmp/pyinfra-sudo-askpass"
+
+        add_op(state, files.rsync, "src", "dest", _sudo=True, _sudo_user="root")
+
+        assert len(state.get_op_order()) == 1
+
+        with (
+            patch("pyinfra.connectors.ssh.run_local_process") as fake_run_local_process,
+            patch("pyinfra.connectors.util.getpass", return_value="PASSWORD"),
+        ):
+            fake_run_local_process.side_effect = [
+                (1, CommandOutput([OutputLine("stderr", "sudo: a password is required")])),
+                (0, CommandOutput([])),
+            ]
+            run_ops(state)
+
+        assert fake_run_local_process.call_args_list[0].args[0] == (
+            "rsync -ax --delete --rsh "
+            '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=accept-new\\""'
+            " --rsync-path 'sudo -H -n -u root rsync' src vagrant@somehost:dest"
+        )
+        assert fake_run_local_process.call_args_list[1].args[0] == (
+            "rsync -ax --delete --rsh "
+            '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=accept-new\\""'
+            " --rsync-path 'env SUDO_ASKPASS=/tmp/pyinfra-sudo-askpass "
+            "PYINFRA_SUDO_PASSWORD=PASSWORD sudo -H -A -k -u root rsync' "
+            "src vagrant@somehost:dest"
         )
 
     @patch("pyinfra.connectors.ssh.SSHConnector.check_can_rsync", lambda _: True)
@@ -343,7 +418,7 @@ class TestOperationsApi(PatchSSHTestCase):
             (
                 "rsync -ax --delete --rsh "
                 '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=no\\""'
-                " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
+                " --rsync-path 'sudo -H -n -u root rsync' src vagrant@somehost:dest"
             ),
             print_output=False,
             print_prefix=inventory.get_host("somehost").print_prefix,
@@ -379,7 +454,7 @@ class TestOperationsApi(PatchSSHTestCase):
                 "rsync -ax --delete --rsh "
                 '"ssh -o BatchMode=yes '
                 '-o \\"StrictHostKeyChecking=no\\" -F /home/me/ssh_test_config"'
-                " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
+                " --rsync-path 'sudo -H -n -u root rsync' src vagrant@somehost:dest"
             ),
             print_output=False,
             print_prefix=inventory.get_host("somehost").print_prefix,
@@ -407,7 +482,7 @@ class TestOperationsApi(PatchSSHTestCase):
                 "rsync -ax --delete --rsh "
                 '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=accept-new\\" '
                 "-F '/home/me/ssh_test_config && echo hi'\""
-                " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
+                " --rsync-path 'sudo -H -n -u root rsync' src vagrant@somehost:dest"
             ),
             print_output=False,
             print_prefix=inventory.get_host("somehost").print_prefix,


### PR DESCRIPTION
## Summary
- build the remote rsync sudo command with pyinfra's normal sudo wrapper
- retry rsync after the standard sudo password prompt path and use the generated askpass helper
- document that SSH rsync supports `sudo_password`

Fixes #1948

## Tests
- `uv run pytest tests/test_api/test_api_operations.py -k rsync -q`
- `uv run pytest tests/test_connectors/test_util.py tests/test_connectors/test_ssh.py -q`
- `uv run pytest tests/test_api/test_api_operations.py -q`
- `uv run ruff check src/pyinfra/connectors/ssh.py src/pyinfra/operations/files.py tests/test_api/test_api_operations.py`
- `uv run ruff format --check src/pyinfra/connectors/ssh.py src/pyinfra/operations/files.py tests/test_api/test_api_operations.py`
- `uv run mypy src/pyinfra/connectors/ssh.py`
- `git diff --check`

## AI assistance
OpenAI Codex was used to inspect the existing rsync and sudo paths, implement the masked display-command fix and regression test, and run the validation commands above.