### PR TITLE
docs: fix connectors index link

### DIFF
--- a/docs/inventory-data.md
+++ b/docs/inventory-data.md
@@ -193,7 +193,7 @@ ssh_key = "~/.ssh/some_key"
 ssh_key_password = "password for key"
 ```
 
-The [Connectors Index](connectors/index.md) contains full details of which data keys are available in each connector.
+The [Connectors Index](connectors.md) contains full details of which data keys are available in each connector.
 
 ## Global Arguments with Data
 


### PR DESCRIPTION
## Summary
- Fix the Inventory & Data docs link to the connectors index
- Point it at the current `connectors.md` page instead of the removed `connectors/index.md` path

Closes #1909.

## Validation
- `test -f docs/connectors.md`
- `! rg -n "connectors/index\.md" docs/inventory-data.md`
- `git diff --check`

Note: `UV_CACHE_DIR=/tmp/uv-cache-pyinfra-docs uv run zensical build --clean` did not complete in this local environment because mkdocstrings could not load the Python docs inventory due to local SSL certificate verification, and the direct zensical build also expects generated snippets such as `facts-cards.html`.