### PR TITLE
fix(connectors.ssh): retry NFSv4 ACL handover

### DIFF
--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -615,6 +615,18 @@ class SSHConnector(BaseConnector):
                     **noauth_arguments,
                 )
 
+                if (
+                    status is False
+                    and "branding mismatch" in output.stderr
+                    and "existing ACL is NFSv4" in output.stderr
+                ):
+                    status, output = self.run_shell_command(
+                        StringCommand("setfacl", "-m", f"u:{other_user}:r::allow", temp_file),
+                        print_output=print_output,
+                        print_input=print_input,
+                        **noauth_arguments,
+                    )
+
                 if status is False:
                     logger.error(f"Error on handover to sudo/su user: {output.stderr}")
                     return False

--- a/tests/test_connectors/test_ssh.py
+++ b/tests/test_connectors/test_ssh.py
@@ -930,6 +930,78 @@ class TestSSHConnector(TestCase):
 
     @mock.patch("pyinfra.connectors.ssh.SSHClient")
     @mock.patch("pyinfra.connectors.ssh.SFTPClient")
+    def test_put_file_sudo_retries_freebsd_nfsv4_acl(self, fake_sftp_client, fake_ssh_client):
+        inventory = make_inventory(hosts=("anotherhost",))
+        state = State(inventory, Config())
+        host = inventory.get_host("anotherhost")
+        host.connect()
+
+        def make_command_result(return_code, stderr_lines=None):
+            stdout_mock = mock.MagicMock()
+            stdout_mock.channel.recv_exit_status.return_value = return_code
+            stdout_mock.__iter__.return_value = iter([])
+            stderr_mock = mock.MagicMock()
+            stderr_mock.__iter__.return_value = iter(stderr_lines or [])
+            return mock.MagicMock(), stdout_mock, stderr_mock
+
+        fake_ssh_client().exec_command.side_effect = [
+            make_command_result(
+                1,
+                [
+                    "setfacl: /tmp/pyinfra-de01e82cb691e8a31369da3c7c8f17341c44ac24: "
+                    "branding mismatch; existing ACL is NFSv4, entry to be merged is POSIX.1e",
+                ],
+            ),
+            make_command_result(0),
+            make_command_result(0),
+            make_command_result(0),
+        ]
+
+        fake_open = mock.mock_open(read_data="test!")
+        with mock.patch("pyinfra.api.util.open", fake_open, create=True):
+            with ctx_state.use(state):
+                status = host.put_file(
+                    "not-a-file",
+                    "not another file",
+                    remote_temp_filename="/tmp/pyinfra-de01e82cb691e8a31369da3c7c8f17341c44ac24",
+                    print_output=True,
+                    _sudo=True,
+                    _sudo_user="root",
+                )
+
+        assert status is True
+
+        fake_ssh_client().exec_command.assert_has_calls(
+            [
+                mock.call(
+                    (
+                        "sh -c 'setfacl -m u:root:r "
+                        "/tmp/pyinfra-de01e82cb691e8a31369da3c7c8f17341c44ac24'"
+                    ),
+                    get_pty=False,
+                ),
+                mock.call(
+                    (
+                        "sh -c 'setfacl -m u:root:r::allow "
+                        "/tmp/pyinfra-de01e82cb691e8a31369da3c7c8f17341c44ac24'"
+                    ),
+                    get_pty=False,
+                ),
+                mock.call(
+                    (
+                        "sudo -H -n -u root sh -c 'cp /tmp/pyinfra-de01e82cb691e8a31369da3c7c8f17341c44ac24 '\"'\"'not another file'\"'\"''"  # noqa: E501
+                    ),
+                    get_pty=False,
+                ),
+                mock.call(
+                    ("sh -c 'rm -f /tmp/pyinfra-de01e82cb691e8a31369da3c7c8f17341c44ac24'"),
+                    get_pty=False,
+                ),
+            ],
+        )
+
+    @mock.patch("pyinfra.connectors.ssh.SSHClient")
+    @mock.patch("pyinfra.connectors.ssh.SFTPClient")
     def test_put_file_doas(self, fake_sftp_client, fake_ssh_client):
         inventory = make_inventory(hosts=("anotherhost",))
         state = State(inventory, Config())


### PR DESCRIPTION
## Summary
- retry privileged SSH file handover with a FreeBSD NFSv4 ACL entry when POSIX `setfacl` fails with a branding mismatch
- keep the existing POSIX ACL path unchanged for other filesystems
- add SSH connector coverage for the reported `files.put(_sudo=True)` failure mode

Fixes #1946.

## Tests
- `uv run pytest tests/test_connectors/test_ssh.py -k freebsd_nfsv4_acl -q`
- `uv run pytest tests/test_connectors/test_ssh.py -q`
- `uv run ruff format --check src/pyinfra/connectors/ssh.py tests/test_connectors/test_ssh.py`
- `uv run ruff check src/pyinfra/connectors/ssh.py tests/test_connectors/test_ssh.py`
- `uv run mypy src/pyinfra/connectors/ssh.py`
- `uv run pytest tests/test_connectors -q`
- `git diff --check`