### PR TITLE
docs: fix links to connectors, operations, and facts indexes

### DIFF
--- a/docs/inventory-data.md
+++ b/docs/inventory-data.md
@@ -193,7 +193,7 @@ ssh_key = "~/.ssh/some_key"
 ssh_key_password = "password for key"
 ```
 
-The [Connectors Index](connectors/index.md) contains full details of which data keys are available in each connector.
+The [Connectors Index](connectors.md) contains full details of which data keys are available in each connector.
 
 ## Global Arguments with Data
 

--- a/docs/using-operations.md
+++ b/docs/using-operations.md
@@ -28,7 +28,7 @@ files.file(
 )
 ```
 
-Uses [`operations.files`](operations/files.md) and [`operations.server`](operations/server.md). You can see all available operations in the [Operations Index](operations/index.md). If you save the file as `deploy.py` you can test it out using Docker:
+Uses [`operations.files`](operations/files.md) and [`operations.server`](operations/server.md). You can see all available operations in the [Operations Index](operations.md). If you save the file as `deploy.py` you can test it out using Docker:
 
 ```sh
 pyinfra @docker/ubuntu:20.04 deploy.py
@@ -157,7 +157,7 @@ if host.get_fact(LinuxName) == "Ubuntu":
 pyinfra inventory.py nano.py
 ```
 
-See [Facts Index](facts/index.md) for a full list of available facts and arguments.
+See [Facts Index](facts.md) for a full list of available facts and arguments.
 
 !!! important
     Only use **immutable** facts in deploy code — facts whose value cannot change *over the course of the deploy*. OS family, distribution, architecture and kernel version are immutable in this sense; "is this package installed", "does this file exist" and "is this service running" are **not**, because an earlier operation in the same deploy could flip them. Facts are read during prepare, before any operation runs, so a mutable fact branched on in Python sees pre-deploy state — not the state at the point of the branch in source order. Use `_if` (see [Change Detection](#change-detection) below) for conditions that need execute-time evaluation. More detail: [using host facts](deploy-process.md#using-host-facts).


### PR DESCRIPTION
<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to third party
    connector packages.
-->

In the conversion to zensical, the links to the Connectors Index, Operations Index, and Facts Index got broken. This PR fixes the links, but doesn't change the wording as it still seemed fine and I'm unfamiliar with any doc conventions in this project.

- [X] Pull request is based on the default branch (`3.x` at this time)
- [ ] ~~Pull request includes tests for any new/updated operations/facts~~
- [ ] ~~Pull request includes documentation for any new/updated operations/facts~~
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
- [X] Pull request title follows the 
      [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format
