### PR TITLE
fix(facts.server): preserve full executable names and args on macOS

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -1305,6 +1305,10 @@ echo "no_reboot_required"
         return list(output)[0].strip() == "reboot_required"
 
 
+_DARWIN_ARGS_FIELDS = "pid,user,stat,%cpu,%mem,args"
+_DARWIN_COMM_MARKER = "===PYINFRA-PROCESSES-COMM==="
+
+
 class Processes(FactBase[dict[int, ProcessDict]]):
     """
     Returns a dictionary of running processes keyed by PID.
@@ -1328,7 +1332,9 @@ class Processes(FactBase[dict[int, ProcessDict]]):
     @override
     def command(self, pid: int | None = None) -> str | StringCommand:
         self._kernel = host.get_fact(Kernel)
-        is_bsd = self._kernel.strip() in ("FreeBSD", "Darwin")
+        kernel = self._kernel.strip()
+        self._is_darwin = kernel == "Darwin"
+        is_bsd = kernel in ("FreeBSD", "Darwin")
 
         # BusyBox ps (Alpine) only supports limited columns.
         # Detect by checking if busybox exists on the system.
@@ -1336,6 +1342,26 @@ class Processes(FactBase[dict[int, ProcessDict]]):
             self._is_busybox = bool(host.get_fact(Which, "busybox"))
         else:
             self._is_busybox = False
+
+        if self._is_darwin:
+            # macOS ps truncates any non-last text column (comm to 16 bytes, args to 64),
+            # so run ps twice with each of those columns last and join by pid.
+            if pid is not None:
+                return StringCommand(
+                    "LANG=C ps -p",
+                    QuoteString(str(pid)),
+                    f"-o {_DARWIN_ARGS_FIELDS} -ww &&",
+                    "echo",
+                    f"{_DARWIN_COMM_MARKER} &&",
+                    "LANG=C ps -p",
+                    QuoteString(str(pid)),
+                    "-o pid,comm -ww",
+                )
+            return (
+                f"LANG=C ps -eo {_DARWIN_ARGS_FIELDS} -ww && "
+                f"echo {_DARWIN_COMM_MARKER} && "
+                "LANG=C ps -eo pid,comm -ww"
+            )
 
         if not self._is_busybox:
             fields = "pid,user,stat,%cpu,%mem,comm,args"
@@ -1357,8 +1383,70 @@ class Processes(FactBase[dict[int, ProcessDict]]):
         else:
             return f"LANG=C ps -eo {fields} --no-headers"
 
+    def _process_darwin(self, output: Iterable[str]) -> dict[int, ProcessDict]:
+        args_lines: list[str] = []
+        comm_lines: list[str] = []
+        current = args_lines
+        marker_seen = False
+
+        for line in output:
+            if line.strip() == _DARWIN_COMM_MARKER:
+                marker_seen = True
+                current = comm_lines
+                continue
+            current.append(line)
+
+        if not marker_seen:
+            raise Exception(
+                f"server.Processes: did not find the {_DARWIN_COMM_MARKER!r} marker in "
+                "the ps output; the ps -eo/-p pipeline may have produced unexpected output"
+            )
+
+        processes: dict[int, ProcessDict] = {}
+
+        for line in args_lines:
+            line = line.strip()
+            if not line or line.startswith("PID"):
+                continue
+            parts = line.split(None, 5)
+            if len(parts) < 6:
+                continue
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+            processes[pid] = {
+                "user": parts[1],
+                "state": parts[2],
+                "cpu_percent": float(parts[3]),
+                "mem_percent": float(parts[4]),
+                "command": "",
+                "args": parts[5],
+            }
+
+        for line in comm_lines:
+            line = line.strip()
+            if not line or line.startswith("PID"):
+                continue
+            parts = line.split(None, 1)
+            if len(parts) < 2:
+                continue
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+            if pid in processes:
+                processes[pid]["command"] = parts[1]
+
+        # A pid without a matched `comm` row means it vanished between the two `ps`
+        # snapshots: drop it rather than return a record with an empty command.
+        return {pid: proc for pid, proc in processes.items() if proc["command"]}
+
     @override
     def process(self, output: Iterable[str]) -> dict[int, ProcessDict]:
+        if self._is_darwin:
+            return self._process_darwin(output)
+
         processes: dict[int, ProcessDict] = {}
 
         for line in output:

--- a/tests/facts/server.Processes/darwin_all.json
+++ b/tests/facts/server.Processes/darwin_all.json
@@ -1,0 +1,63 @@
+{
+  "command": "LANG=C ps -eo pid,user,stat,%cpu,%mem,args -ww && echo ===PYINFRA-PROCESSES-COMM=== && LANG=C ps -eo pid,comm -ww",
+  "facts": {
+    "server.Kernel": "Darwin"
+  },
+  "output": [
+    "  PID USER     STAT  %CPU %MEM ARGS",
+    "    1 root     Ss    0.0  0.1 /sbin/launchd",
+    "  200 root     S     0.0  0.0 /usr/libexec/opendirectoryd",
+    "  300 root     Ss    0.0  0.2 /usr/sbin/sshd -D -o PermitRootLogin=no",
+    "  500 root     Ss    0.3  1.2 /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/XPCServices/backupd-helper.xpc/Contents/MacOS/backupd-helper",
+    "  600 karlicos S     0.1  0.4 /Applications/Some App.app/Contents/MacOS/Some App --flag value",
+    "===PYINFRA-PROCESSES-COMM===",
+    "  PID COMM",
+    "    1 /sbin/launchd",
+    "  200 /usr/libexec/opendirectoryd",
+    "  300 /usr/sbin/sshd",
+    "  500 /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/XPCServices/backupd-helper.xpc/Contents/MacOS/backupd-helper",
+    "  600 /Applications/Some App.app/Contents/MacOS/Some App"
+  ],
+  "fact": {
+    "1": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.1,
+      "command": "/sbin/launchd",
+      "args": "/sbin/launchd"
+    },
+    "200": {
+      "user": "root",
+      "state": "S",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.0,
+      "command": "/usr/libexec/opendirectoryd",
+      "args": "/usr/libexec/opendirectoryd"
+    },
+    "300": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.2,
+      "command": "/usr/sbin/sshd",
+      "args": "/usr/sbin/sshd -D -o PermitRootLogin=no"
+    },
+    "500": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.3,
+      "mem_percent": 1.2,
+      "command": "/System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/XPCServices/backupd-helper.xpc/Contents/MacOS/backupd-helper",
+      "args": "/System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/XPCServices/backupd-helper.xpc/Contents/MacOS/backupd-helper"
+    },
+    "600": {
+      "user": "karlicos",
+      "state": "S",
+      "cpu_percent": 0.1,
+      "mem_percent": 0.4,
+      "command": "/Applications/Some App.app/Contents/MacOS/Some App",
+      "args": "/Applications/Some App.app/Contents/MacOS/Some App --flag value"
+    }
+  }
+}

--- a/tests/facts/server.Processes/darwin_pty_crlf.json
+++ b/tests/facts/server.Processes/darwin_pty_crlf.json
@@ -1,0 +1,53 @@
+{
+  "command": "LANG=C ps -eo pid,user,stat,%cpu,%mem,args -ww && echo ===PYINFRA-PROCESSES-COMM=== && LANG=C ps -eo pid,comm -ww",
+  "facts": {
+    "server.Kernel": "Darwin"
+  },
+  "output": [
+    "  PID USER     STAT  %CPU %MEM ARGS\r",
+    "    1 root     Ss    0.0  0.1 /sbin/launchd\r",
+    "  200 root     S     0.0  0.0 /usr/libexec/opendirectoryd\r",
+    "  300 root     Ss    0.0  0.2 /usr/sbin/sshd -D -o PermitRootLogin=no\r",
+    "  500 root     Ss    0.3  1.2 /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/XPCServices/backupd-helper.xpc/Contents/MacOS/backupd-helper\r",
+    "===PYINFRA-PROCESSES-COMM===\r",
+    "  PID COMM\r",
+    "    1 /sbin/launchd\r",
+    "  200 /usr/libexec/opendirectoryd\r",
+    "  300 /usr/sbin/sshd\r",
+    "  500 /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/XPCServices/backupd-helper.xpc/Contents/MacOS/backupd-helper\r"
+  ],
+  "fact": {
+    "1": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.1,
+      "command": "/sbin/launchd",
+      "args": "/sbin/launchd"
+    },
+    "200": {
+      "user": "root",
+      "state": "S",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.0,
+      "command": "/usr/libexec/opendirectoryd",
+      "args": "/usr/libexec/opendirectoryd"
+    },
+    "300": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.2,
+      "command": "/usr/sbin/sshd",
+      "args": "/usr/sbin/sshd -D -o PermitRootLogin=no"
+    },
+    "500": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.3,
+      "mem_percent": 1.2,
+      "command": "/System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/XPCServices/backupd-helper.xpc/Contents/MacOS/backupd-helper",
+      "args": "/System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/XPCServices/backupd-helper.xpc/Contents/MacOS/backupd-helper"
+    }
+  }
+}

--- a/tests/facts/server.Processes/darwin_single_pid.json
+++ b/tests/facts/server.Processes/darwin_single_pid.json
@@ -1,0 +1,24 @@
+{
+  "command": "LANG=C ps -p 742 -o pid,user,stat,%cpu,%mem,args -ww && echo ===PYINFRA-PROCESSES-COMM=== && LANG=C ps -p 742 -o pid,comm -ww",
+  "arg": 742,
+  "facts": {
+    "server.Kernel": "Darwin"
+  },
+  "output": [
+    "  PID USER     STAT  %CPU %MEM ARGS",
+    "  742 root     Ss    0.0  0.2 /usr/sbin/sshd -D",
+    "===PYINFRA-PROCESSES-COMM===",
+    "  PID COMM",
+    "  742 /usr/sbin/sshd"
+  ],
+  "fact": {
+    "742": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.2,
+      "command": "/usr/sbin/sshd",
+      "args": "/usr/sbin/sshd -D"
+    }
+  }
+}

--- a/tests/facts/server.Processes/darwin_spaced_executable.json
+++ b/tests/facts/server.Processes/darwin_spaced_executable.json
@@ -1,0 +1,23 @@
+{
+  "command": "LANG=C ps -eo pid,user,stat,%cpu,%mem,args -ww && echo ===PYINFRA-PROCESSES-COMM=== && LANG=C ps -eo pid,comm -ww",
+  "facts": {
+    "server.Kernel": "Darwin"
+  },
+  "output": [
+    "  PID USER             STAT  %CPU %MEM ARGS",
+    "36470 karlicos         S      0.0  0.0 ./Example Application 120",
+    "===PYINFRA-PROCESSES-COMM===",
+    "  PID COMM",
+    "36470 ./Example Application"
+  ],
+  "fact": {
+    "36470": {
+      "user": "karlicos",
+      "state": "S",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.0,
+      "command": "./Example Application",
+      "args": "./Example Application 120"
+    }
+  }
+}

--- a/tests/facts/server.Processes/darwin_vanished_pid.json
+++ b/tests/facts/server.Processes/darwin_vanished_pid.json
@@ -1,0 +1,34 @@
+{
+  "command": "LANG=C ps -eo pid,user,stat,%cpu,%mem,args -ww && echo ===PYINFRA-PROCESSES-COMM=== && LANG=C ps -eo pid,comm -ww",
+  "facts": {
+    "server.Kernel": "Darwin"
+  },
+  "output": [
+    "  PID USER     STAT  %CPU %MEM ARGS",
+    "    1 root     Ss    0.0  0.1 /sbin/launchd",
+    "  200 root     S     0.0  0.0 /usr/libexec/opendirectoryd",
+    "  300 root     Ss    0.0  0.2 /usr/sbin/sshd -D",
+    "===PYINFRA-PROCESSES-COMM===",
+    "  PID COMM",
+    "    1 /sbin/launchd",
+    "  300 /usr/sbin/sshd"
+  ],
+  "fact": {
+    "1": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.1,
+      "command": "/sbin/launchd",
+      "args": "/sbin/launchd"
+    },
+    "300": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.2,
+      "command": "/usr/sbin/sshd",
+      "args": "/usr/sbin/sshd -D"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`server.Processes` returns a truncated executable name (`command`) and a misparsed `args`
value for any process on macOS whose path is over 16 bytes, or whose path contains a space.
This fixes both by making the underlying `ps` call and parser complete for macOS, without
touching the FreeBSD, Linux or BusyBox code paths.

## Root cause

macOS `ps` hard-truncates any textual column ("comm" flagged in the source) to its default
width the moment another column follows it: `comm` at 16 bytes, `args` at 64
(`apple-oss-distributions/adv_cmds`, `ps/keyword.c` lines 96 and 101, `ps/print.c` lines
358-378), unconditionally, regardless of `-w`/`-ww` (that flag only ever raises the *last*
column's limit, never a non-last one). The current fact requests `comm` before `args`
(`pid,user,stat,%cpu,%mem,comm,args`), so `comm` is truncated at 16 bytes on every process
whose path is longer, and the parser's plain whitespace split then misattributes the
truncated remainder to `args`, exactly as reported: `./Example Application 120` becomes
`command: "./Example"`, `args: "Applic ./Example Application 120"`.

Verified directly against the cited Apple source (not just the issue's citation of it), and
against three independent runs on a real macOS box (comm truncated non-last; args also
truncated non-last past 64 bytes; args intact when last, with or without `-ww`, under
genuinely non-interactive stdin/stdout/stderr, matching how pyinfra's SSH connector runs
facts by default with no pty).

## Fix

A single `ps` call can make at most one textual column immune to truncation (whichever is
placed last). `comm` and `args` both need to be complete, so this runs two `ps` calls, each
with its one truncation-prone column last and widened with `-ww`, chained with `&&` into one
shell command (one remote round trip):

```
LANG=C ps -eo pid,user,stat,%cpu,%mem,args -ww && echo ===PYINFRA-PROCESSES-COMM=== && LANG=C ps -eo pid,comm -ww
```

`&&`, not `;`: the shell's exit status is the last command's, so a failing first `ps` call
would otherwise be masked by a succeeding second one. Chaining with `&&` means a failing
first call short-circuits the whole command, which pyinfra's own fact loader already reads
as a failed command (returns the fact's default without ever calling `process()`), exactly
like the old single-`ps`-call form already did on any `ps` failure.

`process()` splits the output on the marker (matched by stripped comparison, so a pty's CRLF
line endings don't hide it), parses the `args` block the same way the existing parser already
does (minus the `comm` column, which is no longer requested there), parses the two-field
`comm` block, and merges the two by pid. A pid present in the first block but missing from
the second (the process exited between the two snapshots) is dropped rather than returned
with an empty command. If the marker is missing entirely, the fact raises rather than
silently returning an empty dict indistinguishable from "no processes".

Only the `Darwin` kernel takes this new path. FreeBSD, Linux and BusyBox keep their existing
single `ps` call and parser exactly as they were; their six existing fixtures are re-run
unmodified as the regression guard for this change.

### Alternatives considered and ruled out

- **Swap the column order in one `ps` call** (`args` before `comm`): only moves the
  truncation from one column to the other. `args` also has a default width (64 bytes) and
  gets cut past it once it's not the last column; the existing `linux_all.json` fixture's own
  postgres row (`/usr/lib/postgresql/14/bin/postgres -D /var/lib/postgresql/14/main`) is
  already 66 bytes, longer than that cap.
- **Native `sysctl(KERN_PROCARGS2)`** (this fact's own suggestion, used by `psutil` and
  `osquery`): `FactBase.command()` returns a shell command executed **on the remote target**
  by the connector; `process()` only ever sees stdout from that command. A `ctypes` call runs
  on the controller, not the target, so it cannot be shipped as this fact's command
  regardless of its merits for a purely local tool.
- **Two snapshots race, raised in the issue itself** ("this introduces a potential race
  condition between the two snapshots"): measured directly rather than dismissed. Across five
  consecutive runs of this exact two-call command on this Mac, on a process table of about
  1204 processes, the difference between the two snapshots was exactly one pid each way every
  time: the outgoing `ps` process from each of the two calls, visible only in its own
  snapshot. A pid missing from the second snapshot is dropped rather than reported with an
  empty command, so on this measurement the race costs the two `ps` processes' own transient
  pids, never a real process.

## Before / after

Reproduced directly on macOS with a signed copy of `/bin/sleep` running as
`./Example Application 120` (matching the issue's own repro), feeding the real captured `ps`
output through the actual fact code:

**Before:**
```json
{"command": "./Example", "args": "Applic ./Example Application 120"}
```

**After:**
```json
{"command": "./Example Application", "args": "./Example Application 120"}
```

Also re-run with every output line carrying a synthetic trailing `\r` (the shape pyinfra's own
output handling leaves behind under `_get_pty=True`): identical result to the clean run.

## What this PR does not do

- Does not touch the FreeBSD, Linux or BusyBox code paths at all: same command, same parser,
  same six fixtures, unmodified.
- Does not attempt perfect disambiguation of a process that renames its own `argv[0]` after
  exec (`setproctitle`), decoupling `comm` from the start of `args`. `command` comes directly
  from the `comm` block and `args` directly from the `args` block; there is no string-matching
  heuristic between them to fool.
- Does not close the two-snapshot race window entirely, only shrinks it (see the measurement
  above) and drops any pid missing from either snapshot rather than fabricating a partial
  record.
- Does not change `default = dict`, the `ProcessDict` shape, or anything for callers of this
  fact beyond making `command`/`args` correct on macOS.

## Tests executed

Full `server.Processes` fixture set, including 5 new Darwin fixtures (general sanity with a
path over 16 bytes, over 64 bytes, a path with a space, real trailing arguments distinct from
the command, a pid missing from the second snapshot, and CRLF-terminated output):

```
tests/test_facts.py::server.Processes::test_server.Processes_bsd_all PASSED
tests/test_facts.py::server.Processes::test_server.Processes_bsd_single_pid PASSED
tests/test_facts.py::server.Processes::test_server.Processes_busybox_all PASSED
tests/test_facts.py::server.Processes::test_server.Processes_busybox_single_pid PASSED
tests/test_facts.py::server.Processes::test_server.Processes_darwin_all PASSED
tests/test_facts.py::server.Processes::test_server.Processes_darwin_pty_crlf PASSED
tests/test_facts.py::server.Processes::test_server.Processes_darwin_single_pid PASSED
tests/test_facts.py::server.Processes::test_server.Processes_darwin_spaced_executable PASSED
tests/test_facts.py::server.Processes::test_server.Processes_darwin_vanished_pid PASSED
tests/test_facts.py::server.Processes::test_server.Processes_linux_all PASSED
tests/test_facts.py::server.Processes::test_server.Processes_linux_single_pid PASSED
11 passed, 419 deselected
```

Four separate mutation checks, each isolating one specific piece of the fix, confirmed the
right single fixture fails and nothing else does: reverting the whole diff fails the 5 new
Darwin fixtures only; reverting just the stripped marker match fails only the CRLF fixture;
reverting just the vanished-pid filter fails only that fixture; and reverting just the
comm-block merge (falling back to a naive `args.split()[0]`) fails only the fixtures whose
executable path contains a space, confirming the general Darwin fixture needed such a path to
actually exercise the merge rather than coincidentally passing either way.

Full test suite went from 1997 passed on the unmodified `3.x` tip to 2002 passed with this
diff, zero regressions elsewhere. `scripts/dev-test.sh` and `scripts/dev-lint.sh` (ruff check,
ruff format, mypy, the arguments-sync check, shellcheck) both exited clean.

## PR checklist

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [x] Pull request title follows the
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format

## AI usage disclosure

Per AI_POLICY.md: this change was developed with Claude Code (Anthropic). The tool drafted
the implementation, the fixtures and this description under my direction, and an independent
review pass re-executed every claim. I reviewed the change and can explain it; the bug and the
fix were reproduced on my own macOS machine with a real process, and the repository's test and
lint scripts were run before opening this PR.

Fixes #1952
