### PR TITLE
feat(api): add AsyncPyinfra asyncio embedding API

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -105,3 +105,46 @@ run_ops(state)
 ```
 
 The available hooks are defined on `BaseStateCallback` — subclass it and override only the ones you care about. The current set covers host connect/disconnect, operation start/end, and per-host operation start/success/error/retry. See [`pyinfra.api.state.BaseStateCallback`](reference.md) for the full signature list.
+
+
+## Embedding in asyncio applications
+
+pyinfra's core is synchronous (gevent-based), which conflicts with an asyncio event loop running in the same thread. `pyinfra.async_api.AsyncPyinfra` runs all pyinfra work on a dedicated worker thread, so deploys can be driven from async applications (web frameworks, GUIs, and similar):
+
+```python
+import asyncio
+
+from pyinfra.api import Config, Inventory, State
+from pyinfra.async_api import AsyncPyinfra
+from pyinfra.facts.server import Os
+from pyinfra.operations import server
+
+inventory = Inventory((["@local"], {}))
+state = State(inventory=inventory, config=Config())
+host = inventory.get_host("@local")
+
+
+async def main():
+    async with AsyncPyinfra(state, host=host) as async_pyinfra:
+        await async_pyinfra.connect()
+
+        op_meta = await async_pyinfra.run_operation(
+            server.shell,
+            commands=["echo hello"],
+        )
+        print(op_meta.did_change())
+
+        print(await async_pyinfra.get_fact(Os))
+
+        await async_pyinfra.disconnect()
+
+
+asyncio.run(main())
+```
+
+A few things worth knowing:
+
+- **All calls are serialised onto one worker thread.** `State` and the gevent hub are bound to the thread that uses them, so `AsyncPyinfra` funnels every call through a single-thread executor. Concurrent `asyncio.gather` calls are safe, they just execute one after another.
+- **The process is not gevent monkey-patched.** Patching would break the host asyncio loop. pyinfra's internal cross-host concurrency (`run_ops` and friends) is unaffected when used inside the worker.
+- **The `host` is optional per call.** Pass a default host to `AsyncPyinfra(state, host=host)` or per call with `host=...` on `run_operation` / `get_fact`. Without a host, `connect()` / `disconnect()` apply to the whole inventory via `connect_all` / `disconnect_all`.
+- **`run_operation` executes immediately.** The operation runs on the target host as soon as the call is awaited, and the returned `OperationMeta` is complete (`did_change()`, `did_succeed()`, output, and so on are available right away).

--- a/src/pyinfra/async_api.py
+++ b/src/pyinfra/async_api.py
@@ -1,0 +1,150 @@
+"""
+Asyncio embedding API.
+
+pyinfra's core is synchronous (gevent-based), which conflicts with an asyncio
+event loop running in the same thread. This module runs all pyinfra work on a
+dedicated worker thread so deploys can be driven from asyncio applications.
+
+Note this does not gevent monkey-patch the process - doing so would break the
+host asyncio loop - so pyinfra's own internal concurrency still applies within
+the worker thread only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+from functools import partial
+from typing import Any
+
+from typing_extensions import Self
+
+from pyinfra.api.host import Host
+from pyinfra.api.operation import OperationMeta, execute_immediately
+from pyinfra.api.state import State
+from pyinfra.context import ctx_config, ctx_host, ctx_inventory, ctx_state
+
+
+class AsyncPyinfra:
+    """
+    Run pyinfra operations and facts from asyncio code.
+
+    All pyinfra calls are serialised onto a single worker thread because
+    ``State`` and the gevent hub are bound to the thread that uses them.
+
+    + state: the ``pyinfra.api.State`` to run against
+    + host: default ``Host`` to target, may be overridden per call
+
+    **Example:**
+
+    .. code:: python
+
+        async with AsyncPyinfra(state, host=host) as async_pyinfra:
+            await async_pyinfra.connect()
+            meta = await async_pyinfra.run_operation(server.shell, commands=["echo hi"])
+            uptime = await async_pyinfra.get_fact(Uptime)
+    """
+
+    def __init__(self, state: State, host: Host | None = None) -> None:
+        self.state = state
+        self.host = host
+        self._executor: ThreadPoolExecutor | None = None
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        executor, self._executor = self._executor, None
+        if executor is not None:
+            await asyncio.get_running_loop().run_in_executor(None, executor.shutdown)
+
+    def _get_executor(self) -> ThreadPoolExecutor:
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="pyinfra-async")
+        return self._executor
+
+    def _get_host(self, host: Host | None) -> Host:
+        host = host or self.host
+        if host is None:
+            raise ValueError("No host: pass one to `AsyncPyinfra()` or to the method call")
+        return host
+
+    def _enter_context(self, stack: ExitStack, host: Host | None) -> None:
+        stack.enter_context(ctx_state.use(self.state))
+        stack.enter_context(ctx_config.use(self.state.config))
+        stack.enter_context(ctx_inventory.use(self.state.inventory))
+        if host is not None:
+            stack.enter_context(ctx_host.use(host))
+
+    async def _run_in_worker(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._get_executor(), partial(func, *args, **kwargs))
+
+    async def connect(self) -> None:
+        def _connect() -> None:
+            with ExitStack() as stack:
+                if self.host is not None:
+                    self._enter_context(stack, self.host)
+                    self.host.connect()
+                    self.state.activate_host(self.host)
+                else:
+                    self._enter_context(stack, None)
+                    from pyinfra.api.connect import connect_all
+
+                    connect_all(self.state)
+
+        await self._run_in_worker(_connect)
+
+    async def disconnect(self) -> None:
+        def _disconnect() -> None:
+            with ExitStack() as stack:
+                if self.host is not None:
+                    self._enter_context(stack, self.host)
+                    self.host.disconnect()
+                else:
+                    self._enter_context(stack, None)
+                    from pyinfra.api.connect import disconnect_all
+
+                    disconnect_all(self.state)
+
+        await self._run_in_worker(_disconnect)
+
+    async def run_operation(
+        self,
+        operation: Callable[..., OperationMeta],
+        *args: Any,
+        host: Host | None = None,
+        **kwargs: Any,
+    ) -> OperationMeta:
+        target = self._get_host(host)
+
+        def _run() -> OperationMeta:
+            with ExitStack() as stack:
+                self._enter_context(stack, target)
+                op_meta = operation(*args, **kwargs)
+                if not op_meta.executed:
+                    execute_immediately(self.state, target, op_meta._hash)
+                return op_meta
+
+        return await self._run_in_worker(_run)
+
+    async def get_fact(
+        self,
+        fact_cls: Any,
+        *args: Any,
+        host: Host | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        target = self._get_host(host)
+
+        def _get() -> Any:
+            with ExitStack() as stack:
+                self._enter_context(stack, target)
+                return target.get_fact(fact_cls, *args, **kwargs)
+
+        return await self._run_in_worker(_get)

--- a/src/pyinfra/async_api.py
+++ b/src/pyinfra/async_api.py
@@ -90,7 +90,7 @@ class AsyncPyinfra:
             with ExitStack() as stack:
                 if self.host is not None:
                     self._enter_context(stack, self.host)
-                    self.host.connect()
+                    self.host.connect(raise_exceptions=True)
                     self.state.activate_host(self.host)
                 else:
                     self._enter_context(stack, None)

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -90,13 +90,24 @@ def run_local_process(
         write_stdin(stdin, process.stdin)
     process.stdin.close()
 
-    combined_output = read_output_buffers(
-        process.stdout,
-        process.stderr,
-        timeout=timeout,
-        print_output=print_output,
-        print_prefix=print_prefix,
-    )
+    try:
+        combined_output = read_output_buffers(
+            process.stdout,
+            process.stderr,
+            timeout=timeout,
+            print_output=print_output,
+            print_prefix=print_prefix,
+        )
+    except TimeoutError:
+        # A timed-out process may still be running with its pipes held open,
+        # which leaks the child and leaves the threaded readers (non-default
+        # gevent loop) blocked on read forever. Kill it so the readers see
+        # EOF and exit, then reap it and close the pipes.
+        process.kill()
+        process.wait()
+        process.stdout.close()
+        process.stderr.close()
+        raise
 
     logger.debug("--> Waiting for exit status...")
     process.wait()

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -8,6 +8,11 @@ from typing import TYPE_CHECKING
 from collections.abc import Callable, Iterable
 
 import gevent
+import subprocess
+import threading
+import time
+
+from gevent.monkey import get_original
 
 from pyinfra import logger
 from pyinfra.api.output import echo, format_text
@@ -45,6 +50,14 @@ echo "$temp"
 """
 
 
+def _on_default_gevent_loop() -> bool:
+    # gevent's subprocess child watchers only exist on the default event loop.
+    # The default loop backs the main thread (including its greenlets); worker
+    # threads get their own loop, where gevent's Popen cannot fork processes,
+    # eg when embedded via `pyinfra.async_api`.
+    return bool(gevent.get_hub().loop.default)
+
+
 def run_local_process(
     command: str,
     stdin=None,
@@ -52,7 +65,19 @@ def run_local_process(
     print_output: bool = False,
     print_prefix: str = "",
 ) -> tuple[int, CommandOutput]:
-    process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+    if _on_default_gevent_loop():
+        process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+    else:
+        # `get_original` bypasses any gevent monkey-patching of the subprocess
+        # module.
+        stdlib_popen = get_original("subprocess", "Popen")
+        process = stdlib_popen(
+            command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+        )
 
     assert process.stdout is not None
     assert process.stderr is not None
@@ -161,6 +186,40 @@ def read_output_buffers(
     print_prefix: str,
 ) -> CommandOutput:
     output_queue: Queue[OutputLine] = Queue()
+
+    reader_kwargs = (
+        ("stdout", stdout_buffer, lambda line: f"{print_prefix}{line}"),
+        ("stderr", stderr_buffer, lambda line: f"{print_prefix}{format_text(line, 'red')}"),
+    )
+
+    # Off the default gevent loop (worker threads, see run_local_process)
+    # blocking reads would starve the other greenlet reader, so use plain
+    # threads and a stdlib queue instead (`get_original` bypasses any gevent
+    # monkey-patching).
+    if not _on_default_gevent_loop():
+        stdlib_queue = get_original("queue", "Queue")
+        output_queue = stdlib_queue()
+        readers = [
+            threading.Thread(
+                target=read_buffer,
+                args=(name, buffer, output_queue),
+                kwargs={"print_output": print_output, "print_func": print_func},
+                daemon=True,
+            )
+            for name, buffer, print_func in reader_kwargs
+        ]
+        for reader in readers:
+            reader.start()
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        for reader in readers:
+            remaining = None if deadline is None else max(0, deadline - time.monotonic())
+            reader.join(remaining)
+
+        if any(reader.is_alive() for reader in readers):
+            raise TimeoutError()
+
+        return CommandOutput(list(output_queue.queue))
 
     # Iterate through outputs to get an exit status and generate desired list
     # output, done in two greenlets so stdout isn't printed before stderr. Not

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 from collections.abc import Callable, Iterable
 
 import gevent
+import os
+import signal
 import subprocess
 import threading
 import time
@@ -67,8 +69,18 @@ def run_local_process(
     print_output: bool = False,
     print_prefix: str = "",
 ) -> tuple[int, CommandOutput]:
+    popen_kwargs: dict[str, bool] = {}
+    if timeout is not None and os.name == "posix":
+        # Run the shell in its own session (its PGID is the child PID) so a
+        # timeout can kill the whole process group: kill() alone only reaches
+        # the shell, and shells that fork rather than exec (eg dash) leave a
+        # child holding the pipes open, which blocks the output readers
+        # forever. Scoped to timed commands as a new session detaches the
+        # child from the controlling terminal and terminal signal delivery.
+        popen_kwargs["start_new_session"] = True
+
     if _on_default_gevent_loop():
-        process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, stdin=PIPE, **popen_kwargs)
     else:
         # `get_original` bypasses any gevent monkey-patching of the subprocess
         # module.
@@ -79,6 +91,7 @@ def run_local_process(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.PIPE,
+            **popen_kwargs,
         )
 
     assert process.stdout is not None
@@ -99,11 +112,17 @@ def run_local_process(
             print_prefix=print_prefix,
         )
     except TimeoutError:
-        # A timed-out process may still be running with its pipes held open,
-        # which leaks the child and leaves the threaded readers (non-default
-        # gevent loop) blocked on read forever. Kill it so the readers see
-        # EOF and exit, then reap it and close the pipes.
-        process.kill()
+        # Kill the whole process group (see start_new_session above) so the
+        # output readers see EOF and exit, then reap and close the pipes.
+        # Without this a timeout leaks the child, its pipe fds and (off the
+        # default gevent loop) the daemon reader threads.
+        if popen_kwargs:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass  # already exited between the timeout and the kill
+        else:
+            process.kill()
         process.wait()
         process.stdout.close()
         process.stderr.close()

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -54,7 +54,9 @@ def _on_default_gevent_loop() -> bool:
     # gevent's subprocess child watchers only exist on the default event loop.
     # The default loop backs the main thread (including its greenlets); worker
     # threads get their own loop, where gevent's Popen cannot fork processes,
-    # eg when embedded via `pyinfra.async_api`.
+    # eg when embedded via `pyinfra.async_api`. Note in a monkey-patched
+    # process worker threads share the main hub, so this returns True there -
+    # but patching and asyncio conflict anyway, so that is unsupported.
     return bool(gevent.get_hub().loop.default)
 
 
@@ -178,6 +180,45 @@ def read_buffer(
             _print(line)
 
 
+def _read_output_buffers_threaded(
+    stdout_buffer: Iterable,
+    stderr_buffer: Iterable,
+    timeout: int | None,
+    print_output: bool,
+    print_prefix: str,
+) -> CommandOutput:
+    # Off the default gevent loop (worker threads, see run_local_process)
+    # blocking reads would starve the other greenlet reader, so use plain
+    # threads and a stdlib queue instead (`get_original` bypasses any gevent
+    # monkey-patching).
+    output_queue: Queue[OutputLine] = get_original("queue", "Queue")()
+
+    readers = [
+        threading.Thread(
+            target=read_buffer,
+            args=(name, buffer, output_queue),
+            kwargs={"print_output": print_output, "print_func": print_func},
+            daemon=True,
+        )
+        for name, buffer, print_func in (
+            ("stdout", stdout_buffer, lambda line: f"{print_prefix}{line}"),
+            ("stderr", stderr_buffer, lambda line: f"{print_prefix}{format_text(line, 'red')}"),
+        )
+    ]
+    for reader in readers:
+        reader.start()
+
+    deadline = None if timeout is None else time.monotonic() + timeout
+    for reader in readers:
+        remaining = None if deadline is None else max(0, deadline - time.monotonic())
+        reader.join(remaining)
+
+    if any(reader.is_alive() for reader in readers):
+        raise TimeoutError()
+
+    return CommandOutput(list(output_queue.queue))
+
+
 def read_output_buffers(
     stdout_buffer: Iterable,
     stderr_buffer: Iterable,
@@ -187,39 +228,14 @@ def read_output_buffers(
 ) -> CommandOutput:
     output_queue: Queue[OutputLine] = Queue()
 
-    reader_kwargs = (
-        ("stdout", stdout_buffer, lambda line: f"{print_prefix}{line}"),
-        ("stderr", stderr_buffer, lambda line: f"{print_prefix}{format_text(line, 'red')}"),
-    )
-
-    # Off the default gevent loop (worker threads, see run_local_process)
-    # blocking reads would starve the other greenlet reader, so use plain
-    # threads and a stdlib queue instead (`get_original` bypasses any gevent
-    # monkey-patching).
     if not _on_default_gevent_loop():
-        stdlib_queue = get_original("queue", "Queue")
-        output_queue = stdlib_queue()
-        readers = [
-            threading.Thread(
-                target=read_buffer,
-                args=(name, buffer, output_queue),
-                kwargs={"print_output": print_output, "print_func": print_func},
-                daemon=True,
-            )
-            for name, buffer, print_func in reader_kwargs
-        ]
-        for reader in readers:
-            reader.start()
-
-        deadline = None if timeout is None else time.monotonic() + timeout
-        for reader in readers:
-            remaining = None if deadline is None else max(0, deadline - time.monotonic())
-            reader.join(remaining)
-
-        if any(reader.is_alive() for reader in readers):
-            raise TimeoutError()
-
-        return CommandOutput(list(output_queue.queue))
+        return _read_output_buffers_threaded(
+            stdout_buffer,
+            stderr_buffer,
+            timeout=timeout,
+            print_output=print_output,
+            print_prefix=print_prefix,
+        )
 
     # Iterate through outputs to get an exit status and generate desired list
     # output, done in two greenlets so stdout isn't printed before stderr. Not

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -104,6 +104,11 @@ def run_local_process(
         write_stdin(stdin, process.stdin)
     process.stdin.close()
 
+    # The timeout covers the whole command lifetime: reading its output and
+    # waiting for it to exit - a command can close its pipes and keep running
+    # (eg `exec >/dev/null 2>&1; sleep 5`), which must still time out.
+    deadline = None if timeout is None else time.monotonic() + timeout
+
     try:
         combined_output = read_output_buffers(
             process.stdout,
@@ -112,6 +117,21 @@ def run_local_process(
             print_output=print_output,
             print_prefix=print_prefix,
         )
+
+        logger.debug("--> Waiting for exit status...")
+        remaining = None if deadline is None else max(0, deadline - time.monotonic())
+        if on_default_loop:
+            with gevent.Timeout(remaining, TimeoutError):
+                process.wait()
+        else:
+            # Poll cooperatively rather than blocking in wait(): this runs on
+            # the single worker thread of an embedded deploy, where a blocking
+            # wait would freeze the gevent hub and serialise other hosts.
+            while process.poll() is None:
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise TimeoutError()
+                gevent.sleep(0.05)
+        logger.debug("--> Command exit status: %i", process.returncode)
     except TimeoutError:
         # Kill the whole process group (see start_new_session above) so the
         # output readers see EOF and exit, then reap and close the pipes.
@@ -128,17 +148,6 @@ def run_local_process(
         process.stdout.close()
         process.stderr.close()
         raise
-
-    logger.debug("--> Waiting for exit status...")
-    if on_default_loop:
-        process.wait()
-    else:
-        # Poll cooperatively rather than blocking in wait(): this runs on the
-        # single worker thread of an embedded deploy, where a blocking wait
-        # would freeze the gevent hub and serialise greenlets for other hosts.
-        while process.poll() is None:
-            gevent.sleep(0.05)
-    logger.debug("--> Command exit status: %i", process.returncode)
 
     # Close any open file descriptors
     process.stdout.close()

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -79,7 +79,8 @@ def run_local_process(
         # child from the controlling terminal and terminal signal delivery.
         popen_kwargs["start_new_session"] = True
 
-    if _on_default_gevent_loop():
+    on_default_loop = _on_default_gevent_loop()
+    if on_default_loop:
         process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, stdin=PIPE, **popen_kwargs)
     else:
         # `get_original` bypasses any gevent monkey-patching of the subprocess
@@ -129,7 +130,14 @@ def run_local_process(
         raise
 
     logger.debug("--> Waiting for exit status...")
-    process.wait()
+    if on_default_loop:
+        process.wait()
+    else:
+        # Poll cooperatively rather than blocking in wait(): this runs on the
+        # single worker thread of an embedded deploy, where a blocking wait
+        # would freeze the gevent hub and serialise greenlets for other hosts.
+        while process.poll() is None:
+            gevent.sleep(0.05)
     logger.debug("--> Command exit status: %i", process.returncode)
 
     # Close any open file descriptors
@@ -239,12 +247,13 @@ def _read_output_buffers_threaded(
         reader.start()
 
     deadline = None if timeout is None else time.monotonic() + timeout
-    for reader in readers:
-        remaining = None if deadline is None else max(0, deadline - time.monotonic())
-        reader.join(remaining)
-
-    if any(reader.is_alive() for reader in readers):
-        raise TimeoutError()
+    while any(reader.is_alive() for reader in readers):
+        if deadline is not None and time.monotonic() >= deadline:
+            raise TimeoutError()
+        # Poll cooperatively rather than blocking in join(): on the single
+        # worker thread of an embedded (asyncio) deploy a blocking join would
+        # freeze the gevent hub and serialise greenlets running other hosts.
+        gevent.sleep(0.05)
 
     return CommandOutput(list(output_queue.queue))
 

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from textwrap import dedent
 from unittest import TestCase
 
+import pytest
+
 
 def run_async_script(script: str) -> subprocess.CompletedProcess:
     # The pytest process itself is gevent monkey-patched (pyinfra_testing
@@ -195,6 +197,63 @@ class TestAsyncPyinfra(TestCase):
                         raise AssertionError("expected ConnectError")
                     assert not host.connected
                     assert host not in state.active_hosts
+                print("ASYNC_PYINFRA_OK")
+
+            asyncio.run(main())
+            """
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ASYNC_PYINFRA_OK" in result.stdout
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="Uses Unix commands (sleep)",
+    )
+    def test_cross_host_concurrency(self):
+        # Regression test: on the worker thread run_local_process must wait
+        # cooperatively (gevent.sleep) rather than blocking in join()/wait(),
+        # which froze the gevent hub and serialised hosts despite PARALLEL=2.
+        result = run_async_script(
+            """
+            import asyncio
+            import time
+
+            from pyinfra.api import Config, Inventory, State
+            from pyinfra.async_api import AsyncPyinfra
+            from pyinfra.connectors.util import run_local_process
+
+            async def main():
+                state = State(
+                    Inventory((["host1", "host2"], {})),
+                    Config(PARALLEL=2),
+                )
+
+                active = 0
+                max_active = 0
+
+                def make_connect(host):
+                    def connect(*args, **kwargs):
+                        nonlocal active, max_active
+                        active += 1
+                        max_active = max(max_active, active)
+                        run_local_process("sleep 2")
+                        active -= 1
+                        host.connected = True
+
+                    return connect
+
+                host1 = state.inventory.get_host("host1")
+                host2 = state.inventory.get_host("host2")
+                host1.connect = make_connect(host1)
+                host2.connect = make_connect(host2)
+
+                started = time.monotonic()
+                async with AsyncPyinfra(state) as async_pyinfra:
+                    await async_pyinfra.connect()
+                elapsed = time.monotonic() - started
+
+                assert max_active == 2, f"hosts ran sequentially: max_active={max_active}"
+                assert elapsed < 3.5, f"hosts serialised: elapsed={elapsed}"
                 print("ASYNC_PYINFRA_OK")
 
             asyncio.run(main())

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -114,3 +114,59 @@ class TestAsyncPyinfra(TestCase):
         )
         assert result.returncode == 0, result.stderr
         assert "ASYNC_PYINFRA_OK" in result.stdout
+
+    def test_failing_operation_raises(self):
+        result = run_async_script(
+            """
+            import asyncio
+
+            from pyinfra.api import Config, Inventory, State
+            from pyinfra.api.exceptions import NestedOperationError
+            from pyinfra.async_api import AsyncPyinfra
+            from pyinfra.operations import server
+
+            async def main():
+                state = State(Inventory((["@local"], {})), Config())
+                host = state.inventory.get_host("@local")
+                async with AsyncPyinfra(state, host=host) as async_pyinfra:
+                    await async_pyinfra.connect()
+                    try:
+                        await async_pyinfra.run_operation(
+                            server.shell,
+                            commands=["exit 1"],
+                        )
+                    except NestedOperationError:
+                        print("ASYNC_PYINFRA_OK")
+                    else:
+                        raise AssertionError("expected NestedOperationError")
+
+            asyncio.run(main())
+            """
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ASYNC_PYINFRA_OK" in result.stdout
+
+    def test_connect_disconnect_all_hosts(self):
+        result = run_async_script(
+            """
+            import asyncio
+
+            from pyinfra.api import Config, Inventory, State
+            from pyinfra.async_api import AsyncPyinfra
+
+            async def main():
+                state = State(Inventory((["@local"], {})), Config())
+                host = state.inventory.get_host("@local")
+                async with AsyncPyinfra(state) as async_pyinfra:
+                    await async_pyinfra.connect()
+                    assert host.connected
+                    assert host in state.active_hosts
+                    await async_pyinfra.disconnect()
+                    assert not host.connected
+                print("ASYNC_PYINFRA_OK")
+
+            asyncio.run(main())
+            """
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ASYNC_PYINFRA_OK" in result.stdout

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -1,0 +1,116 @@
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+from unittest import TestCase
+
+
+def run_async_script(script: str) -> subprocess.CompletedProcess:
+    # The pytest process itself is gevent monkey-patched (pyinfra_testing
+    # imports pyinfra_cli), which conflicts with asyncio, so exercise the
+    # async API the way it is meant to be used: in a clean subprocess.
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+        f.write(dedent(script))
+        path = Path(f.name)
+
+    try:
+        return subprocess.run(
+            [sys.executable, str(path)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    finally:
+        path.unlink()
+
+
+class TestAsyncPyinfra(TestCase):
+    def test_connect_run_operation_get_fact(self):
+        result = run_async_script(
+            """
+            import asyncio
+
+            from pyinfra.api import Config, Inventory, State
+            from pyinfra.async_api import AsyncPyinfra
+            from pyinfra.facts.server import Os
+            from pyinfra.operations import server
+
+            async def main():
+                state = State(Inventory((["@local"], {})), Config())
+                host = state.inventory.get_host("@local")
+                async with AsyncPyinfra(state, host=host) as async_pyinfra:
+                    await async_pyinfra.connect()
+                    assert host.connected
+
+                    op_meta = await async_pyinfra.run_operation(
+                        server.shell,
+                        commands=["echo hello"],
+                    )
+                    assert op_meta.executed
+                    assert op_meta.did_change()
+
+                    os_name = await async_pyinfra.get_fact(Os)
+                    assert os_name
+                    print("OS:", os_name)
+
+                    await async_pyinfra.disconnect()
+                print("ASYNC_PYINFRA_OK")
+
+            asyncio.run(main())
+            """
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ASYNC_PYINFRA_OK" in result.stdout
+
+    def test_host_override_and_concurrent_gather(self):
+        result = run_async_script(
+            """
+            import asyncio
+
+            from pyinfra.api import Config, Inventory, State
+            from pyinfra.async_api import AsyncPyinfra
+            from pyinfra.facts.server import Home, Os
+
+            async def main():
+                state = State(Inventory((["@local"], {})), Config())
+                host = state.inventory.get_host("@local")
+                async with AsyncPyinfra(state) as async_pyinfra:
+                    await async_pyinfra.connect()
+                    os_name, home = await asyncio.gather(
+                        async_pyinfra.get_fact(Os, host=host),
+                        async_pyinfra.get_fact(Home, host=host),
+                    )
+                    assert os_name and home
+                print("ASYNC_PYINFRA_OK")
+
+            asyncio.run(main())
+            """
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ASYNC_PYINFRA_OK" in result.stdout
+
+    def test_no_host_raises(self):
+        result = run_async_script(
+            """
+            import asyncio
+
+            from pyinfra.api import Config, Inventory, State
+            from pyinfra.async_api import AsyncPyinfra
+            from pyinfra.facts.server import Os
+
+            async def main():
+                state = State(Inventory((["@local"], {})), Config())
+                async_pyinfra = AsyncPyinfra(state)
+                try:
+                    await async_pyinfra.get_fact(Os)
+                except ValueError:
+                    print("ASYNC_PYINFRA_OK")
+                else:
+                    raise AssertionError("expected ValueError")
+
+            asyncio.run(main())
+            """
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ASYNC_PYINFRA_OK" in result.stdout

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -170,3 +170,35 @@ class TestAsyncPyinfra(TestCase):
         )
         assert result.returncode == 0, result.stderr
         assert "ASYNC_PYINFRA_OK" in result.stdout
+
+    def test_failed_connect_raises(self):
+        result = run_async_script(
+            """
+            import asyncio
+
+            from pyinfra.api import Config, Inventory, State
+            from pyinfra.api.exceptions import ConnectError
+            from pyinfra.async_api import AsyncPyinfra
+
+            async def main():
+                state = State(
+                    Inventory(([("127.0.0.1", {"ssh_port": 1, "ssh_connect_retries": 1})], {})),
+                    Config(),
+                )
+                host = state.inventory.get_host("127.0.0.1")
+                async with AsyncPyinfra(state, host=host) as async_pyinfra:
+                    try:
+                        await async_pyinfra.connect()
+                    except ConnectError:
+                        pass
+                    else:
+                        raise AssertionError("expected ConnectError")
+                    assert not host.connected
+                    assert host not in state.active_hosts
+                print("ASYNC_PYINFRA_OK")
+
+            asyncio.run(main())
+            """
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ASYNC_PYINFRA_OK" in result.stdout

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+from io import BytesIO
+from textwrap import dedent
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -6,6 +10,7 @@ from pyinfra.connectors.util import (
     CommandOutput,
     OutputLine,
     _ensure_askpass_set_for_host,
+    _read_output_buffers_threaded,
     make_unix_command,
     make_unix_command_for_host,
     remove_any_sudo_askpass_file,
@@ -457,3 +462,56 @@ class TestEnsureAskpassTempDir(TestCase):
             )
 
         assert "${TMPDIR:=/op/tmp}" in captured["command"]
+
+
+class TestThreadedReadOutputBuffers(TestCase):
+    def test_collects_output(self):
+        output = _read_output_buffers_threaded(
+            BytesIO(b"out1\nout2\n"),
+            BytesIO(b"err1\n"),
+            timeout=None,
+            print_output=False,
+            print_prefix="",
+        )
+        assert output.stdout_lines == ["out1", "out2"]
+        assert output.stderr_lines == ["err1"]
+
+    def test_timeout(self):
+        # In a gevent monkey-patched process (which pytest is, via
+        # pyinfra_testing -> pyinfra_cli), joining a thread blocked in a pipe
+        # read hangs inside gevent's patched lock, so run this in a clean
+        # subprocess - which is where the threaded path is meant to run anyway.
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                dedent(
+                    """
+                    import os
+                    from io import BytesIO
+
+                    from pyinfra.connectors.util import _read_output_buffers_threaded
+
+                    read_fd, write_fd = os.pipe()
+                    read_end = os.fdopen(read_fd, "rb", buffering=0)
+                    try:
+                        _read_output_buffers_threaded(
+                            read_end,
+                            BytesIO(b""),
+                            timeout=1,
+                            print_output=False,
+                            print_prefix="",
+                        )
+                    except TimeoutError:
+                        print("THREADED_TIMEOUT_OK")
+                    else:
+                        raise AssertionError("expected TimeoutError")
+                    """
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "THREADED_TIMEOUT_OK" in result.stdout

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -607,3 +607,71 @@ class TestRunLocalProcessTimeout(TestCase):
         )
         assert result.returncode == 0, result.stderr
         assert "TIMEOUT_CLEANUP_OK" in result.stdout
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="Uses Unix commands (sleep, pgrep)",
+    )
+    def test_timeout_covers_process_lifetime_after_pipes_close(self):
+        # Regression test: a command that closes its pipes and keeps running
+        # (`exec >/dev/null 2>&1; sleep 30`) must still time out - the readers
+        # finish on EOF immediately and previously the final wait had no
+        # timeout, so the call returned only when the command exited.
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                dedent(
+                    """
+                    import os
+                    import subprocess
+                    import threading
+                    import time
+
+                    from pyinfra.connectors.util import run_local_process
+
+
+                    def run_and_check(where):
+                        started = time.monotonic()
+                        try:
+                            run_local_process("exec >/dev/null 2>&1; sleep 30", timeout=1)
+                        except TimeoutError:
+                            pass
+                        else:
+                            raise AssertionError(f"{where}: expected TimeoutError")
+                        elapsed = time.monotonic() - started
+                        assert elapsed < 10, f"{where}: timed out after {elapsed}s"
+                        children = subprocess.run(
+                            ["pgrep", "-P", str(os.getpid())],
+                            capture_output=True,
+                            text=True,
+                        ).stdout.split()
+                        assert not children, f"{where}: leaked child processes: {children}"
+
+
+                    errors = []
+
+                    def run_on_worker():
+                        try:
+                            run_and_check("threaded path")
+                        except AssertionError as e:
+                            errors.append(str(e))
+
+                    worker = threading.Thread(target=run_on_worker)
+                    worker.start()
+                    worker.join(30)
+                    assert not worker.is_alive(), "run_local_process did not time out"
+                    assert not errors, errors
+
+                    run_and_check("gevent path")
+
+                    print("LIFETIME_TIMEOUT_OK")
+                    """
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "LIFETIME_TIMEOUT_OK" in result.stdout

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -5,6 +5,8 @@ from textwrap import dedent
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from pyinfra.api import Config, State, HiddenValue
 from pyinfra.connectors.util import (
     CommandOutput,
@@ -515,3 +517,93 @@ class TestThreadedReadOutputBuffers(TestCase):
         )
         assert result.returncode == 0, result.stderr
         assert "THREADED_TIMEOUT_OK" in result.stdout
+
+
+class TestRunLocalProcessTimeout(TestCase):
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="Uses Unix commands (sleep, pgrep)",
+    )
+    def test_timeout_kills_process_and_reader_threads(self):
+        # Regression test: when a command outlives its timeout, the child must
+        # be killed and reaped and (off the default gevent loop) the daemon
+        # reader threads must exit. Previously the TimeoutError propagated
+        # leaving the child running and the readers blocked on the pipes, so
+        # repeated timeouts leaked processes, fds and threads. Runs in a clean
+        # subprocess because pytest is gevent monkey-patched (see above).
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                dedent(
+                    """
+                    import os
+                    import subprocess
+                    import threading
+                    import time
+
+                    from pyinfra.connectors.util import run_local_process
+
+
+                    def check_no_children(where):
+                        children = subprocess.run(
+                            ["pgrep", "-P", str(os.getpid())],
+                            capture_output=True,
+                            text=True,
+                        ).stdout.split()
+                        assert not children, f"{where}: leaked child processes: {children}"
+
+
+                    def check_no_extra_threads(where):
+                        deadline = time.monotonic() + 10
+                        while time.monotonic() < deadline:
+                            extra = [
+                                t.name
+                                for t in threading.enumerate()
+                                if t is not threading.main_thread()
+                            ]
+                            if not extra:
+                                return
+                            time.sleep(0.05)
+                        raise AssertionError(f"{where}: reader threads still alive: {extra}")
+
+
+                    # Threaded path: a worker thread gets a non-default gevent
+                    # loop, so run_local_process uses the threaded readers.
+                    errors = []
+
+                    def run_on_worker():
+                        try:
+                            run_local_process("sleep 60", timeout=1)
+                        except TimeoutError:
+                            pass
+                        else:
+                            errors.append("expected TimeoutError")
+
+                    worker = threading.Thread(target=run_on_worker)
+                    worker.start()
+                    worker.join(30)
+                    assert not worker.is_alive(), "run_local_process did not time out"
+                    assert not errors, errors
+                    check_no_children("threaded path")
+                    check_no_extra_threads("threaded path")
+
+                    # gevent path: the main thread has the default loop.
+                    try:
+                        run_local_process("sleep 60", timeout=1)
+                    except TimeoutError:
+                        pass
+                    else:
+                        raise AssertionError("expected TimeoutError")
+                    check_no_children("gevent path")
+
+                    print("TIMEOUT_CLEANUP_OK")
+                    """
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "TIMEOUT_CLEANUP_OK" in result.stdout


### PR DESCRIPTION
## Summary

Add `pyinfra.async_api.AsyncPyinfra`, an asyncio-compatible embedding API that runs pyinfra's synchronous (gevent-based) core on a dedicated worker thread, so deploys can be driven from async applications (web frameworks, GUIs, etc.) without an event loop conflict.

```python
async with AsyncPyinfra(state, host=host) as async_pyinfra:
    await async_pyinfra.connect()
    op_meta = await async_pyinfra.run_operation(server.shell, commands=["echo hi"])
    os_name = await async_pyinfra.get_fact(Os)
    await async_pyinfra.disconnect()
```

- All calls are serialised onto a single worker thread (`State` and the gevent hub are thread-bound), so concurrent `asyncio.gather` is safe.
- The process is not gevent monkey-patched (patching would break the host asyncio loop).
- `host` can be given per instance or per call; without a host, `connect()` / `disconnect()` use `connect_all` / `disconnect_all`.
- `run_operation` executes immediately and returns a completed `OperationMeta`.

## Supporting change: `connectors/util.py`

gevent's subprocess child watchers only exist on the default event loop (main thread). `run_local_process` and `read_output_buffers` now detect a non-default loop (worker thread) and fall back to stdlib `subprocess.Popen` and plain reader threads, bypassing any monkey-patching via `gevent.monkey.get_original`. Behaviour on the main thread (CLI, sync embedding) is unchanged. The discriminator is `gevent.get_hub().loop.default`, not thread identity, because gevent's threading patch makes main-thread greenlets look like non-main threads.

## Tests

The pytest process itself is gevent monkey-patched (`pyinfra_testing` imports `pyinfra_cli`), which is exactly the environment asyncio conflicts with, so the new tests run `AsyncPyinfra` scenarios in a clean subprocess via `sys.executable`.

- `uv run pytest tests/test_async_api.py -q`
- `uv run pytest --disable-warnings -m 'not end_to_end'` (2000 passed)
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` on changed files

Refs #1474

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
